### PR TITLE
docs: document gpu.clique relationship and non-MNNVL topology source

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,35 +56,6 @@ The Engine translates this internal representation into the format expected by t
 - The Provider receives notifications and invokes CSP API to retrieve topology-related information.
 - The Engine converts the topology information into the format expected by the user cluster (e.g., SLURM or Kubernetes).
 
-## How Topograph Fits in the Kubernetes Topology Stack
-
-Kubernetes uses the word "topology" in several distinct contexts. Topograph occupies the inter-node layer:
-
-| | Topograph | [kubelet Topology Manager](https://kubernetes.io/docs/tasks/administer-cluster/topology-manager/) |
-|---|---|---|
-| **Scope** | Inter-node (cluster-wide) | Intra-node (single node) |
-| **What it does** | Discovers the physical network fabric (NVLink domains, switch hierarchy) and publishes it as node labels | Aligns CPU, GPU, and NIC allocations to the same NUMA domain within a node to reduce memory access latency |
-| **Consumed by** | Topology-aware schedulers (KAI Scheduler, Kueue TAS) making multi-node placement decisions | The kubelet itself, when binding a Pod's containers to hardware resources |
-
-The two are complementary and can be active simultaneously. Topology Manager optimizes resource allocation *within* a node; Topograph informs the scheduler about *which nodes* belong together on the network.
-
-```mermaid
-graph TB
-    subgraph topo_scope["Topograph — inter-node scope"]
-        fabric["Physical Network Fabric\n(NVLink domains · IB/Ethernet switches)"]
-        topograph["Topograph\n(queries CSP/fabric APIs)"]
-        labels["Kubernetes Node Labels\n(network.topology.nvidia.com/*)"]
-        scheduler["Topology-Aware Scheduler\n(KAI Scheduler · Kueue TAS)"]
-        fabric --> topograph --> labels --> scheduler
-    end
-
-    subgraph kubelet_scope["kubelet — intra-node scope"]
-        tm["Topology Manager\n(NUMA alignment within a node)"]
-    end
-
-    scheduler -. "schedules Pods onto nodes;\nTopology Manager handles\nresource alignment inside each node" .-> tm
-```
-
 ## Configuration
 
 Topograph accepts its configuration file path using the `-c` command-line parameter. The configuration file is a YAML document. A sample configuration file is located at [config/topograph-config.yaml](config/topograph-config.yaml).

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ Currently supported engines:
 
 For MNNVL environments, NetQ and DRA operate at different layers and can coexist: NetQ provides infrastructure-level visibility into the NVLink fabric while DRA feeds topology directly to Kubernetes schedulers via `nvidia.com/gpu.clique` node labels.
 
+For non-MNNVL GPU clusters (such as DGX B200 or B300 SuperPODs), `nvidia.com/gpu.clique` is not set — Topograph with an InfiniBand provider is the only source of network topology for scheduling decisions on these systems.
+
 ## Using Topograph
 
 Topograph offers three endpoints for interacting with the service. Below are the details of each endpoint:

--- a/README.md
+++ b/README.md
@@ -56,6 +56,35 @@ The Engine translates this internal representation into the format expected by t
 - The Provider receives notifications and invokes CSP API to retrieve topology-related information.
 - The Engine converts the topology information into the format expected by the user cluster (e.g., SLURM or Kubernetes).
 
+## How Topograph Fits in the Kubernetes Topology Stack
+
+Kubernetes uses the word "topology" in several distinct contexts. Topograph occupies the inter-node layer:
+
+| | Topograph | [kubelet Topology Manager](https://kubernetes.io/docs/tasks/administer-cluster/topology-manager/) |
+|---|---|---|
+| **Scope** | Inter-node (cluster-wide) | Intra-node (single node) |
+| **What it does** | Discovers the physical network fabric (NVLink domains, switch hierarchy) and publishes it as node labels | Aligns CPU, GPU, and NIC allocations to the same NUMA domain within a node to reduce memory access latency |
+| **Consumed by** | Topology-aware schedulers (KAI Scheduler, Kueue TAS) making multi-node placement decisions | The kubelet itself, when binding a Pod's containers to hardware resources |
+
+The two are complementary and can be active simultaneously. Topology Manager optimizes resource allocation *within* a node; Topograph informs the scheduler about *which nodes* belong together on the network.
+
+```mermaid
+graph TB
+    subgraph topo_scope["Topograph — inter-node scope"]
+        fabric["Physical Network Fabric\n(NVLink domains · IB/Ethernet switches)"]
+        topograph["Topograph\n(queries CSP/fabric APIs)"]
+        labels["Kubernetes Node Labels\n(network.topology.nvidia.com/*)"]
+        scheduler["Topology-Aware Scheduler\n(KAI Scheduler · Kueue TAS)"]
+        fabric --> topograph --> labels --> scheduler
+    end
+
+    subgraph kubelet_scope["kubelet — intra-node scope"]
+        tm["Topology Manager\n(NUMA alignment within a node)"]
+    end
+
+    scheduler -. "schedules Pods onto nodes;\nTopology Manager handles\nresource alignment inside each node" .-> tm
+```
+
 ## Configuration
 
 Topograph accepts its configuration file path using the `-c` command-line parameter. The configuration file is a YAML document. A sample configuration file is located at [config/topograph-config.yaml](config/topograph-config.yaml).

--- a/docs/engines/k8s.md
+++ b/docs/engines/k8s.md
@@ -53,6 +53,17 @@ graph TB
     scheduler -. "schedules Pods onto nodes;\nTopology Manager handles\nresource alignment inside each node" .-> tm
 ```
 
+### Relationship to `nvidia.com/gpu.clique`
+
+The GPU Operator device plugin sets `nvidia.com/gpu.clique` on nodes with Multi-Node NVLink (MNNVL) GPUs (e.g., GB200 NVL72). This label identifies the NVLink clique a node belongs to and can be used as a topology key for Pod placement.
+
+Topograph's `network.topology.nvidia.com/accelerator` label and `nvidia.com/gpu.clique` are complementary:
+
+- On **MNNVL systems**: the InfiniBand provider's `accelerator` value is derived from the same `ClusterUUID.CliqueId` hardware identifiers as `gpu.clique`. The two labels carry the same value and can be correlated.
+- On **non-MNNVL systems** (e.g., DGX B200, B300): `nvidia.com/gpu.clique` is not set — the device plugin requires the GPU fabric to reach `GPU_FABRIC_STATE_COMPLETED`, which non-MNNVL GPUs do not reach. Topograph with an InfiniBand provider is the only source of network topology labels on these clusters.
+
+In addition to NVLink domain membership, Topograph provides the IB switch hierarchy (`leaf`, `spine`, `core`) — giving schedulers both dimensions of topology simultaneously.
+
 ## Use of Topograph
 
 While there is currently no fully network-aware scheduler capable of optimally placing groups of pods based on network considerations, Topograph serves as a stepping stone toward developing such a scheduler.
@@ -99,6 +110,10 @@ Since the default Kubernetes scheduler places one pod at a time, the placement m
 the first pod is placed. As a result, each scheduling decision might not be globally optimal.
 However, by aligning pod placement with network-aware labels, we can significantly improve inter-pod
 communication efficiency within the limitations of the scheduler.
+
+### Mixed Workload Considerations
+
+Topology labels are most valuable when nodes in a topology domain are available for topology-sensitive workloads together. Mixed clusters running both distributed training and topology-insensitive workloads (single-GPU inference, CPU services) present a scheduling challenge: topology-insensitive Pods will consume nodes that could otherwise form complete leaf-switch groups or NVLink domains, forcing training jobs to communicate across additional hops. Schedulers that honor topology labels — such as [KAI Scheduler](https://github.com/NVIDIA/KAI-Scheduler) and Kueue with Topology-Aware Scheduling — can minimize this fragmentation, but only when topology information is available. Topograph's labels are a prerequisite for making these decisions.
 
 ## Configuration
 Topograph is deployed as a standard Kubernetes application using a [Helm chart](https://github.com/NVIDIA/topograph/tree/main/charts/topograph).

--- a/docs/providers/infiniband.md
+++ b/docs/providers/infiniband.md
@@ -43,7 +43,7 @@ See the [engine documentation](../engines/) for details on each output format.
 ### How It Works
 
 1. Runs `sudo ibnetdiscover` via `pdsh` on one node per IB fabric segment to map the full switch tree
-2. On NVIDIA GPU nodes: runs `nvidia-smi -q | grep "ClusterUUID\|CliqueId" | sort -u` via `pdsh` across all nodes to collect NVLink clique IDs
+2. On NVIDIA GPU nodes: runs `nvidia-smi -q | grep "ClusterUUID\|CliqueId" | sort -u` via `pdsh` across all nodes to collect NVLink clique IDs. The resulting `accelerator` label value is `ClusterUUID.CliqueId` — the same format as `nvidia.com/gpu.clique` set by the GPU Operator device plugin on MNNVL systems.
 3. Combines the switch tree and any NVLink clique data into the topology graph
 
 ### Configuration
@@ -82,7 +82,7 @@ For the Slurm engine, verify the generated `topology.conf` reflects the expected
 ### How It Works
 
 1. Runs `ibnetdiscover` by exec-ing into a node-data-broker pod on each node to map the switch tree
-2. On NVIDIA GPU nodes: reads NVLink clique IDs from the `topograph.nvidia.com/cluster-id` node annotations set by the node-data-broker
+2. On NVIDIA GPU nodes: reads NVLink clique IDs from the `topograph.nvidia.com/cluster-id` node annotations set by the node-data-broker. The resulting `accelerator` label value is `ClusterUUID.CliqueId` — the same format as `nvidia.com/gpu.clique` set by the GPU Operator device plugin on MNNVL systems.
 3. Combines the switch tree and any NVLink clique data into the topology graph
 
 ### Configuration

--- a/docs/providers/netq.md
+++ b/docs/providers/netq.md
@@ -108,7 +108,7 @@ The provider makes two independent API calls and combines their results:
 
 **NVLink domains (topology/block):**
 1. Fetches compute node records via `GET nmx/v1/compute-nodes` using Basic auth — the `nmx` path reflects the NetQ NVLink Management API, previously known as NMX-M
-2. Groups nodes by `DomainUUID` to build the NVLink domain map
+2. Groups nodes by `DomainUUID` to build the NVLink domain map. The `DomainUUID` is a NetQ/NMX identifier and differs in format from the `ClusterUUID.CliqueId` value used by `nvidia.com/gpu.clique` and the InfiniBand provider — both identify the same physical NVLink domain, but the values are not directly comparable as strings.
 
 NVLink domain discovery is best-effort — if it fails, Topograph logs a warning and returns the switch tree only. Multi-premises environments are supported: Topograph iterates over all accessible premises and merges their topology graphs.
 


### PR DESCRIPTION
## Summary

Adds technical context clarifying how Topograph's network topology labels relate to `nvidia.com/gpu.clique` (set by the GPU Operator device plugin) and why Topograph is often the **only** source of topology on non-MNNVL GPU clusters (DGX B200/B300).

## Changes

- **`docs/engines/k8s.md`** — new subsections:
  - *Relationship to `nvidia.com/gpu.clique`* — explains that the InfiniBand provider's `accelerator` label value is derived from the same `ClusterUUID.CliqueId` hardware identifiers used by `gpu.clique` on MNNVL systems (correlatable). On non-MNNVL systems `gpu.clique` is absent because the IMEX labeler requires `GPU_FABRIC_STATE_COMPLETED`, which non-MNNVL GPUs do not reach.
  - *Mixed Workload Considerations* — describes how topology-insensitive workloads (single-GPU inference, CPU services) fragment available NVLink/leaf-switch groups, and that topology labels are a prerequisite for schedulers like KAI Scheduler or Kueue TAS to mitigate this.
- **`docs/providers/infiniband.md`** — notes that the `accelerator` value format matches `gpu.clique` in both `infiniband-bm` and `infiniband-k8s` variants.
- **`docs/providers/netq.md`** — notes that NMX `DomainUUID` is a distinct identifier from `gpu.clique`'s `ClusterUUID.CliqueId`; the values are not directly comparable.
- **`README.md`** — adds a brief note that on non-MNNVL GPU clusters (DGX B200/B300 SuperPODs), `gpu.clique` is not set and Topograph with an InfiniBand provider is the only topology source.

## Why this matters

For operators evaluating Topograph: it clarifies when Topograph is essential vs. when it complements existing signals. For developers: it documents a non-obvious invariant about where identifier formats match across providers vs. diverge.

## Test plan

- [x] `gpu.clique` value format verified against `NVIDIA/k8s-device-plugin/internal/lm/imex.go` (IMEX labeler)
- [x] `IsFabricAttached()` behavior verified against `NVIDIA/go-nvlib/pkg/nvlib/device/device.go`
- [x] IB provider value format verified against `pkg/providers/infiniband/common.go` and `bm.go` (`Cluster.ID()` returns `UUID + "." + cliqueID`)
- [x] NetQ provider value format verified against `pkg/providers/netq/nmx.go` (`DomainUUID` source)