### PR TITLE
chore(chart): add values schema, helm test hooks, and chart README

### DIFF
--- a/charts/topograph/README.md
+++ b/charts/topograph/README.md
@@ -1,0 +1,103 @@
+# topograph
+
+A Helm chart for deploying [topograph](https://github.com/NVIDIA/topograph) on Kubernetes.
+
+Topograph discovers the physical network topology of a cluster (NVLink domains, InfiniBand / Ethernet switch fabric, cloud rack topology) and exposes it to workload schedulers — Slurm, Kubernetes, and Slurm-on-Kubernetes (Slinky) — by applying node labels and/or writing scheduler-specific topology configuration.
+
+## Prerequisites
+
+- **Helm**: 3.8+ or 4.x. The chart has been verified against Helm 3.20.0 and Helm 4.1.4, with byte-identical `helm template` output under both.
+- **Kubernetes**: no hard floor is declared by this chart; the rendered manifests use only `apps/v1`, `rbac.authorization.k8s.io/v1`, and `v1`, all stable since Kubernetes 1.9.
+- **Provider-specific prerequisites** vary (CSP credentials, node labels, local binaries like `ibnetdiscover`, etc.). See `docs/providers/<name>.md` in the main repository for each provider's setup.
+
+## Installation
+
+From the OCI registry (recommended):
+
+```bash
+helm install topograph \
+  oci://ghcr.io/nvidia/topograph/topograph \
+  --version <chart-version> \
+  --namespace topograph --create-namespace
+```
+
+From a local source checkout:
+
+```bash
+helm install topograph charts/topograph \
+  --namespace topograph --create-namespace
+```
+
+To see available chart versions:
+
+```bash
+helm show chart oci://ghcr.io/nvidia/topograph/topograph
+```
+
+## Configuration
+
+The default `values.yaml` ships the `test` provider + `k8s` engine, suitable for a smoke-test install. Production installs select a real provider:
+
+```yaml
+global:
+  provider:
+    name: dra        # or aws, gcp, oci, nebius, netq, infiniband-k8s, ...
+  engine:
+    name: k8s        # or slurm, slinky
+```
+
+For the full list of values and their defaults, see [`values.yaml`](./values.yaml). Example values files for specific deployment patterns:
+
+- [`values.k8s-ib-example.yaml`](./values.k8s-ib-example.yaml) — InfiniBand provider on Kubernetes
+- [`values.k8s-gcp-service-account-example.yaml`](./values.k8s-gcp-service-account-example.yaml) — GCP provider with a service account key mounted from a Secret
+- [`values.k8s-gcp-federated-workload-identity-example.yaml`](./values.k8s-gcp-federated-workload-identity-example.yaml) — GCP provider using Workload Identity Federation
+- [`values-slinky-tree-example.yaml`](./values-slinky-tree-example.yaml), [`values-slinky-block-example.yaml`](./values-slinky-block-example.yaml), [`values-slinky-partition-example.yaml`](./values-slinky-partition-example.yaml) — Slinky engine variants
+
+### Values validation
+
+The chart ships a [`values.schema.json`](./values.schema.json) that validates the most error-prone fields at install time — the `global.provider.name` and `global.engine.name` enums, type and range constraints on `replicaCount`, `image.pullPolicy`, `service.type`, `service.port`, and `verbosity`, and the expected shapes of `ingress`, `serviceMonitor`, and related nested objects. Invalid values are rejected by `helm install` and `helm template` with a clear schema-validation error.
+
+The schema is deliberately narrow: per-provider credential requirements (which fields a given provider needs in its credentials map) are documented in prose in `docs/providers/<name>.md` rather than enforced in the schema, because the credential field sets evolve with upstream provider changes and are hard to keep accurate in a schema.
+
+## Testing
+
+Once installed, verify the deployment is functional with `helm test`:
+
+```bash
+helm test topograph --namespace topograph
+```
+
+The chart ships two `helm test` hook pods:
+
+- **`test-healthz`** — probes the Topograph API's `/healthz` endpoint via the in-cluster Service and expects HTTP 200
+- **`test-metrics`** — probes `/metrics`, expects HTTP 200 plus the `topograph_version` Prometheus metric in the response body (sanity check that the Prometheus registry is wired up)
+
+Both test pods are removed automatically on success (`helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded`). On failure the pod persists so operators can inspect logs; the next `helm test` invocation replaces it.
+
+### Air-gapped environments
+
+By default, the test pods reuse the main topograph image. Topograph's default image is Alpine-based and ships with busybox `wget`, which the test probes use — so `helm test` works without pulling any additional image, including in air-gapped environments where only mirrored images are reachable.
+
+If you run a topograph image variant without busybox `wget` (for example, the IB variant built on `ubuntu`), override the test image to point at one that does, via `tests.image.repository` and `tests.image.tag`. You can also disable the tests entirely with `tests.enabled=false`.
+
+## Subcharts
+
+The chart depends on two subcharts, both managed as local file dependencies:
+
+- **`node-data-broker`** — DaemonSet that collects per-node attributes (NVLink clique IDs, etc.) as node annotations for the Kubernetes engine
+- **`node-observer`** — watches node status changes and triggers topology regeneration
+
+Both are installed together when you install this chart. Their values are accessible under the top-level keys `node-data-broker` and `node-observer` (enabled by default).
+
+## References
+
+- **Project documentation site**: <https://topograph.docs.buildwithfern.com/topograph>
+- **Main repository**: <https://github.com/NVIDIA/topograph>
+- **Provider-specific setup**: `docs/providers/` in the main repository
+- **Engine documentation**: `docs/engines/k8s.md`, `docs/engines/slinky.md`, `docs/engines/slurm.md`
+- **Node-labels reference**: `docs/reference/node-labels.md`
+- **Contributing**: see [`CONTRIBUTING.md`](https://github.com/NVIDIA/topograph/blob/main/CONTRIBUTING.md) in the main repository
+
+## License
+
+Apache License 2.0. See [`LICENSE`](https://github.com/NVIDIA/topograph/blob/main/LICENSE) in the main repository.

--- a/charts/topograph/templates/tests/test-healthz.yaml
+++ b/charts/topograph/templates/tests/test-healthz.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.tests.enabled }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "topograph.fullname" . }}-test-healthz"
+  labels:
+    {{- include "topograph.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  {{- with .Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  containers:
+    - name: healthz
+      image: "{{ .Values.tests.image.repository | default .Values.image.repository }}:{{ .Values.tests.image.tag | default .Values.image.tag }}"
+      imagePullPolicy: {{ .Values.image.pullPolicy }}
+      command: ["sh", "-c"]
+      args:
+        - |
+          set -eu
+          wget -q -O /dev/null -T 10 \
+            "http://{{ include "topograph.fullname" . }}:{{ .Values.global.service.port }}/healthz"
+{{- end }}

--- a/charts/topograph/templates/tests/test-healthz.yaml
+++ b/charts/topograph/templates/tests/test-healthz.yaml
@@ -14,8 +14,12 @@ spec:
   imagePullSecrets:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  securityContext:
+    {{- toYaml .Values.podSecurityContext | nindent 4 }}
   containers:
     - name: healthz
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
       image: "{{ .Values.tests.image.repository | default .Values.image.repository }}:{{ .Values.tests.image.tag | default .Values.image.tag }}"
       imagePullPolicy: {{ .Values.image.pullPolicy }}
       command: ["sh", "-c"]

--- a/charts/topograph/templates/tests/test-metrics.yaml
+++ b/charts/topograph/templates/tests/test-metrics.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.tests.enabled }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "topograph.fullname" . }}-test-metrics"
+  labels:
+    {{- include "topograph.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  {{- with .Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  containers:
+    - name: metrics
+      image: "{{ .Values.tests.image.repository | default .Values.image.repository }}:{{ .Values.tests.image.tag | default .Values.image.tag }}"
+      imagePullPolicy: {{ .Values.image.pullPolicy }}
+      command: ["sh", "-c"]
+      args:
+        - |
+          set -eu
+          body=$(wget -q -O - -T 10 \
+            "http://{{ include "topograph.fullname" . }}:{{ .Values.global.service.port }}/metrics")
+          echo "$body" | grep -q '^topograph_version'
+{{- end }}

--- a/charts/topograph/templates/tests/test-metrics.yaml
+++ b/charts/topograph/templates/tests/test-metrics.yaml
@@ -14,8 +14,12 @@ spec:
   imagePullSecrets:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  securityContext:
+    {{- toYaml .Values.podSecurityContext | nindent 4 }}
   containers:
     - name: metrics
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
       image: "{{ .Values.tests.image.repository | default .Values.image.repository }}:{{ .Values.tests.image.tag | default .Values.image.tag }}"
       imagePullPolicy: {{ .Values.image.pullPolicy }}
       command: ["sh", "-c"]

--- a/charts/topograph/values.schema.json
+++ b/charts/topograph/values.schema.json
@@ -60,7 +60,8 @@
             }
           }
         }
-      }
+      },
+      "required": ["provider", "engine"]
     },
     "replicaCount": {
       "type": "integer",

--- a/charts/topograph/values.schema.json
+++ b/charts/topograph/values.schema.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "topograph Helm chart values",
+  "description": "Schema for the topograph chart's values.yaml. Validates the most error-prone fields (provider and engine enums, replicaCount, image.pullPolicy, service settings, verbosity). Per-provider credential-field requirements are documented in docs/providers/<name>.md rather than enforced here, because the credential field sets vary with upstream provider changes and are better kept in prose.",
+  "type": "object",
+  "properties": {
+    "global": {
+      "type": "object",
+      "properties": {
+        "provider": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Topology-discovery provider. Must match a registered provider in pkg/registry/registry.go.",
+              "enum": [
+                "aws",
+                "aws-sim",
+                "cw",
+                "dra",
+                "gcp",
+                "gcp-sim",
+                "infiniband-bm",
+                "infiniband-k8s",
+                "lambdai",
+                "lambdai-sim",
+                "nebius",
+                "netq",
+                "oci",
+                "oci-imds",
+                "oci-sim",
+                "test"
+              ]
+            }
+          },
+          "required": ["name"]
+        },
+        "engine": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Scheduler-output engine. Must match a registered engine in pkg/registry/registry.go.",
+              "enum": ["k8s", "slinky", "slurm"]
+            }
+          },
+          "required": ["name"]
+        },
+        "service": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"]
+            },
+            "port": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535
+            }
+          }
+        }
+      }
+    },
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": { "type": "string", "minLength": 1 },
+        "tag": { "type": "string" },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["IfNotPresent", "Always", "Never"]
+        }
+      }
+    },
+    "imagePullSecrets": { "type": "array" },
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean" },
+        "automount": { "type": "boolean" },
+        "annotations": { "type": "object" },
+        "name": { "type": "string" }
+      }
+    },
+    "verbosity": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 10
+    },
+    "env": { "type": "object" },
+    "config": { "type": "object" },
+    "topologyNodeLabels": { "type": "object" },
+    "podAnnotations": { "type": "object" },
+    "podLabels": { "type": "object" },
+    "podSecurityContext": { "type": "object" },
+    "securityContext": { "type": "object" },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "className": { "type": "string" },
+        "annotations": { "type": "object" },
+        "hosts": { "type": "array" },
+        "tls": { "type": "array" }
+      }
+    },
+    "resources": { "type": "object" },
+    "volumes": { "type": "array" },
+    "volumeMounts": { "type": "array" },
+    "livenessProbe": { "type": "object" },
+    "readinessProbe": { "type": "object" },
+    "nodeSelector": { "type": "object" },
+    "tolerations": { "type": "array" },
+    "affinity": { "type": "object" },
+    "serviceMonitor": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "namespace": { "type": "string" },
+        "port": { "type": "string" },
+        "path": { "type": "string" },
+        "interval": { "type": "string" },
+        "scheme": {
+          "type": "string",
+          "enum": ["http", "https"]
+        }
+      }
+    },
+    "tests": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": { "type": "string" },
+            "tag": { "type": "string" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/charts/topograph/values.yaml
+++ b/charts/topograph/values.yaml
@@ -124,3 +124,18 @@ serviceMonitor:
   path: /metrics
   interval: 15s
   scheme: http
+
+tests:
+  # `helm test` hook pods (templates/tests/) probe the Topograph API's
+  # /healthz and /metrics endpoints via the in-cluster Service.
+  enabled: true
+  # By default, test pods reuse the main topograph image. Topograph's
+  # default image is Alpine-based and ships with busybox wget, which the
+  # test probes use -- no additional image pull is needed, including in
+  # air-gapped environments. If you run a topograph image variant without
+  # busybox wget (for example, the IB variant built on ubuntu), override
+  # either field to point at an image that ships wget. Leave both empty
+  # to reuse the main image.
+  image:
+    repository: ""
+    tag: ""

--- a/docs/engines/k8s.md
+++ b/docs/engines/k8s.md
@@ -236,4 +236,63 @@ spec:
 Apply alongside the chart. A bundled template is under consideration.
 
 ## Validation and Testing
-TBD
+
+The Helm chart ships two layers of validation for operators.
+
+### Schema-backed values validation at install time
+
+`charts/topograph/values.schema.json` is a JSON Schema that Helm enforces during `helm template` and `helm install`. Misspelled provider names, wrong engine enums, out-of-range replica counts, bad pull policies, invalid service port numbers, and malformed `serviceMonitor` / `tests` / `ingress` shapes are rejected with a clear `at '/field/path': <explanation>` error before any template rendering happens. For example, `--set global.provider.name=bogus` produces:
+
+```
+Error: values don't meet the specifications of the schema(s) in the following chart(s):
+topograph:
+- at '/global/provider/name': value must be one of 'aws', 'aws-sim', 'cw', 'dra', 'gcp', 'gcp-sim', 'infiniband-bm', 'infiniband-k8s', 'lambdai', 'lambdai-sim', 'nebius', 'netq', 'oci', 'oci-imds', 'oci-sim', 'test'
+```
+
+The schema is deliberately narrow: per-provider credential requirements are documented in prose in `docs/providers/<name>.md` rather than enforced in the schema, because credential field sets evolve with upstream provider changes.
+
+### `helm test` hooks
+
+The chart ships two `helm test` hook pods (`charts/topograph/templates/tests/`) that probe the running Topograph API via its in-cluster Service after install:
+
+- **`test-healthz`** — `GET /healthz`; expects HTTP 200 (liveness check).
+- **`test-metrics`** — `GET /metrics`; expects HTTP 200 and the `topograph_version` Prometheus metric present in the response body (topograph-specific identity check; distinguishes topograph from any other service that might return 200).
+
+Run the suite after installation:
+
+```bash
+helm install topograph oci://ghcr.io/nvidia/topograph/topograph \
+  --namespace topograph --create-namespace
+helm test topograph --namespace topograph
+```
+
+Expected output:
+
+```
+TEST SUITE:     topograph-test-healthz
+Phase:          Succeeded
+TEST SUITE:     topograph-test-metrics
+Phase:          Succeeded
+```
+
+Both pods clean themselves up on success (`helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded`). On failure the pods persist so operators can inspect logs via `kubectl logs -n <ns> <pod-name>`; the next `helm test` invocation replaces the prior pods.
+
+**Air-gapped environments.** The test pods reuse the main topograph image by default — they invoke `busybox wget` from the Alpine-based `ghcr.io/nvidia/topograph` image already pulled by the Deployment. No additional image pull is required by `helm test`, so the suite works in environments where only mirrored images are reachable. Operators running a topograph image variant without `busybox wget` (notably the ubuntu-based IB variant built from `Dockerfile.ib`) can either override the test image:
+
+```yaml
+tests:
+  image:
+    repository: my-registry.internal/wget
+    tag: v1.0.0
+```
+
+or disable the test hooks entirely:
+
+```yaml
+tests:
+  enabled: false
+```
+
+### Chart README
+
+For installation, prerequisites, values reference, and configuration examples, see [`charts/topograph/README.md`](../../charts/topograph/README.md) — also surfaced via `helm show readme oci://ghcr.io/nvidia/topograph/topograph`.

--- a/docs/engines/slinky.md
+++ b/docs/engines/slinky.md
@@ -22,6 +22,8 @@ Topograph is configured using a configuration file stored in a ConfigMap and mou
 In addition, when sending a topology request, the request payload includes additional parameters.
 The parameters for the configuration file and topology request are defined in the `global` section of the Helm values file, as shown below:
 
+> **Shared with the Kubernetes engine:** because the Topograph API server runs as a Kubernetes workload regardless of the engine, anything about the chart's deployment surface — values-schema validation, `helm test` hooks, Prometheus `ServiceMonitor`, `NetworkPolicy` guidance, the chart's `README.md`, and access patterns (ClusterIP port-forward, Ingress) — is shared with the Kubernetes engine and documented authoritatively in [`engines/k8s.md`](./k8s.md#validation-and-testing) and [`engines/k8s.md#exposing-the-topograph-api`](./k8s.md#exposing-the-topograph-api). Those sections apply equally to Slinky deployments.
+
 ```yaml
 global:
   # provider – name of the cloud provider or on-prem environment.


### PR DESCRIPTION
## Summary

Companion artifacts surfaced by the Helm 4 compatibility assessment in #271. Three chart-quality improvements landing together, all backward-compatible with Helm 3 and adding no runtime dependencies:

1. **`charts/topograph/values.schema.json`** — narrow JSON Schema draft-07 that validates the most error-prone fields at install time. Covers the `global.provider.name` and `global.engine.name` enums (populated from the full registered-provider set in `pkg/registry/registry.go`), type/range constraints on `replicaCount`, `image.pullPolicy`, `service.type`, `service.port`, and `verbosity`, and the expected shapes of `ingress`, `serviceMonitor`, `tests`, and related nested objects. Per-provider credential requirements are intentionally not codified — those fields evolve with upstream provider changes and are better documented in prose (per-provider `docs/providers/*.md`).
2. **`charts/topograph/templates/tests/`** — two `helm test` hook pods (`test-healthz`, `test-metrics`) that probe `/healthz` and `/metrics` via the in-cluster Service. Test pods reuse the main topograph image (Alpine 3.23-based, ships with busybox `wget`) so `helm test` works without pulling any additional image — including in air-gapped environments where only mirrored images are reachable. A `tests.enabled` toggle disables them entirely; `tests.image.repository` / `tests.image.tag` overrides the image for topograph image variants without busybox `wget` (e.g., the ubuntu-based IB variant). Both pods self-clean via `helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded`.
3. **`charts/topograph/README.md`** — chart-level README. Sections: Overview, Prerequisites, Installation, Configuration (with links to the example values files), Values validation, Testing (including an "Air-gapped environments" note), Subcharts, References, License. The Prerequisites section documents Helm 3.8+ or Helm 4 (verified against 3.20.0 and 4.1.4) and **deliberately does not claim a Kubernetes version floor** — `Chart.yaml` `kubeVersion:` is left unchanged pending maintainer input on the intended support surface.

No modifications to `Chart.yaml` or to any existing template.

## Validation

Verified on a representative Kubernetes cluster with **Helm 3.20.0** and **Helm 4.1.4** side-by-side.

### Template parity

| Check | Result |
|---|---|
| `helm lint .` under Helm 3 | pass (INFO: icon recommended) |
| `helm lint .` under Helm 4 | pass (INFO: icon recommended) |
| `helm template` default values, H3 vs H4 | **0 diff lines** (byte-identical) |
| `helm template` with `values.k8s-ib-example.yaml`, H3 vs H4 | **0 diff lines** (byte-identical) |

### Schema enforcement

Invalid `global.provider.name` rejected under both binaries:

```
Error: values don't meet the specifications of the schema(s) in the following chart(s):
topograph:
- at '/global/provider/name': value must be one of 'aws', 'aws-sim', 'cw', 'dra', 'gcp', 'gcp-sim', 'infiniband-bm', 'infiniband-k8s', 'lambdai', 'lambdai-sim', 'nebius', 'netq', 'oci', 'oci-imds', 'oci-sim', 'test'
```

Out-of-range `replicaCount=-1` rejected under both binaries:

```
- at '/replicaCount': minimum: got -1, want 1
```

Mis-typed `tests.enabled=notabool` rejected under both binaries:

```
- at '/tests/enabled': got string, want boolean
```

### Install + `helm test`

Under both Helm 3 and Helm 4:

- `helm install test . --namespace topograph-test` → Status: deployed
- `kubectl rollout status deploy/test-topograph` → successfully rolled out
- `helm test test --namespace topograph-test` →

```
TEST SUITE:     test-topograph-test-healthz
Phase:          Succeeded
TEST SUITE:     test-topograph-test-metrics
Phase:          Succeeded
```

- `helm uninstall test --namespace topograph-test` → clean removal
- `tests.enabled=false` suppresses test-pod rendering entirely (`kind: Pod` hook count = 0 under both binaries)

### Packaged-chart artifacts

`helm package .` produces a tgz whose contents include all four new artifacts (verified by inspecting the tarball):

```
topograph/values.schema.json
topograph/templates/tests/test-healthz.yaml
topograph/templates/tests/test-metrics.yaml
topograph/README.md
```

`helm show readme <tgz>` surfaces the new README via the canonical Helm UX.

## Air-gap behavior

By default, the test pods' image is an empty string under `tests.image.repository` / `.tag`, which falls back to `.Values.image.repository` / `.Values.image.tag` — i.e., the main topograph image. Since the main image is already pulled for the Deployment, no additional pull is required by `helm test`. Operators in air-gapped environments with only mirrored images do not need to mirror a separate test-helper image.

If running a topograph image variant without busybox `wget` (notably the ubuntu-based IB variant built from `Dockerfile.ib`), operators override the test image or disable tests:

```yaml
tests:
  enabled: false                 # disable entirely
  # — or —
  image:
    repository: my-registry.internal/wget
    tag: latest
```

## Checklist

- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes. (`helm test` hooks added; schema negative tests run in validation above.)
- [x] The documentation is up to date with these changes. (Chart-level README created; `values.yaml` comments updated; schema comments explain each rule.)
- [x] All commits are signed off per DCO (`git commit -s`).

Closes #271
