### PR TITLE
Introduce fake nodes to pad the block

### DIFF
--- a/pkg/engines/slurm/slurm.go
+++ b/pkg/engines/slurm/slurm.go
@@ -47,10 +47,12 @@ const NAME = "slurm"
 type SlurmEngine struct{}
 
 type Params struct {
-	Plugin         string `mapstructure:"plugin"`
-	TopoConfigPath string `mapstructure:"topology_config_path"`
-	BlockSizes     string `mapstructure:"block_sizes"`
-	Reconfigure    bool   `mapstructure:"reconfigure"`
+	Plugin           string `mapstructure:"plugin"`
+	TopoConfigPath   string `mapstructure:"topology_config_path"`
+	BlockSizes       string `mapstructure:"block_sizes"`
+	Reconfigure      bool   `mapstructure:"reconfigure"`
+	FakeNodesEnabled bool   `mapstructure:"fakeNodesEnabled"`
+	SlurmFile        string `mapstructure:"slurmFile"`
 }
 
 type instanceMapper interface {
@@ -179,6 +181,11 @@ func GenerateOutputParams(ctx context.Context, tree *topology.Vertex, params *Pa
 	tree.Metadata[topology.KeyPlugin] = plugin
 	if len(params.BlockSizes) != 0 {
 		tree.Metadata[topology.KeyBlockSizes] = params.BlockSizes
+	}
+
+	if params.FakeNodesEnabled {
+		tree.Metadata[topology.KeyFakeNodesEnabled] = "true"
+		tree.Metadata[topology.KeySlurmFile] = params.SlurmFile
 	}
 
 	err := translate.Write(buf, tree)

--- a/pkg/engines/slurm/slurm.go
+++ b/pkg/engines/slurm/slurm.go
@@ -146,7 +146,7 @@ func getFakeNodes(data string) (string, error) {
 	prefix := "Nodes="
 	scanner := bufio.NewScanner(strings.NewReader(data))
 	for scanner.Scan() {
-		if line := scanner.Text(); strings.HasPrefix(line, prefix) {
+		if line := strings.TrimSpace(scanner.Text()); strings.HasPrefix(line, prefix) {
 			return line[len(prefix):], nil
 		}
 	}

--- a/pkg/engines/slurm/slurm.go
+++ b/pkg/engines/slurm/slurm.go
@@ -53,6 +53,7 @@ type Params struct {
 	BlockSizes       string `mapstructure:"block_sizes"`
 	Reconfigure      bool   `mapstructure:"reconfigure"`
 	FakeNodesEnabled bool   `mapstructure:"fakeNodesEnabled"`
+	FakeNodePool     string `mapstructure:"fake_node_pool"`
 }
 
 type instanceMapper interface {
@@ -210,10 +211,16 @@ func GenerateOutputParams(ctx context.Context, tree *topology.Vertex, params *Pa
 		tree.Metadata[topology.KeyBlockSizes] = params.BlockSizes
 	}
 
-	if params.FakeNodesEnabled {
-		fakeData, err := GetFakeNodes(ctx)
-		if err != nil {
-			return nil, err
+	if plugin == topology.TopologyBlock && params.FakeNodesEnabled {
+		var fakeData string
+		var err error
+		if len(params.FakeNodePool) > 0 {
+			fakeData = params.FakeNodePool
+		} else {
+			fakeData, err = GetFakeNodes(ctx)
+			if err != nil {
+				return nil, err
+			}
 		}
 		tree.Metadata[topology.KeyFakeConfig] = fakeData
 	}

--- a/pkg/engines/slurm/slurm.go
+++ b/pkg/engines/slurm/slurm.go
@@ -136,11 +136,15 @@ func GetFakeNodes(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	out := stdout.String()
+	klog.V(4).Infof("stdout: %s", out)
 
-	klog.V(4).Infof("stdout: %s", stdout.String())
+	return getFakeNodes(out)
+}
 
+func getFakeNodes(data string) (string, error) {
 	prefix := "Nodes="
-	scanner := bufio.NewScanner(strings.NewReader(stdout.String()))
+	scanner := bufio.NewScanner(strings.NewReader(data))
 	for scanner.Scan() {
 		if line := scanner.Text(); strings.HasPrefix(line, prefix) {
 			return line[len(prefix):], nil

--- a/pkg/engines/slurm/slurm_test.go
+++ b/pkg/engines/slurm/slurm_test.go
@@ -36,13 +36,13 @@ func TestGetFakeNodes(t *testing.T) {
 		{
 			name: "Case 2: valid input",
 			in: `PartitionName=fake
-AllowQos=ALL
-DefaultTime=NONE DisableRootJobs=NO ExclusiveUser=NO GraceTime=0 Hidden=NO
-MaxNodes=UNLIMITED MaxTime=08:00:00 MinNodes=1 LLN=NO MaxCPUsPerNode=UNLIMITED MaxCPUsPerSocket=UNLIMITED
-Nodes=fake-[01-16]
-OverTimeLimit=NONE PreemptMode=OFF
-JobDefaults=(null)
-DefMemPerNode=UNLIMITED MaxMemPerNode=UNLIMITED
+   AllowQos=ALL
+   DefaultTime=NONE DisableRootJobs=NO ExclusiveUser=NO GraceTime=0 Hidden=NO
+   MaxNodes=UNLIMITED MaxTime=08:00:00 MinNodes=1 LLN=NO MaxCPUsPerNode=UNLIMITED MaxCPUsPerSocket=UNLIMITED
+   Nodes=fake-[01-16]
+   OverTimeLimit=NONE PreemptMode=OFF
+   JobDefaults=(null)
+   DefMemPerNode=UNLIMITED MaxMemPerNode=UNLIMITED
 `,
 			out: "fake-[01-16]",
 		},

--- a/pkg/engines/slurm/slurm_test.go
+++ b/pkg/engines/slurm/slurm_test.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package slurm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetFakeNodes(t *testing.T) {
+	testCases := []struct {
+		name string
+		in   string
+		out  string
+		err  string
+	}{
+		{
+			name: "Case 1: no nodes",
+			err:  "fake partition has no nodes",
+		},
+		{
+			name: "Case 2: valid input",
+			in: `PartitionName=fake
+AllowQos=ALL
+DefaultTime=NONE DisableRootJobs=NO ExclusiveUser=NO GraceTime=0 Hidden=NO
+MaxNodes=UNLIMITED MaxTime=08:00:00 MinNodes=1 LLN=NO MaxCPUsPerNode=UNLIMITED MaxCPUsPerSocket=UNLIMITED
+Nodes=fake-[01-16]
+OverTimeLimit=NONE PreemptMode=OFF
+JobDefaults=(null)
+DefMemPerNode=UNLIMITED MaxMemPerNode=UNLIMITED
+`,
+			out: "fake-[01-16]",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := getFakeNodes(tc.in)
+			if len(tc.err) != 0 {
+				require.EqualError(t, err, tc.err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.out, out)
+			}
+		})
+	}
+}

--- a/pkg/providers/providers_sim.go
+++ b/pkg/providers/providers_sim.go
@@ -26,8 +26,9 @@ import (
 var APIError = errors.New("API error")
 
 type SimulationParams struct {
-	ModelPath string `mapstructure:"model_path"`
-	APIError  int    `mapstructure:"api_error"`
+	ModelPath    string `mapstructure:"model_path"`
+	APIError     int    `mapstructure:"api_error"`
+	FakeNodePool string `mapstructure:"fake_node_pool"`
 }
 
 func GetSimulationParams(params map[string]any) (*SimulationParams, error) {
@@ -38,6 +39,5 @@ func GetSimulationParams(params map[string]any) (*SimulationParams, error) {
 	if len(p.ModelPath) == 0 {
 		return nil, fmt.Errorf("no model path for simulation")
 	}
-
 	return &p, nil
 }

--- a/pkg/providers/providers_sim.go
+++ b/pkg/providers/providers_sim.go
@@ -26,9 +26,8 @@ import (
 var APIError = errors.New("API error")
 
 type SimulationParams struct {
-	ModelPath    string `mapstructure:"model_path"`
-	APIError     int    `mapstructure:"api_error"`
-	FakeNodePool string `mapstructure:"fake_node_pool"`
+	ModelPath string `mapstructure:"model_path"`
+	APIError  int    `mapstructure:"api_error"`
 }
 
 func GetSimulationParams(params map[string]any) (*SimulationParams, error) {

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -30,12 +30,11 @@ const (
 	KeyTopoConfigmapNamespace = "topology_configmap_namespace"
 	KeyBlockSizes             = "block_sizes"
 
-	KeyPlugin           = "plugin"
-	TopologyTree        = "topology/tree"
-	TopologyBlock       = "topology/block"
-	NoTopology          = "no-topology"
-	KeyFakeNodesEnabled = "fakeNodesEnabled"
-	KeySlurmFile        = "slurmFile"
+	KeyPlugin     = "plugin"
+	TopologyTree  = "topology/tree"
+	TopologyBlock = "topology/block"
+	NoTopology    = "no-topology"
+	KeyFakeConfig = "fakeConfig"
 )
 
 // Vertex is a tree node, representing a compute node or a network switch, where

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -30,10 +30,12 @@ const (
 	KeyTopoConfigmapNamespace = "topology_configmap_namespace"
 	KeyBlockSizes             = "block_sizes"
 
-	KeyPlugin     = "plugin"
-	TopologyTree  = "topology/tree"
-	TopologyBlock = "topology/block"
-	NoTopology    = "no-topology"
+	KeyPlugin        = "plugin"
+	TopologyTree     = "topology/tree"
+	TopologyBlock    = "topology/block"
+	NoTopology       = "no-topology"
+	KeyFakeNodesEnabled = "fakeNodesEnabled"
+	KeySlurmFile        = "slurmFile"
 )
 
 // Vertex is a tree node, representing a compute node or a network switch, where

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -30,10 +30,10 @@ const (
 	KeyTopoConfigmapNamespace = "topology_configmap_namespace"
 	KeyBlockSizes             = "block_sizes"
 
-	KeyPlugin        = "plugin"
-	TopologyTree     = "topology/tree"
-	TopologyBlock    = "topology/block"
-	NoTopology       = "no-topology"
+	KeyPlugin           = "plugin"
+	TopologyTree        = "topology/tree"
+	TopologyBlock       = "topology/block"
+	NoTopology          = "no-topology"
 	KeyFakeNodesEnabled = "fakeNodesEnabled"
 	KeySlurmFile        = "slurmFile"
 )

--- a/pkg/translate/output.go
+++ b/pkg/translate/output.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -58,15 +59,19 @@ func Write(wr io.Writer, root *topology.Vertex) error {
 }
 
 func getFakeNodeConfig(fakeNodeData string) (*fakeNodeConfig, error) {
-	fakeData := strings.Split(fakeNodeData, ",")
+	reFake := regexp.MustCompile(`(.*)\[(\d+)-(\d+)\]`)
+	fakeRange := reFake.FindStringSubmatch(fakeNodeData)
+	if len(fakeRange) == 4 {
+		return nil, fmt.Errorf("insupported format of fake nodes: %s", fakeNodeData)
+	}
 
-	fakeNodePrefix := fakeData[0]
+	fakeNodePrefix := fakeRange[1]
 
-	start, err := strconv.Atoi(fakeData[1])
+	start, err := strconv.Atoi(fakeRange[2])
 	if err != nil {
 		return nil, err
 	}
-	end, err := strconv.Atoi(fakeData[2])
+	end, err := strconv.Atoi(fakeRange[3])
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/translate/output.go
+++ b/pkg/translate/output.go
@@ -167,10 +167,7 @@ func findMinDomainSize(blockRoot *topology.Vertex) (int, int) {
 }
 
 func isEnoughFakeNodesAvailable(blockSize int, numDomains int, fnc *fakeNodeConfig) bool {
-	if (fnc.endRange - fnc.startRange + 1) >= (blockSize * numDomains) {
-		return true
-	}
-	return false
+	return (fnc.endRange - fnc.startRange + 1) >= (blockSize * numDomains)
 }
 
 // getBlockSize returns blocksize for each possible level.

--- a/pkg/translate/output.go
+++ b/pkg/translate/output.go
@@ -61,7 +61,7 @@ func Write(wr io.Writer, root *topology.Vertex) error {
 func getFakeNodeConfig(fakeNodeData string) (*fakeNodeConfig, error) {
 	reFake := regexp.MustCompile(`(.*)\[(\d+)-(\d+)\]`)
 	fakeRange := reFake.FindStringSubmatch(fakeNodeData)
-	if len(fakeRange) == 4 {
+	if len(fakeRange) != 4 {
 		return nil, fmt.Errorf("insupported format of fake nodes: %s", fakeNodeData)
 	}
 

--- a/pkg/translate/output_test.go
+++ b/pkg/translate/output_test.go
@@ -698,7 +698,7 @@ func TestGetBlockSizeWithFakeNodes(t *testing.T) {
 
 func TestBlockFakeNodes(t *testing.T) {
 	// Test Fake node config
-	fakeNodeData := "fake,100,998"
+	fakeNodeData := "fake[100-998]"
 	fnc, err := getFakeNodeConfig(fakeNodeData)
 	require.NoError(t, err)
 

--- a/pkg/translate/output_test.go
+++ b/pkg/translate/output_test.go
@@ -704,7 +704,7 @@ func TestBlockFakeNodes(t *testing.T) {
 	defer func() { _ = os.Remove(file.Name()) }()
 	defer func() { _ = file.Close() }()
 
-	_, err = file.WriteString(fmt.Sprintf(slurmFileData))
+	_, err = file.WriteString(slurmFileData)
 	require.NoError(t, err)
 
 	fnc, err := getFakeNodeConfig(file.Name())

--- a/tests/models/nvl72.yaml
+++ b/tests/models/nvl72.yaml
@@ -1,0 +1,58 @@
+#      _________
+#      |       | 
+#   spine-1 spine-2 
+#      |       | 
+#      |      ... 
+#      |
+#      ____________
+#      |          |
+#   leaf-1-1   leaf-1-2
+#      |          |
+#   -------    -------
+#    1101       1201
+#     ...        ...
+#    1108       1208
+#   -------    ------- 
+#   cb-1-1     cb-1-2
+#
+# Supported block sizes: 18, 36, 72
+#
+switches:
+- name: core
+  metadata:
+    region: us-east
+    group: none
+  switches: [spine-1,spine-2]
+- name: spine-1
+  metadata:
+    availability_zone: zone1
+  switches: [leaf-1-1,leaf-1-2]
+- name: spine-2
+  metadata:
+    availability_zone: zone1
+  switches: [leaf-2-1,leaf-2-2]
+- name: leaf-1-1
+  capacity_blocks: [cb-1-1]
+- name: leaf-1-2
+  capacity_blocks: [cb-1-2]
+- name: leaf-2-1
+  capacity_blocks: [cb-2-1]
+- name: leaf-2-2
+  capacity_blocks: [cb-2-2]
+capacity_blocks:
+- name: cb-1-1
+  type: GB200
+  nvlink: nvl-1-1
+  nodes: ["[1101-1115]"]
+- name: cb-1-2
+  type: GB200
+  nvlink: nvl-1-2
+  nodes: ["[1201-1215]"]
+- name: cb-2-1
+  type: GB200
+  nvlink: nvl-2-1
+  nodes: ["[2101-2115]"]
+- name: cb-2-2
+  type: GB200
+  nvlink: nvl-2-2
+  nodes: ["[2201-2218]"]

--- a/tests/payloads/test-aws-sim-large-block-fake.json
+++ b/tests/payloads/test-aws-sim-large-block-fake.json
@@ -1,0 +1,18 @@
+{
+  "provider": {
+    "name": "aws-sim",
+    "params": {
+      "model_path": "tests/models/nvl72.yaml"
+    }
+  },
+  "engine": {
+    "name": "slurm",
+    "params": {
+      "plugin": "topology/block",
+      "topology_config_path": "topology_block_fake.conf",
+      "fakeNodesEnabled": true,
+      "block_sizes": "16,32",
+      "fake_node_pool": "fake[100-200]"
+    }
+  }
+}

--- a/tests/payloads/test-oci-sim-large-block-fake.json
+++ b/tests/payloads/test-oci-sim-large-block-fake.json
@@ -1,0 +1,18 @@
+{
+    "provider": {
+      "name": "oci-sim",
+      "params": {
+        "model_path": "tests/models/large.yaml"
+      }
+    },
+    "engine": {
+      "name": "slurm",
+      "params": {
+        "plugin": "topology/block",
+        "topology_config_path": "topology_block_fake.conf",
+        "fakeNodesEnabled": true,
+        "fake_node_pool": "fake[100-1000]"
+      }
+    }
+  }
+  

--- a/tests/payloads/test-toposim-block-fake.json
+++ b/tests/payloads/test-toposim-block-fake.json
@@ -1,0 +1,18 @@
+{
+    "provider": {
+      "name": "test",
+      "params": {
+        "model_path": "tests/models/nvl72.yaml"
+      }
+    },
+    "engine": {
+      "name": "slurm",
+      "params": {
+        "plugin": "topology/block",
+        "fakeNodesEnabled" : "true",
+        "fake_node_pool": "fake[1-80]",
+        "topology_config_path": "topology_block_fake.conf"
+      }
+    }
+  }
+  


### PR DESCRIPTION
Few engine parameters that have been added are
`"engine": {
    "name": "slurm",
    "params": {
      "plugin": "topology/block",
      "topology_config_path": "topology.conf",
      "fakeNodesEnabled": true,
      "block_sizes": "14,32",
      "slurmFile": "<SLURM.CONF_PATH>"
    }
  }`

Tentative slurm.conf will contain fake node names in the following manner
`NodeName=fake[100-998] RealMemory=65238 Boards=1 SocketsPerBoard=1 CoresPerSocket=16 ThreadsPerCore=1 Features=location=us-central1-b,CPU State=FUTURE
PartitionName="cpu-small" MinNodes=1 DefaultTime=8:00:00 MaxTime=8:00:00 AllowGroups=ALL PriorityJobFactor=1 PriorityTier=1 OverSubscribe=NO PreemptMode=OFF QOS=20_cpus_per_user AllowAccounts=ALL AllowQos=ALL TRESBillingWeights=CPU=0.0000001,Mem=0.000000015G Nodes=cpu-small-[001,002],fake[001-998]`
