### PR TITLE
chore: fix print_env.sh template placeholder and copyright year

### DIFF
--- a/print_env.sh
+++ b/print_env.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Copyright (c) 2023, NVIDIA CORPORATION.
 # Reports relevant environment information useful for diagnosing and
-# debugging __PROJECT__ issues.
+# debugging Topograph issues.
 # Usage:
 # "./print_env.sh" - prints to stdout
 # "./print_env.sh > env.txt" - prints to file "env.txt"

--- a/print_env.sh
+++ b/print_env.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2026, NVIDIA CORPORATION.
 # Reports relevant environment information useful for diagnosing and
 # debugging Topograph issues.
 # Usage:


### PR DESCRIPTION
## Summary

Two small cleanups to `print_env.sh`, which was added in #244:

- Replace the uncustomized `__PROJECT__` template placeholder with `Topograph` on line 4 (usage header)
- Bump stale `Copyright (c) 2023` to `2026` on line 2

## Test plan

- [x] `bash -n print_env.sh` parses clean
- [x] `./print_env.sh | head` renders the updated header correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)