### PR TITLE
docs(governance): add CODE_OF_CONDUCT, SECURITY, and pull request template

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -228,6 +228,10 @@ git config --global commit.gpgsign true
 
 Signed commits get a **Verified** badge on GitHub. The GPG public key must be uploaded to your GitHub account.
 
+### Potential security issues
+
+If you discover what appears to be a security vulnerability while working in this codebase — unauthenticated code path, exposed credential, injection vulnerability, privilege-escalation path, dependency with a known CVE, or similar — do **not** file a public GitHub issue or include it in a public PR description. Surface it privately to the maintainer, who can route it through the NVIDIA PSIRT channels documented in `SECURITY.md` (`psirt@nvidia.com` and the submission form; not GitHub).
+
 ### Documentation Impact Evaluation
 
 Every PR should be evaluated for documentation impact before pre-push qualification. The following changes imply specific doc updates in the same PR:
@@ -245,6 +249,8 @@ Every PR should be evaluated for documentation impact before pre-push qualificat
 If a change falls outside these categories, it still warrants a moment's review for collateral doc drift.
 
 ### Pre-push checklist
+
+When filing a PR (`gh pr create` or the GitHub UI), `.github/PULL_REQUEST_TEMPLATE.md` auto-populates the body with a Description section and a Checklist. Fill in the Description and tick the checklist items as completed — do not delete or replace the template wholesale.
 
 - [ ] `make qualify` passes (runs fmt, vet, lint, test)
 - [ ] New or changed public behavior is covered by a test

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+## Description
+<!-- Provide a standalone description of changes in this PR. -->
+<!-- Reference any issues closed by this PR with "closes #1234". -->
+
+## Checklist
+- [ ] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
+- [ ] New or existing tests cover these changes.
+- [ ] The documentation is up to date with these changes.
+- [ ] All commits are signed off per DCO (`git commit -s`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,6 +228,10 @@ git config --global commit.gpgsign true
 
 Signed commits get a **Verified** badge on GitHub. The GPG public key must be uploaded to your GitHub account.
 
+### Potential security issues
+
+If you discover what appears to be a security vulnerability while working in this codebase — unauthenticated code path, exposed credential, injection vulnerability, privilege-escalation path, dependency with a known CVE, or similar — do **not** file a public GitHub issue or include it in a public PR description. Surface it privately to the maintainer, who can route it through the NVIDIA PSIRT channels documented in `SECURITY.md` (`psirt@nvidia.com` and the submission form; not GitHub).
+
 ### Documentation Impact Evaluation
 
 Every PR should be evaluated for documentation impact before pre-push qualification. The following changes imply specific doc updates in the same PR:
@@ -245,6 +249,8 @@ Every PR should be evaluated for documentation impact before pre-push qualificat
 If a change falls outside these categories, it still warrants a moment's review for collateral doc drift.
 
 ### Pre-push checklist
+
+When filing a PR (`gh pr create` or the GitHub UI), `.github/PULL_REQUEST_TEMPLATE.md` auto-populates the body with a Description section and a Checklist. Fill in the Description and tick the checklist items as completed — do not delete or replace the template wholesale.
 
 - [ ] `make qualify` passes (runs fmt, vet, lint, test)
 - [ ] New or changed public behavior is covered by a test

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -67,7 +67,7 @@ reported by contacting GitHub_Conduct@nvidia.com. All complaints will be reviewe
 investigated and will result in a response that is deemed necessary and appropriate
 to the circumstances. The project team is obligated to maintain confidentiality with
 regard to the reporter of an incident. Further details of specific enforcement policies
-may be posted separately. 
+may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,84 @@
+# Contributor Covenant Code of Conduct
+
+## Overview
+
+Define the code of conduct followed and enforced for __Topograph__.
+
+### Intended audience
+
+Community | Developers | Project Leads
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting GitHub_Conduct@nvidia.com. All complaints will be reviewed and
+investigated and will result in a response that is deemed necessary and appropriate
+to the circumstances. The project team is obligated to maintain confidentiality with
+regard to the reporter of an incident. Further details of specific enforcement policies
+may be posted separately. 
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+## Security
+
+NVIDIA is dedicated to the security and trust of our software products and services, including all source code repositories managed through our organization.
+
+If you need to report a security issue, please use the appropriate contact points outlined below. **Please do not report security vulnerabilities through GitHub.** If a potential security issue is inadvertently reported via a public issue or pull request, NVIDIA maintainers may limit public discussion and redirect the reporter to the appropriate private disclosure channels.
+
+## Reporting Potential Security Vulnerability in an NVIDIA Product
+
+To report a potential security vulnerability in any NVIDIA product:
+- Web: [Security Vulnerability Submission Form](https://www.nvidia.com/object/submit-security-vulnerability.html)
+- E-Mail: psirt@nvidia.com
+    - We encourage you to use the following PGP key for secure email communication: [NVIDIA public PGP Key for communication](https://www.nvidia.com/en-us/security/pgp-key)
+    - Please include the following information:
+   	 - Product/Driver name and version/branch that contains the vulnerability
+     - Type of vulnerability (code execution, denial of service, buffer overflow, etc.)
+   	 - Instructions to reproduce the vulnerability
+   	 - Proof-of-concept or exploit code
+   	 - Potential impact of the vulnerability, including how an attacker could exploit the vulnerability
+
+While NVIDIA currently does not have a bug bounty program, we do offer acknowledgement when an externally reported security issue is addressed under our coordinated vulnerability disclosure policy. Please visit our [Product Security Incident Response Team (PSIRT)](https://www.nvidia.com/en-us/security/psirt-policies/) policies page for more information.
+
+## NVIDIA Product Security
+
+For all security-related concerns, please visit NVIDIA's Product Security portal at https://www.nvidia.com/en-us/security


### PR DESCRIPTION
Closes #272.

Adds three standard NVIDIA OSS governance artifacts:

- **`CODE_OF_CONDUCT.md`** — Contributor Covenant v1.4 with NVIDIA governance wrapper; enforcement contact `GitHub_Conduct@nvidia.com`. Content matches comparable projects such as [NVIDIA/aicr](https://github.com/NVIDIA/aicr/blob/main/CODE_OF_CONDUCT.md) and [NVIDIA/NVSentinel](https://github.com/NVIDIA/NVSentinel/blob/main/CODE_OF_CONDUCT.md), with the project name substituted for Topograph.
- **`SECURITY.md`** — standard NVIDIA PSIRT reporting guidance ([submission form](https://www.nvidia.com/object/submit-security-vulnerability.html), `psirt@nvidia.com`, [PGP key](https://www.nvidia.com/en-us/security/pgp-key), [PSIRT policies](https://www.nvidia.com/en-us/security/psirt-policies/)). Explicitly redirects security reports away from public GitHub issues.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — minimal Description + Checklist covering tests, documentation, DCO sign-off, and familiarity with `CONTRIBUTING.md`. The DCO checklist item is topograph-specific — every commit requires `Signed-off-by:` and there is no org-member exemption.

## AGENTS.md / CLAUDE.md

Both files receive two small additions under §5 Pull Request Guidelines, since two of the three governance artifacts shape agent behavior directly:

- New **"Potential security issues"** subsection directs security findings away from public GitHub issues toward the NVIDIA PSIRT channels documented in the new `SECURITY.md`.
- New note in the pre-push checklist reminding contributors to fill in the new `.github/PULL_REQUEST_TEMPLATE.md` rather than replacing it wholesale.

Bodies remain byte-identical between `AGENTS.md` and `.claude/CLAUDE.md` from line 6 onward (verified via `cmp <(tail -n +6 .claude/CLAUDE.md) <(tail -n +6 AGENTS.md)`).

## Test plan

- [x] `CODE_OF_CONDUCT.md` renders cleanly; project name resolves as **Topograph**
- [x] `SECURITY.md` external links all resolve
- [x] `.github/PULL_REQUEST_TEMPLATE.md` auto-populates on this PR (visible in the description above)
- [x] AGENTS.md / CLAUDE.md bodies byte-identical from line 6 onward