### PR TITLE
docs(fern): add fern/README.md describing the Fern docs workflow

### DIFF
--- a/fern/README.md
+++ b/fern/README.md
@@ -1,0 +1,38 @@
+# Topograph Fern Docs
+
+This directory contains the [Fern](https://buildwithfern.com) configuration for Topograph documentation. The deployed site lives at <https://topograph.docs.buildwithfern.com/topograph>.
+
+The `docs/` directory on `main` is the **source of truth**. This `fern/` directory holds site config and theme assets only — never doc content.
+
+## Local preview
+
+```bash
+npm install -g fern-api@4.42.1
+fern check
+HOST=0.0.0.0 fern docs dev   # bind to host IP for remote access
+# navigate to http://<host>:3000/topograph/dev
+```
+
+All authoring happens in `docs/`; update `docs/index.yml` to add or move pages in the sidebar.
+
+## CI workflows
+
+| Workflow | Trigger | Purpose |
+|---|---|---|
+| `fern-docs-ci.yml` | PR touching `docs/**` or `fern/**` | `fern check` + broken-links validation |
+| `fern-docs-preview-build.yml` | PR touching `docs/**` or `fern/**` | Collects sources as artifact (no secrets) |
+| `fern-docs-preview-comment.yml` | After preview build completes | Generates preview URL and posts PR comment |
+| `publish-fern-docs.yml` | `docs/v*` tag push or manual dispatch | Publishes to production |
+
+Preview and publish workflows require `DOCS_FERN_TOKEN` — a repo secret provisioned by the docs infrastructure team for this project.
+
+## Publishing
+
+Push a `docs/v*` tag to trigger a publish:
+
+```bash
+git tag docs/v1.0.0
+git push origin docs/v1.0.0
+```
+
+Or trigger manually from the **Actions** tab → **Publish Fern Docs** → **Run workflow**.


### PR DESCRIPTION
## Summary

Adds a `fern/README.md` that describes how to work with the Fern documentation scaffolding introduced in #249. Ports the Fern workflow guide that already exists in [NVIDIA/NVSentinel's `fern/README.md`](https://github.com/NVIDIA/NVSentinel/blob/main/fern/README.md), substituting `topograph` for `nvsentinel` in paths and preview URLs.

## What it covers

- **Source-of-truth rule** — `docs/` on `main` is authoritative; `fern/` holds site config and theme assets only (never doc content)
- **Local preview** — exact commands to install `fern-api@4.42.1`, run `fern check`, and spin up `fern docs dev` with the correct `/topograph/dev` preview path
- **CI workflows table** — describes `fern-docs-ci.yml`, `fern-docs-preview-build.yml`, `fern-docs-preview-comment.yml`, and `publish-fern-docs.yml`: trigger + purpose of each
- **Secret requirement** — `DOCS_FERN_TOKEN` (matches what `publish-fern-docs.yml` already references)
- **Publishing trigger** — push a `docs/v*` tag or dispatch the workflow manually

## Why

The Fern setup landed in #249 but the operational knowledge (how to preview locally, when each workflow fires, where content goes vs. theme goes, how to publish) hasn't been documented in the repo. Anyone wanting to work with the docs right now has to read the workflow YAMLs or ask the original author.

NVSentinel already has this document and works on the same Fern + GitHub Actions pattern, so the content ports cleanly with minimal substitution.

## Test plan

- [x] All workflow filenames verified against `.github/workflows/fern-*.yml`
- [x] `DOCS_FERN_TOKEN` secret name verified against `publish-fern-docs.yml`
- [x] `docs/v*` tag trigger verified against `publish-fern-docs.yml` (already present)
- [x] `fern-api@4.42.1` version matches `fern/fern.config.json`
- [x] `/topograph/dev` preview path derived from `fern/docs.yml` `instances.url` entry (`topograph.docs.buildwithfern.com/topograph`)
- [x] Deployed site URL verified reachable at <https://topograph.docs.buildwithfern.com/topograph>
- [x] Markdown renders cleanly in GitHub preview

## Related

- #249 — original Fern scaffolding PR
- NVIDIA/NVSentinel `fern/README.md` — template this is ported from