### PR TITLE
build: add make qualify pre-push aggregator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,10 @@ vet:
 lint:
 	$(LINTER_BIN) run --new-from-rev "HEAD~$(git rev-list master.. --count)" ./...
 
+.PHONY: qualify
+qualify: fmt vet lint test
+	@echo "All quality checks passed."
+
 .PHONY: mod
 mod:
 	go mod tidy


### PR DESCRIPTION
## Summary

Adds a `qualify` target to the Makefile that runs the full local quality check battery in sequence: `fmt`, `vet`, `lint`, `test`.

```makefile
.PHONY: qualify
qualify: fmt vet lint test
	@echo "All quality checks passed."
```

## Why

Reduces the pre-push ceremony from four separate commands to one. Makes AGENTS.md and CONTRIBUTING.md able to cite a single canonical pre-push command. Matches the convention already established in other NVIDIA OSS repos (e.g., AICR).

No new checks are introduced — this is purely a convenience aggregator over existing targets.

## Test plan

- [x] `make -n qualify` dry-runs the expected sequence (fmt → vet → lint → test → success echo)
- [x] All four constituent targets already exist and pass in CI on main