### PR TITLE
replace URL query with payload in HTTP request

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Topograph is a component designed to expose the underlying physical network topo
 
 ### 1. CSP Connector
 
-The CSP Connector is responsible for interfacing with various CSPs to retrieve cluster-related information. Currently, it supports AWS, with plans to add support for OCI, GCP, and Azure. The primary goal of the CSP Connector is to obtain the network topology configuration of a cluster, which may require several subsequent API calls. Once the information is obtained, the CSP Connector translates the network topology from CSP-specific formats to an internal format that can be utilized by the Topology Generator.
+The CSP Connector is responsible for interfacing with various CSPs to retrieve cluster-related information. Currently, it supports AWS, OCI, GCP, CoreWeave, bare metal, with plans to add support for Azure. The primary goal of the CSP Connector is to obtain the network topology configuration of a cluster, which may require several subsequent API calls. Once the information is obtained, the CSP Connector translates the network topology from CSP-specific formats to an internal format that can be utilized by the Topology Generator.
 
 ### 2. API Server
 
@@ -45,6 +45,7 @@ For the SLURM engine, topograph supports the following CSPs:
 - OCI
 - GCP
 - CoreWeave
+- Bare metal
 
 ### Kubernetes Engine
 
@@ -64,19 +65,22 @@ There is a special *provider* and *engine* named `test`, which supports both SLU
 - The Topology Generator returns the network topology configuration to the API Server, which then relays it back to the requester.
 
 ## Topograph Installation and Configuration
+Topograph can operate as a standalone service within SLURM clusters or be deployed in Kubernetes clusters.
+
+### Topograph as a Standalone Service
 Topograph can be installed using the `topograph` Debian or RPM package. This package sets up a service but does not start it automatically, allowing users to update the configuration before launch.
 
-### Configuration
+#### Configuration
 The default configuration file is located at [config/topograph-config.yaml](config/topograph-config.yaml). It includes settings for:
  - HTTP endpoint for the Topology Generator
  - SSL/TLS connection
  - environment variables
 
-By default, SSL/TLS is enabled, and the server certificate and key are generated during package installation.
+By default, SSL/TLS is disabled, but the server certificate and key are generated during package installation.
 
 The configuration file also includes an optional section for environment variables. When specified, these variables are added to the shell environment. Note that the `PATH` variable, if provided, is appended to the existing `PATH`.
 
-### Service Management
+#### Service Management
 To enable and start the service, run the following commands:
 ```bash
 systemctl enable topograph.service
@@ -95,102 +99,64 @@ systemctl disable topograph.service
 systemctl daemon-reload
 ```
 
-### Testing the Service
+#### Testing the Service
 To verify the service is running correctly, you can use the following commands:
+
 ```bash
 curl http://localhost:49021/healthz
 
-curl -X POST "http://localhost:49021/v1/generate?provider=test&engine=test"
+id=$(curl -s -X POST -H "Content-Type: application/json" -d '{"provider":{"name":"test"},"engine":{"name":"test"}}' http://localhost:49021/v1/generate)
+
+curl -s "http://localhost:49021/v1/topology?uid=$id"
 ```
 
-### Using the Cluster Topology Generator
+#### Using the Cluster Topology Generator
 
 The Cluster Topology Generator offers three endpoints for interacting with the service. Below are the details of each endpoint:
 
-#### 1. Health Endpoint
+##### 1. Health Endpoint
 
 - **URL:** `http://<server>:<port>/healthz`
 - **Description:** This endpoint verifies the service status. It returns a "200 OK" HTTP response if the service is operational.
 
-#### 2. Topology Request Endpoint
+##### 2. Topology Request Endpoint
 
-- **URL:** `http://<server>:<port>/v1/generate`
+- **URL:** `http(s)://<server>:<port>/v1/generate`
 - **Description:** This endpoint is used to request a new cluster topology.
-- **URL Query Parameters:**
-  - **provider**: (mandatory) Specifies the Cloud Service Provider (CSP) such as `aws`, `oci`, `gcp`, `azure`, or `test`.
-  - **engine**: (mandatory) Specifies the configuration format, either `slurm` or `k8s`.
-  - **topology_config_path**: (optional for `engine=slurm`, mandatory for `engine=k8s`) Specifies the file path for the topology config when `engine=slurm`, or the key for the topology config in the configmap when `engine=k8s`. If omitted for `slurm`, the content of the topology config is returned with the HTTP response.
-  - **topology_configmap_name**: (mandatory for `engine=k8s`) Specifies the name of the configmap containing the topology config.
-  - **topology_configmap_namespace**: (mandatory for `engine=k8s`) Specifies the namespace of the configmap containing the topology config.
-  - **skip_reload**: (optional for `engine=slurm`) Omit cluster reconfiguration if present.
-- **Response:** This endpoint immediately returns a "202 Accepted" status with a unique request ID if the request is valid. If not, it returns an appropriate error code.
+- **Payload:** The payload is a JSON object that includes the following fields:
+  - **provider name**: (mandatory) A string specifying the Service Provider, such as `aws`, `oci`, `gcp`, `cw`, `baremetal` or `test`.
+  - **provider credentials**: (optional) A key-value map with provider-specific parameters for authentication.
+  - **engine name**: (mandatory) A string specifying the topology output, either `slurm` or `k8s`.
+  - **engine parameters**: A key-value map with engine-specific parameters.
+    - **slurm parameters**:
+      - **topology_config_path**: (optional) A string specifying the file path for the topology configuration. If omitted, the topology config content is returned in the HTTP response.
+      - **plugin**: (optional) A string specifying topology plugin. Default topology/tree.
+      - **block_sizes**: (optional) A string specifying block size for topology/block plugin
+      - **skip_reload**: (optional) If present, the cluster reconfiguration is skipped.
+    - **k8s parameters**:
+      - **topology_config_path**: (mandatory) A string specifying the key for the topology config in the ConfigMap.
+      - **topology_configmap_name**: (mandatory) A string specifying the name of the ConfigMap containing the topology config.
+      - **topology_configmap_namespace**: (mandatory) A string specifying the namespace of the ConfigMap containing the topology config.
+      - **nodes**: (optional) An array of regions mapping instance IDs to node names.
 
-#### 3. Topology Result Endpoint
+  Example:
 
-- **URL:** `http://<server>:<port>/v1/topology`
-- **Description:** This endpoint retrieves the result of a topology request.
-- **URL Query Parameters:**
-  - **uid**: Specifies the request ID returned by the topology request endpoint.
-- **Response:** Depending on the request's execution stage, this endpoint can return:
-  - "404 NotFound" if the configuration is not ready yet.
-  - "200 OK" if the request has been completed successfully.
-  - "500 InternalServerError" if there was an error during request execution.
-
-Example usage:
-
-```bash
-id=$(curl -s -X POST "http://localhost:49021/v1/generate?provider=aws&engine=slurm&topology_config_path=/path/to/topology.conf")
-
-curl -s http://localhost:49021/v1/topology?uid=$id
-```
-
-You can optionally skip the SLURM reconfiguration:
-
-```bash
-id=$(curl -X POST "http://localhost:49021/v1/generate?provider=oci&engine=slurm&topology_config_path=/path/to/topology.conf&skip_reload)
-
-curl -s http://localhost:49021/v1/topology?uid=$id
-```
-
-### Automated Solution for SLURM
-
-The Cluster Topology Generator enables a fully automated solution when combined with SLURM's `strigger` command. You can set up a trigger that runs whenever a node goes down or comes up:
-
-```bash
-strigger --set --node --down --up --flags=perm --program=<script>
-```
-
-In this setup, the `<script>` would contain the curl command to call the asynchronous endpoint:
-
-```bash
-curl -X POST "http://localhost:49021/v1/generate?provider=aws&engine=slurm&topology_config_path=/path/to/topology.conf"
-```
-
-We provide the [create-topology-update-script.sh](scripts/create-topology-update-script.sh) script, which performs the steps outlined above: it creates the topology update script and registers it with the strigger.
-
-The script accepts the following parameters:
-- **provider name** (aws, oci, gcp)
-- **path to the generated topology update script**
-- **path to the topology.conf file**
-
-Usage:
-```bash
-create-topology-update-script.sh -p <provider name> -s <topology update script> -c <path to topology.conf>
-```
-
-Example:
-```bash
-create-topology-update-script.sh -p aws -s /etc/slurm/update-topology-config.sh -c /etc/slurm/topology.conf
-```
-
-This automation ensures that your cluster topology is updated and SLURM configuration is reloaded whenever there are changes in node status, maintaining an up-to-date cluster configuration.
-
-
-### Optional: Instance ID to Node Name Mapping
-You can provide a mapping between CSP VM instance IDs and SLURM cluster node names as part of the request payload:
-```bash
-cat payload.json
-{
+```json
+  {
+  "provider": {
+    "name": "aws",
+    "creds": {
+      "access_key_id": "id",
+      "secret_access_key": "secret"
+    }
+  },
+  "engine": {
+    "name": "slurm",
+    "params": {
+      "plugin": "topology/block",
+      "block_sizes": "30,120"
+    }
+  },
   "nodes": [
     {
       "region": "region1",
@@ -210,6 +176,58 @@ cat payload.json
     }
   ]
 }
-
-curl -X POST -H "Content-Type: application/json" -d @payload.json "http://localhost:49021/v1/generate?provider=aws&engine=slurm"
 ```
+
+- **Response:** This endpoint immediately returns a "202 Accepted" status with a unique request ID if the request is valid. If not, it returns an appropriate error code.
+
+##### 3. Topology Result Endpoint
+
+- **URL:** `http(s)://<server>:<port>/v1/topology`
+- **Description:** This endpoint retrieves the result of a topology request.
+- **URL Query Parameters:**
+  - **uid**: Specifies the request ID returned by the topology request endpoint.
+- **Response:** Depending on the request's execution stage, this endpoint can return:
+  - "404 NotFound" if the configuration is not ready yet.
+  - "200 OK" if the request has been completed successfully.
+  - "500 InternalServerError" if there was an error during request execution.
+
+Example usage:
+
+```bash
+id=$(curl -s -X POST -H "Content-Type: application/json" -d @payload.json http://localhost:49021/v1/generate)
+
+curl -s "http://localhost:49021/v1/topology?uid=$id"
+```
+
+#### Automated Solution for SLURM
+
+The Cluster Topology Generator enables a fully automated solution when combined with SLURM's `strigger` command. You can set up a trigger that runs whenever a node goes down or comes up:
+
+```bash
+strigger --set --node --down --up --flags=perm --program=<script>
+```
+
+In this setup, the `<script>` would contain the curl command to call the endpoint:
+
+```bash
+curl -s -X POST -H "Content-Type: application/json" -d @payload.json http://localhost:49021/v1/generate
+```
+
+We provide the [create-topology-update-script.sh](scripts/create-topology-update-script.sh) script, which performs the steps outlined above: it creates the topology update script and registers it with the strigger.
+
+The script accepts the following parameters:
+- **provider name** (aws, oci, gcp, cw, baremetal)
+- **path to the generated topology update script**
+- **path to the topology.conf file**
+
+Usage:
+```bash
+create-topology-update-script.sh -p <provider name> -s <topology update script> -c <path to topology.conf>
+```
+
+Example:
+```bash
+create-topology-update-script.sh -p aws -s /etc/slurm/update-topology-config.sh -c /etc/slurm/topology.conf
+```
+
+This automation ensures that your cluster topology is updated and SLURM configuration is reloaded whenever there are changes in node status, maintaining an up-to-date cluster configuration.

--- a/config/topograph-config.yaml
+++ b/config/topograph-config.yaml
@@ -1,7 +1,7 @@
 # serving topograph endpoint
 http:
   port: 49021
-  ssl: true
+  ssl: false
 
 # waiting period before processing a request
 request_aggregation_delay: 15s

--- a/pkg/common/const.go
+++ b/pkg/common/const.go
@@ -29,8 +29,6 @@ const (
 	EngineTest  = "test"
 
 	KeyUID                    = "uid"
-	KeyProvider               = "provider"
-	KeyEngine                 = "engine"
 	KeyTopoConfigPath         = "topology_config_path"
 	KeyTopoConfigmapName      = "topology_configmap_name"
 	KeyTopoConfigmapNamespace = "topology_configmap_namespace"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,7 +25,6 @@ import (
 	"gopkg.in/yaml.v3"
 	"k8s.io/klog/v2"
 
-	"github.com/NVIDIA/topograph/pkg/common"
 	"github.com/NVIDIA/topograph/pkg/utils"
 )
 
@@ -39,7 +38,7 @@ type Config struct {
 	Env                     map[string]string `yaml:"env"`
 
 	// derived
-	Credentials common.Credentials
+	Credentials map[string]string
 }
 
 type Endpoint struct {

--- a/pkg/factory/engine.go
+++ b/pkg/factory/engine.go
@@ -53,6 +53,9 @@ func GetEngine(engine string) (common.Engine, *common.HTTPError) {
 type testEngine struct{}
 
 func (eng *testEngine) GenerateOutput(ctx context.Context, tree *common.Vertex, params map[string]string) ([]byte, error) {
+	if params == nil {
+		params = make(map[string]string)
+	}
 	params[common.KeySkipReload] = ""
 	return slurm.GenerateOutput(ctx, tree, params)
 }

--- a/pkg/factory/provider.go
+++ b/pkg/factory/provider.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/NVIDIA/topograph/pkg/common"
 	"github.com/NVIDIA/topograph/pkg/providers/aws"
+	"github.com/NVIDIA/topograph/pkg/providers/baremetal"
 	"github.com/NVIDIA/topograph/pkg/providers/cw"
 	"github.com/NVIDIA/topograph/pkg/providers/gcp"
 	"github.com/NVIDIA/topograph/pkg/providers/oci"
@@ -44,6 +45,8 @@ func GetProvider(provider string) (common.Provider, *common.HTTPError) {
 		prv, err = oci.GetProvider()
 	case common.ProviderCW:
 		prv, err = cw.GetProvider()
+	case common.ProviderBM:
+		prv, err = baremetal.GetProvider()
 	case common.ProviderTest:
 		prv = GetTestProvider()
 	default:
@@ -69,7 +72,7 @@ func GetTestProvider() *testProvider {
 	return p
 }
 
-func (p *testProvider) GetCredentials(_ *common.Credentials) (interface{}, error) {
+func (p *testProvider) GetCredentials(_ map[string]string) (interface{}, error) {
 	return nil, nil
 }
 

--- a/pkg/providers/aws/instance_topology.go
+++ b/pkg/providers/aws/instance_topology.go
@@ -32,7 +32,7 @@ import (
 
 var defaultPageSize int32 = 100
 
-func GenerateInstanceTopology(ctx context.Context, creds *common.AWSCredentials, pageSize int32, cis []common.ComputeInstances) ([]types.InstanceTopology, error) {
+func GenerateInstanceTopology(ctx context.Context, creds *Credentials, pageSize int32, cis []common.ComputeInstances) ([]types.InstanceTopology, error) {
 	var err error
 	topology := []types.InstanceTopology{}
 	for _, ci := range cis {
@@ -44,7 +44,7 @@ func GenerateInstanceTopology(ctx context.Context, creds *common.AWSCredentials,
 	return topology, nil
 }
 
-func generateInstanceTopology(ctx context.Context, creds *common.AWSCredentials, pageSize int32, ci *common.ComputeInstances, topology []types.InstanceTopology) ([]types.InstanceTopology, error) {
+func generateInstanceTopology(ctx context.Context, creds *Credentials, pageSize int32, ci *common.ComputeInstances, topology []types.InstanceTopology) ([]types.InstanceTopology, error) {
 	if len(ci.Region) == 0 {
 		return nil, fmt.Errorf("must specify region to query instance topology")
 	}

--- a/pkg/providers/baremetal/provider.go
+++ b/pkg/providers/baremetal/provider.go
@@ -16,7 +16,7 @@ func GetProvider() (*Provider, error) {
 	return &Provider{}, nil
 }
 
-func (p *Provider) GetCredentials(_ *common.Credentials) (interface{}, error) {
+func (p *Provider) GetCredentials(_ map[string]string) (interface{}, error) {
 	return nil, nil
 }
 

--- a/pkg/providers/cw/provider.go
+++ b/pkg/providers/cw/provider.go
@@ -36,7 +36,7 @@ func GetProvider() (*Provider, error) {
 	return &Provider{}, nil
 }
 
-func (p *Provider) GetCredentials(_ *common.Credentials) (interface{}, error) {
+func (p *Provider) GetCredentials(_ map[string]string) (interface{}, error) {
 	return nil, nil
 }
 

--- a/pkg/providers/gcp/provider.go
+++ b/pkg/providers/gcp/provider.go
@@ -34,7 +34,7 @@ func GetProvider() (*Provider, error) {
 	return &Provider{}, nil
 }
 
-func (p *Provider) GetCredentials(_ *common.Credentials) (interface{}, error) {
+func (p *Provider) GetCredentials(_ map[string]string) (interface{}, error) {
 	return nil, nil
 }
 

--- a/pkg/providers/oci/provider.go
+++ b/pkg/providers/oci/provider.go
@@ -36,14 +36,28 @@ func GetProvider() (*Provider, error) {
 	return &Provider{}, nil
 }
 
-func (p *Provider) GetCredentials(creds *common.Credentials) (interface{}, error) {
-	if creds != nil && creds.OCI != nil {
+func (p *Provider) GetCredentials(creds map[string]string) (interface{}, error) {
+	if len(creds) != 0 {
+		var tenancyID, userID, region, fingerprint, privateKey, passphrase string
 		klog.Info("Using provided credentials")
-		var passphrase *string
-		if creds.OCI.Passphrase != "" {
-			passphrase = &creds.OCI.Passphrase
+		if tenancyID = creds["tenancy_id"]; len(tenancyID) == 0 {
+			return nil, fmt.Errorf("credentials error: missing tenancy_id")
 		}
-		return OCICommon.NewRawConfigurationProvider(creds.OCI.TenancyID, creds.OCI.UserID, creds.OCI.Region, creds.OCI.Fingerprint, creds.OCI.PrivateKey, passphrase), nil
+		if userID = creds["user_id"]; len(userID) == 0 {
+			return nil, fmt.Errorf("credentials error: missing user_id")
+		}
+		if region = creds["region"]; len(region) == 0 {
+			return nil, fmt.Errorf("credentials error: missing region")
+		}
+		if fingerprint = creds["fingerprint"]; len(fingerprint) == 0 {
+			return nil, fmt.Errorf("credentials error: missing fingerprint")
+		}
+		if privateKey = creds["private_key"]; len(privateKey) == 0 {
+			return nil, fmt.Errorf("credentials error: missing private_key")
+		}
+		passphrase = creds["passphrase"]
+
+		return OCICommon.NewRawConfigurationProvider(tenancyID, userID, region, fingerprint, privateKey, &passphrase), nil
 	}
 
 	klog.Info("No credentials provided, trying default configuration provider")

--- a/pkg/server/grpc_client.go
+++ b/pkg/server/grpc_client.go
@@ -28,7 +28,7 @@ import (
 	pb "github.com/NVIDIA/topograph/pkg/protos"
 )
 
-func forwardRequest(ctx context.Context, tr *TopologyRequest, url string, cis []common.ComputeInstances) (*common.Vertex, error) {
+func forwardRequest(ctx context.Context, tr *common.TopologyRequest, url string, cis []common.ComputeInstances) (*common.Vertex, error) {
 	klog.Infof("Forwarding request to %s", url)
 	conn, err := grpc.NewClient(url, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
@@ -48,7 +48,7 @@ func forwardRequest(ctx context.Context, tr *TopologyRequest, url string, cis []
 	klog.Infof("Getting topology for instances %v", ids)
 
 	response, err := client.DescribeTopology(ctx, &pb.TopologyRequest{
-		Provider:    tr.provider,
+		Provider:    tr.Provider.Name,
 		Region:      "",
 		InstanceIds: ids,
 	})

--- a/scripts/create-topology-update-script.sh
+++ b/scripts/create-topology-update-script.sh
@@ -95,8 +95,7 @@ echo ""
 cat <<EOF > $SCRIPT_PATH
 #!/bin/bash
 
-curl -X POST "http://localhost:49021/v1/generate?provider=$PROVIDER&engine=slurm&topology_config_path=$TOPOLOGY_CONFIG_PATH"
-
+curl -X POST -H "Content-Type: application/json" -d '{"provider":{"name":"$PROVIDER"},"engine":{"name":"slurm","params":{"topology_config_path":"$TOPOLOGY_CONFIG_PATH"}}}' http://localhost:49021/v1/generate
 EOF
 
 chmod 755 $SCRIPT_PATH


### PR DESCRIPTION
This PR is a step one in adding support for block topology.
In this PR we replace the use of URL query in HTTP request for specifying provider and engine with the use of payload.
We also change the structure of the payload to contain provider credentials and engine parameters.
A sample payload will look like that:
```json
{
  "provider": {
    "name": "aws",
	"creds": {
      "access_key_id": "id",
      "secret_access_key": "secret"
    }
  },
  "engine": {
    "name": "slurm",
	"params": {
	  "plugin": "topology/block",
	  "block_sizes": "30,120"
	}
  },
  "nodes": [
    {
      "region": "region1",
      "instances": {
        "instance1": "node1",
        "instance2": "node2",
        "instance3": "node3"
      }
    },
    {
      "region": "region2",
      "instances": {
        "instance4": "node4",
        "instance5": "node5",
        "instance6": "node6"
      }
    }
  ]
}
```