### PR TITLE
Fix deployment issues where node-observer couldn't connect to the topograph service

### DIFF
--- a/charts/topograph/charts/node-observer/templates/configmap.yml
+++ b/charts/topograph/charts/node-observer/templates/configmap.yml
@@ -6,7 +6,7 @@ metadata:
     {{- include "node-observer.labels" . | nindent 4 }}
 data:
   node-observer-config.yaml: |-
-    topology_generator_url: "http://{{ include "topograph.service.name" $ }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.global.service.port }}/v1/generate"
+    topology_generator_url: "{{ include "topograph.url" $ }}/v1/generate"
     params:
       {{- toYaml .Values.global.engineParams | nindent 6 }}
     trigger:

--- a/charts/topograph/charts/node-observer/templates/deployment.yaml
+++ b/charts/topograph/charts/node-observer/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           args:
             - -c
             - |
-              until curl -sf "http://{{ include "topograph.service.name" $ }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.global.service.port }}/healthz" ; do
+              until curl -sf "{{ include "topograph.url" $ }}/healthz" ; do
                 echo "Waiting for topograph to start ..."
                 sleep 2
               done

--- a/charts/topograph/templates/_helpers.tpl
+++ b/charts/topograph/templates/_helpers.tpl
@@ -62,8 +62,8 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Create the name of the topograph service
+Create topograph service URL
 */}}
-{{- define "topograph.service.name" -}}
-{{- .Release.Name }}
+{{- define "topograph.url" -}}
+{{ printf "http://%s.%s.svc.cluster.local:%.0f" .Release.Name .Release.Namespace .Values.global.service.port }}
 {{- end }}


### PR DESCRIPTION
## Overview

This PR fixes a service discovery issue in the node-observer.

Problem: The node-observer subchart was using hardcoded service names (topograph) for health checks and API calls, but the actual topograph service name is dynamically generated based on the release name (e.g., slinky-topograph). This caused deployment failures where the node-observer init container would timeout waiting for a service that didn't exist.

## Key Changes

- Added clean service name helper
- Updated node-observer deployment
- Updated node-observer config

## How This Was Tested

Helm Template Validation:

- [x] Verified correct service name generation: test-topograph.default.svc.cluster.local
- [x] Tested with different release names to ensure helper works dynamically

Runtime Verification:

- [x] Verified topograph-s-topograph.s-topograph.svc.cluster.local:49021
- [x] Confirmed successful HTTP requests to topograph service
- [x] Verified topology generation and ConfigMap updates working


