### PR TITLE
docs: add InfiniBand, NetQ, and DRA provider documentation, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,35 @@ The Engine translates this internal representation into the format expected by t
 - The Provider receives notifications and invokes CSP API to retrieve topology-related information.
 - The Engine converts the topology information into the format expected by the user cluster (e.g., SLURM or Kubernetes).
 
+## How Topograph Fits in the Kubernetes Topology Stack
+
+Kubernetes uses the word "topology" in several distinct contexts. Topograph occupies the inter-node layer:
+
+| | Topograph | [kubelet Topology Manager](https://kubernetes.io/docs/tasks/administer-cluster/topology-manager/) |
+|---|---|---|
+| **Scope** | Inter-node (cluster-wide) | Intra-node (single node) |
+| **What it does** | Discovers the physical network fabric (NVLink domains, switch hierarchy) and publishes it as node labels | Aligns CPU, GPU, and NIC allocations to the same NUMA domain within a node to reduce memory access latency |
+| **Consumed by** | Topology-aware schedulers (KAI Scheduler, Kueue TAS) making multi-node placement decisions | The kubelet itself, when binding a Pod's containers to hardware resources |
+
+The two are complementary and can be active simultaneously. Topology Manager optimizes resource allocation *within* a node; Topograph informs the scheduler about *which nodes* belong together on the network.
+
+```mermaid
+graph TB
+    subgraph topo_scope["Topograph — inter-node scope"]
+        fabric["Physical Network Fabric\n(NVLink domains · IB/Ethernet switches)"]
+        topograph["Topograph\n(queries CSP/fabric APIs)"]
+        labels["Kubernetes Node Labels\n(network.topology.nvidia.com/*)"]
+        scheduler["Topology-Aware Scheduler\n(KAI Scheduler · Kueue TAS)"]
+        fabric --> topograph --> labels --> scheduler
+    end
+
+    subgraph kubelet_scope["kubelet — intra-node scope"]
+        tm["Topology Manager\n(NUMA alignment within a node)"]
+    end
+
+    scheduler -. "schedules Pods onto nodes;\nTopology Manager handles\nresource alignment inside each node" .-> tm
+```
+
 ## Configuration
 
 Topograph accepts its configuration file path using the `-c` command-line parameter. The configuration file is a YAML document. A sample configuration file is located at [config/topograph-config.yaml](config/topograph-config.yaml).

--- a/README.md
+++ b/README.md
@@ -46,35 +46,6 @@ The Engine translates this internal representation into the format expected by t
 - The Provider receives notifications and invokes CSP API to retrieve topology-related information.
 - The Engine converts the topology information into the format expected by the user cluster (e.g., SLURM or Kubernetes).
 
-## How Topograph Fits in the Kubernetes Topology Stack
-
-Kubernetes uses the word "topology" in several distinct contexts. Topograph occupies the inter-node layer:
-
-| | Topograph | [kubelet Topology Manager](https://kubernetes.io/docs/tasks/administer-cluster/topology-manager/) |
-|---|---|---|
-| **Scope** | Inter-node (cluster-wide) | Intra-node (single node) |
-| **What it does** | Discovers the physical network fabric (NVLink domains, switch hierarchy) and publishes it as node labels | Aligns CPU, GPU, and NIC allocations to the same NUMA domain within a node to reduce memory access latency |
-| **Consumed by** | Topology-aware schedulers (KAI Scheduler, Kueue TAS) making multi-node placement decisions | The kubelet itself, when binding a Pod's containers to hardware resources |
-
-The two are complementary and can be active simultaneously. Topology Manager optimizes resource allocation *within* a node; Topograph informs the scheduler about *which nodes* belong together on the network.
-
-```mermaid
-graph TB
-    subgraph topo_scope["Topograph — inter-node scope"]
-        fabric["Physical Network Fabric\n(NVLink domains · IB/Ethernet switches)"]
-        topograph["Topograph\n(queries CSP/fabric APIs)"]
-        labels["Kubernetes Node Labels\n(network.topology.nvidia.com/*)"]
-        scheduler["Topology-Aware Scheduler\n(KAI Scheduler · Kueue TAS)"]
-        fabric --> topograph --> labels --> scheduler
-    end
-
-    subgraph kubelet_scope["kubelet — intra-node scope"]
-        tm["Topology Manager\n(NUMA alignment within a node)"]
-    end
-
-    scheduler -. "schedules Pods onto nodes;\nTopology Manager handles\nresource alignment inside each node" .-> tm
-```
-
 ## Configuration
 
 Topograph accepts its configuration file path using the `-c` command-line parameter. The configuration file is a YAML document. A sample configuration file is located at [config/topograph-config.yaml](config/topograph-config.yaml).

--- a/README.md
+++ b/README.md
@@ -111,18 +111,33 @@ Topograph operates with two primary concepts: `provider` and `engine`. A `provid
 Currently supported providers:
 
 - [AWS](./docs/providers/aws.md)
-- OCI
+- [OCI](./docs/providers/oci.md)
 - [GCP](./docs/providers/gcp.md)
 - [Nebius](./docs/providers/nebius.md)
-- NetQ
-- DRA
-- InfiniBand
+- [NetQ](./docs/providers/netq.md)
+- [DRA](./docs/providers/dra.md) — reads `nvidia.com/gpu.clique` labels set by the NVIDIA GPU operator DRA driver
+- [InfiniBand (bare-metal)](./docs/providers/infiniband.md)
+- [InfiniBand (Kubernetes)](./docs/providers/infiniband.md)
 
 Currently supported engines:
 
 - [SLURM](./docs/engines/slurm.md)
 - [Kubernetes](./docs/engines/k8s.md)
 - [SLURM-on-Kubernetes (Slinky)](./docs/engines/slinky.md)
+
+### Choosing a Provider
+
+| Scenario | Recommended provider |
+|---|---|
+| Cloud cluster (AWS, GCP, OCI, Nebius) | Use the matching CSP provider |
+| Spectrum-X fabric | [NetQ](./docs/providers/netq.md) |
+| Multi-Node NVLink (MNNVL), infrastructure visibility | [NetQ](./docs/providers/netq.md) |
+| MNNVL on Kubernetes (scheduling) | [DRA](./docs/providers/dra.md) |
+| InfiniBand fabric, NetQ deployed | [NetQ](./docs/providers/netq.md) |
+| InfiniBand fabric, no NetQ, bare-metal / Slurm | [InfiniBand (bare-metal)](./docs/providers/infiniband.md) |
+| InfiniBand fabric, no NetQ, Kubernetes | [InfiniBand (Kubernetes)](./docs/providers/infiniband.md) |
+
+For MNNVL environments, NetQ and DRA operate at different layers and can coexist: NetQ provides infrastructure-level visibility into the NVLink fabric while DRA feeds topology directly to Kubernetes schedulers via `nvidia.com/gpu.clique` node labels.
 
 ## Using Topograph
 

--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ Currently supported providers:
 - [Nebius](./docs/providers/nebius.md)
 - [NetQ](./docs/providers/netq.md)
 - [DRA](./docs/providers/dra.md) — reads `nvidia.com/gpu.clique` labels set by the NVIDIA GPU operator DRA driver
-- [InfiniBand (bare-metal)](./docs/providers/infiniband.md)
-- [InfiniBand (Kubernetes)](./docs/providers/infiniband.md)
+- [InfiniBand (bare-metal)](./docs/providers/infiniband.md#infiniband-bm-bare-metal)
+- [InfiniBand (Kubernetes)](./docs/providers/infiniband.md#infiniband-k8s-kubernetes)
 
 Currently supported engines:
 

--- a/docs/engines/k8s.md
+++ b/docs/engines/k8s.md
@@ -24,6 +24,35 @@ For example, if a node belongs to NVLink domain `nvl1` and connects to switch `s
 
 <p align="center"><img src="../assets/topograph-k8s.png" width="600" alt="Design"></p>
 
+### Relationship to the kubelet Topology Manager
+
+Kubernetes includes a [Topology Manager](https://kubernetes.io/docs/tasks/administer-cluster/topology-manager/) (GA since Kubernetes 1.27) that aligns CPU, GPU, and NIC allocations to the same NUMA domain *within a single node*, reducing memory access latency for a Pod's containers. These two features are complementary and address different scopes:
+
+| | Topograph (`k8s` engine) | kubelet Topology Manager |
+|---|---|---|
+| **Scope** | Inter-node (cluster-wide) | Intra-node (single node) |
+| **What it does** | Discovers the physical network fabric and publishes it as node labels | Aligns CPU/device allocations to the same NUMA domain within a node |
+| **Consumed by** | Topology-aware schedulers (KAI Scheduler, Kueue TAS) for multi-node placement | The kubelet itself, when binding containers to hardware resources |
+
+Both can be active simultaneously. Topology Manager optimizes resource allocation within a node; Topograph labels tell the scheduler which nodes belong together on the network.
+
+```mermaid
+graph TB
+    subgraph topo_scope["Topograph — inter-node scope"]
+        fabric["Physical Network Fabric\n(NVLink domains · IB/Ethernet switches)"]
+        topograph["Topograph\n(queries CSP/fabric APIs)"]
+        labels["Kubernetes Node Labels\n(network.topology.nvidia.com/*)"]
+        scheduler["Topology-Aware Scheduler\n(KAI Scheduler · Kueue TAS)"]
+        fabric --> topograph --> labels --> scheduler
+    end
+
+    subgraph kubelet_scope["kubelet — intra-node scope"]
+        tm["Topology Manager\n(NUMA alignment within a node)"]
+    end
+
+    scheduler -. "schedules Pods onto nodes;\nTopology Manager handles\nresource alignment inside each node" .-> tm
+```
+
 ## Use of Topograph
 
 While there is currently no fully network-aware scheduler capable of optimally placing groups of pods based on network considerations, Topograph serves as a stepping stone toward developing such a scheduler.

--- a/docs/providers/dra.md
+++ b/docs/providers/dra.md
@@ -100,10 +100,10 @@ After triggering topology generation, inspect the node labels applied by Topogra
 kubectl get nodes -o json | jq '.items[].metadata.labels | with_entries(select(.key | startswith("network.topology.nvidia.com")))'
 ```
 
-If topology generation returns a `502` error, check that the expected nodes have the `nvidia.com/gpu.clique` label:
+If topology generation returns a `502` error, check that the expected nodes have the `nvidia.com/gpu.clique` label and the `topograph.nvidia.com/region` / `topograph.nvidia.com/instance` annotations (the latter two are set by Topograph itself during topology discovery):
 
 ```bash
-kubectl get nodes -o json | jq '.items[].metadata.labels["nvidia.com/gpu.clique"]'
+kubectl get nodes -o json | jq '.items[] | {name: .metadata.name, clique: .metadata.labels["nvidia.com/gpu.clique"], region: .metadata.annotations["topograph.nvidia.com/region"], instance: .metadata.annotations["topograph.nvidia.com/instance"]}'
 ```
 
 See the [Kubernetes engine documentation](../engines/k8s.md) for details on the label schema.

--- a/docs/providers/dra.md
+++ b/docs/providers/dra.md
@@ -1,0 +1,109 @@
+# DRA Topology Provider
+
+The DRA provider discovers NVLink domain membership by reading `nvidia.com/gpu.clique` node labels set by the [NVIDIA GPU Operator](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/index.html)'s Dynamic Resource Allocation (DRA) driver. It is a Kubernetes-only provider that uses in-cluster service account auth — no credentials are required.
+
+**Important**: The DRA provider produces **block topology only** (`topology/block` — NVLink domain membership). It does not discover switch tree topology. If you need both switch tree and NVLink domain topology, use the [InfiniBand](./infiniband.md) or [NetQ](./netq.md) provider instead.
+
+## Background: ComputeDomains and MNNVL
+
+On GB200 NVL72 and similar Multi-Node NVLink (MNNVL) hardware, groups of nodes share a high-bandwidth NVLink fabric (1.8 TB/s chip-to-chip). Workloads that span these nodes — distributed training, disaggregated inference — benefit significantly from being placed within the same NVLink domain.
+
+Kubernetes exposes this through **ComputeDomains**, a DRA-based abstraction that represents a set of nodes sharing an NVLink/MNNVL domain as a first-class scheduling object. The GPU Operator's DRA driver labels each node with `nvidia.com/gpu.clique` to encode its NVLink clique membership. Schedulers like [KAI Scheduler](https://github.com/NVIDIA/KAI-Scheduler) consume these labels — via Topograph — to make topology-aware placement decisions.
+
+The DRA provider is Topograph's integration point for this ecosystem. For more background, see:
+- [Enabling Multi-Node NVLink on Kubernetes for GB200 and Beyond](https://developer.nvidia.com/blog/enabling-multi-node-nvlink-on-kubernetes-for-gb200-and-beyond/)
+- [Running Large-Scale GPU Workloads on Kubernetes with Slurm](https://developer.nvidia.com/blog/running-large-scale-gpu-workloads-on-kubernetes-with-slurm/)
+- [Running AI Workloads on Rack-Scale Supercomputers: From Hardware to Topology-Aware Scheduling](https://developer.nvidia.com/blog/running-ai-workloads-on-rack-scale-supercomputers-from-hardware-to-topology-aware-scheduling/)
+
+## When to Use This Provider
+
+Use the DRA provider when:
+
+- Your cluster runs Kubernetes with the NVIDIA GPU Operator and DRA support enabled
+- You have MNNVL hardware (e.g. GB200 NVL72) and need NVLink domain topology for block-based scheduling
+- You are using Slinky (Slurm-on-Kubernetes) with MNNVL nodes
+
+If you also need switch tree topology — for example to express the full fabric hierarchy for `topology/tree` scheduling — use the [InfiniBand](./infiniband.md) or [NetQ](./netq.md) provider instead.
+
+## How It Works
+
+The `nvidia.com/gpu.clique` labels are applied automatically by the GPU Operator's DRA driver — these are not manually configured by users.
+
+Topograph reads these labels from the Kubernetes API:
+
+1. Lists all nodes (filtered by `nodeSelector` if provided)
+2. For each node with a `nvidia.com/gpu.clique` label, reads the clique ID and groups nodes by domain
+3. Returns the NVLink domain map as block topology
+
+If no nodes with matching labels are found, Topograph returns a `502` error with a diagnostic message indicating which label and annotations to check.
+
+## Prerequisites
+
+- Kubernetes cluster with the NVIDIA GPU Operator deployed and DRA support enabled
+- Nodes must have `nvidia.com/gpu.clique` labels — applied automatically by the DRA driver
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `nodeSelector` | `map[string]string` | No | Label selector to filter which nodes participate in topology discovery |
+
+## Configuration
+
+No credentials are required. The provider uses the in-cluster service account automatically.
+
+Set `provider: dra` in your Topograph config:
+
+```yaml
+http:
+  port: 49021
+  ssl: false
+
+provider: dra
+engine: k8s
+```
+
+For Slinky (Slurm-on-Kubernetes) deployments:
+
+```yaml
+http:
+  port: 49021
+  ssl: false
+
+provider: dra
+engine: slinky
+```
+
+To filter participating nodes via `nodeSelector`, pass parameters in the topology request payload:
+
+```json
+{
+  "provider": {
+    "name": "dra",
+    "params": {
+      "nodeSelector": {
+        "nvidia.com/gpu.present": "true"
+      }
+    }
+  },
+  "engine": {
+    "name": "k8s"
+  }
+}
+```
+
+## Verifying the Output
+
+After triggering topology generation, inspect the node labels applied by Topograph:
+
+```bash
+kubectl get nodes -o json | jq '.items[].metadata.labels | with_entries(select(.key | startswith("network.topology.nvidia.com")))'
+```
+
+If topology generation returns a `502` error, check that the expected nodes have the `nvidia.com/gpu.clique` label:
+
+```bash
+kubectl get nodes -o json | jq '.items[].metadata.labels["nvidia.com/gpu.clique"]'
+```
+
+See the [Kubernetes engine documentation](../engines/k8s.md) for details on the label schema.

--- a/docs/providers/infiniband.md
+++ b/docs/providers/infiniband.md
@@ -1,0 +1,147 @@
+# InfiniBand Topology Provider
+
+Topograph provides two variations of InfiniBand provider. Both discover the IB fabric switch tree using `ibnetdiscover`, which is useful for any cluster — CPU-only, mixed, or GPU-accelerated — where topology-aware scheduling across an InfiniBand fabric improves workload performance. NVLink domain discovery is an additional capability that applies only to nodes with NVLink-connected NVIDIA GPUs.
+
+The choice of which to use depends on the specifics of the deployment environment:
+
+- Use **`infiniband-bm`** for bare-metal clusters (e.g. Slurm)
+- Use **`infiniband-k8s`** for Kubernetes clusters
+
+If **NetQ is deployed** in your environment, consider using the [NetQ provider](./netq.md) instead — it discovers topology via the NetQ management API rather than directly from the fabric, which avoids node access requirements and is the standard approach for Spectrum-X environments.
+
+For **Multi-Node NVLink (MNNVL) Kubernetes clusters** (e.g. GB200 NVL72), use the [DRA provider](./dra.md) instead — it reads `nvidia.com/gpu.clique` labels set by the GPU Operator's DRA driver and is the Kubernetes-native integration path for MNNVL topology.
+
+| | `infiniband-bm` | `infiniband-k8s` |
+|---|---|---|
+| **Auth** | None | In-cluster service account |
+| **Node access** | `pdsh` (SSH-based) | Kubernetes pod exec |
+| **NVLink clique source** | `nvidia-smi` via pdsh | Node annotations (set by node-data-broker) |
+| **Target environment** | Bare-metal / Slurm | Kubernetes |
+
+Both variants are presently single-region only (multi-region requests return a `400 Bad Request` error). No CSP credentials are required.
+
+## Output
+
+Both variants produce the same topology representation, and are in turn consumed by whichever engine you configure:
+
+- **Slurm engine** (`engine: slurm`) — writes a `topology.conf` file describing the switch tree, used by the Slurm topology plugin for topology-aware scheduling
+- **Kubernetes engine** (`engine: k8s`) — applies `network.topology.nvidia.com/` labels to nodes reflecting their position in the switch hierarchy and (where applicable) their NVLink domain
+- **Slinky engine** (`engine: slinky`) — writes topology data to a Kubernetes ConfigMap for Slurm-on-Kubernetes deployments
+
+See the [engine documentation](../engines/) for details on each output format.
+
+---
+
+## `infiniband-bm` (Bare-Metal)
+
+### Prerequisites
+
+- `pdsh` must be installed on the node running Topograph and able to reach at least one node per IB fabric segment — Topograph discovers the full fabric from a single entry point per segment, so every node does not need to be reachable via pdsh
+- `ibnetdiscover` must be available on cluster nodes (invoked via `pdsh` with `sudo`) — part of the standard `infiniband-diags` package (`dnf install infiniband-diags` / `apt install infiniband-diags`), expected to already be present on any properly configured IB system
+- NVIDIA GPU driver required on nodes with NVLink-connected GPUs — used to collect NVLink clique IDs via `nvidia-smi`. Nodes without NVLink are included in the IB switch tree but excluded from block topology.
+
+### How It Works
+
+1. Runs `sudo ibnetdiscover` via `pdsh` on one node per IB fabric segment to map the full switch tree
+2. On NVIDIA GPU nodes: runs `nvidia-smi -q | grep "ClusterUUID\|CliqueId" | sort -u` via `pdsh` across all nodes to collect NVLink clique IDs
+3. Combines the switch tree and any NVLink clique data into the topology graph
+
+### Configuration
+
+No credentials or parameters are required. Set `provider: infiniband-bm` in your Topograph config:
+
+```yaml
+http:
+  port: 49021
+  ssl: false
+
+provider: infiniband-bm
+engine: slurm
+```
+
+### Verifying the Output
+
+After triggering topology generation, query the result endpoint:
+
+```bash
+id=$(curl -s -X POST -H "Content-Type: application/json" -d @payload.json http://localhost:49021/v1/generate)
+curl -s "http://localhost:49021/v1/topology?uid=$id"
+```
+
+For the Slurm engine, verify the generated `topology.conf` reflects the expected switch hierarchy. See the [Slurm engine documentation](../engines/slurm.md) for details.
+
+---
+
+## `infiniband-k8s` (Kubernetes)
+
+### Prerequisites
+
+- Topograph deployed via Helm — the node-data-broker DaemonSet (a Topograph subchart, enabled by default) collects NVLink clique IDs from each node and stores them as Kubernetes node annotations (`topograph.nvidia.com/cluster-id`)
+- NVIDIA GPU Operator — standard on NVIDIA GPU Kubernetes clusters; manages the device plugin DaemonSet used to read NVLink clique IDs. Required only for NVLink domain discovery; on clusters without NVLink-connected GPUs this does not apply and the provider will still discover the IB switch tree.
+
+### How It Works
+
+1. Runs `ibnetdiscover` by exec-ing into a node-data-broker pod on each node to map the switch tree
+2. On NVIDIA GPU nodes: reads NVLink clique IDs from the `topograph.nvidia.com/cluster-id` node annotations set by the node-data-broker
+3. Combines the switch tree and any NVLink clique data into the topology graph
+
+### Configuration
+
+No credentials are required. The provider uses the in-cluster service account automatically.
+
+Set `provider: infiniband-k8s` in your Topograph config:
+
+```yaml
+http:
+  port: 49021
+  ssl: false
+
+provider: infiniband-k8s
+engine: k8s
+```
+
+### Parameters
+
+The following optional parameter can be passed in the topology request payload:
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `nodeSelector` | `map[string]string` | — | Label selector to filter which nodes participate in topology discovery |
+
+To override the GPU Operator namespace or device plugin DaemonSet name (defaults: `gpu-operator` and `nvidia-device-plugin-daemonset`), set these via `node-data-broker.initc.extraArgs` in your Helm values — they are init container arguments, not provider request parameters:
+
+```yaml
+node-data-broker:
+  initc:
+    extraArgs:
+      - gpu-operator-namespace=my-namespace
+      - device-plugin-daemonset=my-daemonset
+```
+
+Example request payload with `nodeSelector`:
+
+```json
+{
+  "provider": {
+    "name": "infiniband-k8s",
+    "params": {
+      "nodeSelector": {
+        "nvidia.com/gpu.present": "true"
+      }
+    }
+  },
+  "engine": {
+    "name": "k8s"
+  }
+}
+```
+
+### Verifying the Output
+
+After topology generation, inspect the node labels applied by Topograph:
+
+```bash
+kubectl get nodes -o json | jq '.items[].metadata.labels | with_entries(select(.key | startswith("network.topology.nvidia.com")))'
+```
+
+See the [Kubernetes engine documentation](../engines/k8s.md) for details on the label schema.

--- a/docs/providers/netq.md
+++ b/docs/providers/netq.md
@@ -1,0 +1,124 @@
+# NetQ Topology Provider
+
+[NVIDIA NetQ](https://docs.nvidia.com/networking-ethernet-software/cumulus-netq/) collects telemetry from Ethernet switches, DPUs, hosts, and NVLink fabrics, normalizes it, and streams it into a central analytics layer where metrics, events, and topology data are correlated in near real time. It exposes this processed data through a unified monitoring and operations platform supporting alerting, validation, and visibility for large-scale GPU and Ethernet/NVLink environments.
+
+The Topograph NetQ provider queries the NetQ API to extract fabric topology and NVLink domain data, translating it into the format expected by your workload manager. It builds both a switch tree (for Slurm `topology/tree` or Kubernetes labels) and an NVLink domain map (for `topology/block`).
+
+Topology discovery scope is determined by the NetQ server and the premises accessible to the configured account. No CSP credentials are required.
+
+## When to Use This Provider
+
+**Spectrum-X environments**: NetQ is the standard management plane for Spectrum-X and is the recommended provider — it has authoritative, real-time visibility into the fabric that `ibnetdiscover`-based approaches cannot provide.
+
+**Multi-node NVLink (MNNVL) environments**: NetQ includes NVLink Management (previously packaged as NMX-M), which provides native visibility into NVLink fabric topology, domain membership, and partitions at the infrastructure level. Note that for Kubernetes MNNVL scheduling, the [DRA provider](./dra.md) is the appropriate Topograph integration — it reads `nvidia.com/gpu.clique` labels set by the GPU Operator's DRA driver and feeds them directly to Kubernetes schedulers. NetQ and DRA operate at different layers and can coexist.
+
+**Traditional IB environments**: If NetQ is already deployed and managing your IB fabric, use this provider to leverage its existing topology data. If NetQ is not present, use the [InfiniBand provider](./infiniband.md) instead.
+
+| Scenario | Recommended Topograph provider |
+|---|---|
+| Spectrum-X fabric | NetQ |
+| MNNVL fabric, infrastructure visibility | NetQ |
+| MNNVL fabric, Kubernetes scheduling | [DRA](./dra.md) |
+| Traditional IB fabric, NetQ deployed | NetQ |
+| Traditional IB fabric, no NetQ | `infiniband-bm` or `infiniband-k8s` |
+
+## Output
+
+The NetQ provider produces the same topology representation as the InfiniBand providers, consumed by whichever engine you configure:
+
+- **Slurm engine** (`engine: slurm`) — writes a `topology.conf` file for Slurm topology-aware scheduling
+- **Kubernetes engine** (`engine: k8s`) — applies `network.topology.nvidia.com/` labels to nodes
+- **Slinky engine** (`engine: slinky`) — writes topology data to a Kubernetes ConfigMap
+
+See the [engine documentation](../engines/) for details on each output format.
+
+## Prerequisites
+
+- A running NetQ server accessible from the Topograph host
+- A NetQ account with access to at least one premises with topology data
+
+## Credentials
+
+| Field | Required | Description |
+|---|---|---|
+| `username` | Yes | NetQ account username |
+| `password` | Yes | NetQ account password |
+
+## Parameters
+
+| Field | Required | Description |
+|---|---|---|
+| `apiUrl` | Yes | Base URL of the NetQ server (e.g. `https://netq.example.com`) |
+
+## Configuration
+
+### Credentials via File
+
+Store credentials in a YAML file:
+
+```yaml
+username: <USERNAME>
+password: <PASSWORD>
+```
+
+Reference the file in your Topograph config:
+
+```yaml
+http:
+  port: 49021
+  ssl: false
+
+provider: netq
+engine: slurm
+
+credentialsPath: /path/to/credentials.yaml
+```
+
+### Credentials via API Request Payload
+
+Pass credentials directly in the topology request:
+
+```json
+{
+  "provider": {
+    "name": "netq",
+    "creds": {
+      "username": "<USERNAME>",
+      "password": "<PASSWORD>"
+    },
+    "params": {
+      "apiUrl": "https://netq.example.com"
+    }
+  },
+  "engine": {
+    "name": "slurm"
+  }
+}
+```
+
+## How It Works
+
+The provider makes two independent API calls and combines their results:
+
+**Switch tree (topology/tree):**
+1. Authenticates via `POST api/netq/auth/v1/login` to obtain an access token and list of premises
+2. For each premises with topology data, selects it via `GET api/netq/auth/v1/select/opid/{opid}`
+3. Fetches the fabric topology graph via `POST api/netq/telemetry/v1/object/topologygraph/fetch-topology`
+4. Parses the tier-based node and link graph into a switch tree; Clos topologies are reduced to a canonical tree representation
+
+**NVLink domains (topology/block):**
+1. Fetches compute node records via `GET nmx/v1/compute-nodes` using Basic auth — the `nmx` path reflects the NetQ NVLink Management API, previously known as NMX-M
+2. Groups nodes by `DomainUUID` to build the NVLink domain map
+
+NVLink domain discovery is best-effort — if it fails, Topograph logs a warning and returns the switch tree only. Multi-premises environments are supported: Topograph iterates over all accessible premises and merges their topology graphs.
+
+## Verifying the Output
+
+After triggering topology generation, query the result endpoint:
+
+```bash
+id=$(curl -s -X POST -H "Content-Type: application/json" -d @payload.json http://localhost:49021/v1/generate)
+curl -s "http://localhost:49021/v1/topology?uid=$id"
+```
+
+For the Slurm engine, verify the generated `topology.conf` reflects the expected switch hierarchy. See the [Slurm engine documentation](../engines/slurm.md) for details.


### PR DESCRIPTION
  ## Summary                                                                                                                                       
                                                                                                                                                   
  - Add `docs/providers/infiniband.md` covering both `infiniband-bm` (bare-metal/pdsh) and `infiniband-k8s` (Kubernetes pod exec) variants,        
  including prerequisites, configuration, parameters, and guidance on when to use each vs. NetQ and DRA                                            
  - Add `docs/providers/netq.md` covering the NetQ provider with credentials, parameters, Spectrum-X and MNNVL use cases, multi-premises support,  
  and the complementary relationship between NetQ (infrastructure visibility) and DRA (Kubernetes scheduling)                                      
  - Add `docs/providers/dra.md` covering the DRA provider: block topology only via `nvidia.com/gpu.clique` labels, ComputeDomains/MNNVL background,
   prerequisites, configuration, and troubleshooting                                                                                               
  - Update `README.md`: fix missing OCI link, split InfiniBand into bare-metal and Kubernetes entries, add links for NetQ and DRA, add a "Choosing 
  a Provider" scenario table                                                                                                                       
                                                                                                                                                   
  ## Test plan                                                                                                                                     
                                                                                                                                                   
  - [ ] Verify all internal doc cross-links resolve (infiniband ↔ netq ↔ dra ↔ README)                                                             
  - [ ] Verify Helm values examples (`node-data-broker.initc.extraArgs`) match `charts/topograph/charts/node-data-broker/values.yaml`              
  - [ ] Verify provider parameter tables match implementation (`pkg/providers/infiniband/`, `pkg/providers/netq/`, `pkg/providers/dra/`) 