### PR TITLE
use label selector for SLURM pods in Slinky

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Topograph offers three endpoints for interacting with the service. Below are the
       - **reconfigure**: (optional) If `true`, invoke `scontrol reconfigure` after topology config is generated. Default `false`
     - **slinky parameters**:
       - **namespace**: A string specifying namespace where SLURM cluster is running.
-      - **pod_label**: A string specifying label for pods running SLURM nodes.
+      - **podSelector**: A standard Kubernetes label selector for pods running SLURM nodes.
       - **plugin**: (optional) A string specifying topology plugin: `topology/tree` (default) or `topology/block`.
       - **block_sizes**: (optional) A string specifying block size for `topology/block` plugin.
       - **topology_config_path**: A string specifying the key for the topology config in the ConfigMap.

--- a/charts/topograph/charts/node-observer/templates/configmap.yml
+++ b/charts/topograph/charts/node-observer/templates/configmap.yml
@@ -6,7 +6,7 @@ metadata:
     {{- include "node-observer.labels" . | nindent 4 }}
 data:
   node-observer-config.yaml: |-
-    topology_generator_url: "{{ include "topograph.url" $ }}/v1/generate"
+    generateTopologyUrl: "{{ include "topograph.url" $ }}/v1/generate"
     params:
       {{- toYaml .Values.global.engineParams | nindent 6 }}
     trigger:

--- a/charts/topograph/charts/node-observer/values.yaml
+++ b/charts/topograph/charts/node-observer/values.yaml
@@ -28,10 +28,10 @@ serviceAccount:
 verbosity: 3
 
 topograph:
-  # Initiate topology request based on changes in nodes with these node labels
+  # Initiate topology request based on changes in selected nodes and pods
   trigger:
-    node_labels: {}
-    pod_labels: {}
+    nodeSelector: {}
+    podSelector: {}
 
 podAnnotations: {}
 podLabels: {}

--- a/charts/topograph/values-slinky-block-example.yaml
+++ b/charts/topograph/values-slinky-block-example.yaml
@@ -3,23 +3,19 @@
 # Declare variables to be passed into your templates.
 
 global:
-  # provider: "aws", "oci", "gcp", "nebius", "baremetal" or "test".
-  provider: "aws"
+  # provider: "aws", "oci", "gcp", "nebius", "netq", "baremetal" or "test".
+  provider: aws
   #  engine: "k8s" or "slinky"
-  engine: "slinky"
+  engine: slinky
   engineParams:
     namespace: slurm
-    pod_label: "app.kubernetes.io/component=compute"
-    plugin: "topology/block"
+    podSelector:
+      matchLabels:
+        app.kubernetes.io/component: compute
+    plugin: topology/block
     block_sizes: 4
     topology_config_path: topology.conf
     topology_configmap_name: slurm-config
-
-  service:
-    type: ClusterIP
-    port: 49021
-
-replicaCount: 1
 
 nodeSelector:
   dedicated: user-workload
@@ -32,5 +28,6 @@ node-observer:
     dedicated: user-workload
   topograph:
     trigger:
-      pod_labels:
-        app.kubernetes.io/component: compute
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/component: compute

--- a/charts/topograph/values-slinky-partition-example.yaml
+++ b/charts/topograph/values-slinky-partition-example.yaml
@@ -12,7 +12,18 @@ global:
     podSelector:
       matchLabels:
         app.kubernetes.io/component: compute
-    plugin: topology/tree
+    topologies:
+      topo1:
+        plugin: topology/block
+        block_sizes: "2,4"
+      topo2:
+        plugin: topology/block
+        block_sizes: "8,16"
+      topo3:
+        plugin: topology/tree
+      topo-default:
+        plugin: topology/flat
+        cluster_default: true
     topology_config_path: topology.conf
     topology_configmap_name: slurm-config
 

--- a/charts/topograph/values.yaml
+++ b/charts/topograph/values.yaml
@@ -3,10 +3,10 @@
 # Declare variables to be passed into your templates.
 
 global:
-  # provider: "aws", "oci", "gcp", "nebius", "baremetal" or "test".
-  provider: "test"
+  # provider: "aws", "oci", "gcp", "nebius", "netq", "baremetal" or "test".
+  provider: test
   #  engine: "k8s" or "slinky"
-  engine: "k8s"
+  engine: k8s
   # engineParams:
 
   service:
@@ -46,10 +46,10 @@ config:
   # credentials_secret:
 
 topologyNodeLabels:
-  accelerator: "network.topology.nvidia.com/accelerator"
-  block: "network.topology.nvidia.com/block"
-  spine: "network.topology.nvidia.com/spine"
-  datacenter: "network.topology.nvidia.com/datacenter"
+  accelerator: network.topology.nvidia.com/accelerator
+  block: network.topology.nvidia.com/block
+  spine: network.topology.nvidia.com/spine
+  datacenter: network.topology.nvidia.com/datacenter
 
 podAnnotations: {}
 podLabels: {}
@@ -126,7 +126,7 @@ node-observer:
   verbosity: 3
   topograph:
     trigger:
-      node_labels: {}
+      nodeSelector: {}
 
 node-data-broker:
   image:

--- a/cmd/node-observer/main.go
+++ b/cmd/node-observer/main.go
@@ -73,7 +73,10 @@ func mainInternal(c string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	controller := node_observer.NewController(ctx, kubeClient, cfg)
+	controller, err := node_observer.NewController(ctx, kubeClient, cfg)
+	if err != nil {
+		return err
+	}
 
 	var g run.Group
 	// Signal handler

--- a/docs/slinky.md
+++ b/docs/slinky.md
@@ -25,13 +25,15 @@ The parameters for the configuration file and topology request are defined in th
 ```yaml
 global:
   # provider – name of the cloud provider or on-prem environment.
-  # Supported values: "aws", "gcp", "oci", "nebius", "baremetal.ib".
-  provider: "aws"
-  engine: "slinky"
+  # Supported values: "aws", "gcp", "oci", "nebius", "netq", "baremetal.ib".
+  provider: aws
+  engine: slinky
   engineParams:
     namespace: ns-slinky                               # Namespace where Slinky is running
-    pod_label: "app.kubernetes.io/component=compute"   # Label of the pods running SLURM nodes
-    plugin: "topology/block"                           # Name of the topology plugin
+    podSelector:                                      # Label selector for pods running SLURM nodes
+      matchLabels:
+        app.kubernetes.io/component: compute
+    plugin: topology/block                             # Name of the topology plugin
     block_sizes: 4                                     # (Optional) Block size for the block topology plugin
     topology_configmap_name: slurm-config              # Name of the ConfigMap containing the topology config
     topology_config_path: topology.conf                # Key in the ConfigMap for the topology config
@@ -90,7 +92,11 @@ curl -X POST -H "Content-Type: application/json" \
       "name": "slinky",
       "params": {
         "namespace": "ns-slinky",
-        "pod_label": "app.kubernetes.io/component=compute",
+        "podSelector": {
+          "matchLabels": {
+            "app.kubernetes.io/component": "compute"
+          }
+        },
         "topology_config_path": "topology.conf",
         "topology_configmap_name": "slurm-config"
       }
@@ -109,7 +115,11 @@ curl -X POST -H "Content-Type: application/json" \
       "name": "slinky",
       "params": {
         "namespace": "ns-slinky",
-        "pod_label": "app.kubernetes.io/component=compute",
+        "podSelector": {
+          "matchLabels": {
+            "app.kubernetes.io/component": "compute"
+          }
+        },
         "topology_config_path": "topology.conf",
         "topology_configmap_name": "slurm-config",
         "plugin": "topology/block",

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	k8s.io/apimachinery v0.31.2
 	k8s.io/client-go v0.31.2
 	k8s.io/klog/v2 v2.130.1
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -109,5 +110,4 @@ require (
 	k8s.io/utils v0.0.0-20241104163129-6fe5fd82f078 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/pkg/node_observer/config.go
+++ b/pkg/node_observer/config.go
@@ -20,20 +20,21 @@ import (
 	"fmt"
 	"os"
 
-	"gopkg.in/yaml.v3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 )
 
 type Config struct {
-	TopologyGeneratorURL string         `yaml:"topology_generator_url"`
-	Trigger              Trigger        `yaml:"trigger"`
-	Provider             string         `yaml:"provider"`
-	Engine               string         `yaml:"engine"`
-	Params               map[string]any `yaml:"params"`
+	GenerateTopologyURL string         `yaml:"generateTopologyUrl"`
+	Trigger             Trigger        `yaml:"trigger"`
+	Provider            string         `yaml:"provider"`
+	Engine              string         `yaml:"engine"`
+	Params              map[string]any `yaml:"params"`
 }
 
 type Trigger struct {
-	NodeLabels map[string]string `yaml:"node_labels"`
-	PodLabels  map[string]string `yaml:"pod_labels"`
+	NodeSelector map[string]string     `yaml:"nodeSelector,omitempty"`
+	PodSelector  *metav1.LabelSelector `yaml:"podSelector,omitempty"`
 }
 
 func NewConfigFromFile(fname string) (*Config, error) {
@@ -48,12 +49,12 @@ func NewConfigFromFile(fname string) (*Config, error) {
 		return nil, fmt.Errorf("failed to parse %s: %v", fname, err)
 	}
 
-	if len(cfg.TopologyGeneratorURL) == 0 {
-		return nil, fmt.Errorf("must specify topology_generator_url")
+	if len(cfg.GenerateTopologyURL) == 0 {
+		return nil, fmt.Errorf("must specify generateTopologyUrl")
 	}
 
-	if len(cfg.Trigger.NodeLabels) == 0 && len(cfg.Trigger.PodLabels) == 0 {
-		return nil, fmt.Errorf("must specify node_labels and/or pod_labels in trigger")
+	if len(cfg.Trigger.NodeSelector) == 0 && cfg.Trigger.PodSelector == nil {
+		return nil, fmt.Errorf("must specify nodeSelector and/or podSelector in trigger")
 	}
 
 	return cfg, nil

--- a/pkg/node_observer/controller_test.go
+++ b/pkg/node_observer/controller_test.go
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package node_observer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNewController(t *testing.T) {
+	ctx := context.TODO()
+
+	cfg := &Config{
+		Provider: "test",
+		Engine:   "test",
+	}
+
+	testCases := []struct {
+		name    string
+		trigger Trigger
+		err     string
+	}{
+		{
+			name: "Case 1: bad trigger",
+			trigger: Trigger{
+				PodSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{Operator: "BAD"},
+					},
+				},
+			},
+			err: `"BAD" is not a valid label selector operator`,
+		},
+		{
+			name: "Case 2: valid input",
+			trigger: Trigger{
+				PodSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"key": "val"},
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{Key: "key", Operator: "In", Values: []string{"val"}},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg.Trigger = tc.trigger
+			_, err := NewController(ctx, nil, cfg)
+			if len(tc.err) != 0 {
+				require.EqualError(t, err, tc.err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/node_observer/node_informer_test.go
+++ b/pkg/node_observer/node_informer_test.go
@@ -10,15 +10,19 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestNewNodeInformer(t *testing.T) {
 	ctx := context.TODO()
 	trigger := &Trigger{
-		NodeLabels: map[string]string{"key": "val"},
-		PodLabels:  map[string]string{"key": "val"},
+		NodeSelector: map[string]string{"key": "val"},
+		PodSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{"key": "val"},
+		},
 	}
-	informer := NewNodeInformer(ctx, nil, trigger, nil)
+	informer, err := NewNodeInformer(ctx, nil, trigger, nil)
+	require.NoError(t, err)
 	require.NotNil(t, informer.nodeFactory)
 	require.NotNil(t, informer.podFactory)
 

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -26,7 +26,7 @@ const (
 
 	KeyUID               = "uid"
 	KeyNamespace         = "namespace"
-	KeyPodLabel          = "pod_label"
+	KeyPodSelector       = "podSelector"
 	KeyTopoConfigPath    = "topology_config_path"
 	KeyTopoConfigmapName = "topology_configmap_name"
 	KeyBlockSizes        = "block_sizes"


### PR DESCRIPTION
We want to provide a more flexible way to select Slurm pods instead of relying on a single pod label. For this reason, we will use a standard label selector.