### PR TITLE
feat(chart): add Gateway API (HTTPRoute) support

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -177,6 +177,8 @@ Engines are much rarer (three exist: slurm, k8s, slinky). Follow the same regist
 | Modify an AGENTS.md-described surface (new Makefile target, top-level directory, chart template, invariant) without updating `AGENTS.md` + `.claude/CLAUDE.md` in the same PR | Drift between the code and its agent-facing description; the next contributor / agent reads stale guidance |
 | Skip DCO sign-off to "fix later" | The DCO bot will block the PR; rebase with `--signoff` is always available |
 | Use plain `error` at the provider interface boundary | Must be `*httperr.Error` so the API server returns the correct HTTP status |
+| Enable both `ingress.enabled` and `gatewayAPI.enabled` in the same Helm release | Mutually exclusive; deploying both routing resources against the same Service is almost always a misconfiguration. Enforced by `charts/topograph/templates/_validation.tpl`. |
+| Add implementation-specific annotations, CRDs, or extensions to `charts/topograph/templates/httproute.yaml` | The default `HTTPRoute` must use only standard `gateway.networking.k8s.io/v1` fields so it renders and functions against any conformant Gateway API implementation. Implementation-specific examples (kgateway `TrafficPolicy`, etc.) belong in `values.k8s-gateway-api-example.yaml` as separate attached resources, not in the chart's default template. |
 
 ### Label and annotation reference
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,8 @@ Engines are much rarer (three exist: slurm, k8s, slinky). Follow the same regist
 | Modify an AGENTS.md-described surface (new Makefile target, top-level directory, chart template, invariant) without updating `AGENTS.md` + `.claude/CLAUDE.md` in the same PR | Drift between the code and its agent-facing description; the next contributor / agent reads stale guidance |
 | Skip DCO sign-off to "fix later" | The DCO bot will block the PR; rebase with `--signoff` is always available |
 | Use plain `error` at the provider interface boundary | Must be `*httperr.Error` so the API server returns the correct HTTP status |
+| Enable both `ingress.enabled` and `gatewayAPI.enabled` in the same Helm release | Mutually exclusive; deploying both routing resources against the same Service is almost always a misconfiguration. Enforced by `charts/topograph/templates/_validation.tpl`. |
+| Add implementation-specific annotations, CRDs, or extensions to `charts/topograph/templates/httproute.yaml` | The default `HTTPRoute` must use only standard `gateway.networking.k8s.io/v1` fields so it renders and functions against any conformant Gateway API implementation. Implementation-specific examples (kgateway `TrafficPolicy`, etc.) belong in `values.k8s-gateway-api-example.yaml` as separate attached resources, not in the chart's default template. |
 
 ### Label and annotation reference
 

--- a/charts/topograph/README.md
+++ b/charts/topograph/README.md
@@ -51,6 +51,7 @@ For the full list of values and their defaults, see [`values.yaml`](./values.yam
 - [`values.k8s-ib-example.yaml`](./values.k8s-ib-example.yaml) — InfiniBand provider on Kubernetes
 - [`values.k8s-gcp-service-account-example.yaml`](./values.k8s-gcp-service-account-example.yaml) — GCP provider with a service account key mounted from a Secret
 - [`values.k8s-gcp-federated-workload-identity-example.yaml`](./values.k8s-gcp-federated-workload-identity-example.yaml) — GCP provider using Workload Identity Federation
+- [`values.k8s-gateway-api-example.yaml`](./values.k8s-gateway-api-example.yaml) — exposing the Topograph API via Gateway API (`HTTPRoute`) instead of `Ingress`
 - [`values-slinky-tree-example.yaml`](./values-slinky-tree-example.yaml), [`values-slinky-block-example.yaml`](./values-slinky-block-example.yaml), [`values-slinky-partition-example.yaml`](./values-slinky-partition-example.yaml) — Slinky engine variants
 
 ### Values validation

--- a/charts/topograph/templates/NOTES.txt
+++ b/charts/topograph/templates/NOTES.txt
@@ -1,5 +1,19 @@
 1. Get the application URL by running these commands:
-{{- if .Values.ingress.enabled }}
+{{- if .Values.gatewayAPI.enabled }}
+{{- if .Values.gatewayAPI.hostnames }}
+{{- range $host := .Values.gatewayAPI.hostnames }}
+  http://{{ $host }}/
+{{- end }}
+  NOTE: The above URL(s) resolve to the Gateway referenced by parentRefs.
+        The Gateway is platform-owned; confirm the operator has provisioned
+        it and (if needed) published its listener address in DNS.
+{{- else }}
+  NOTE: Gateway API HTTPRoute is rendered but no hostnames are set.
+        The route will accept any hostname routed to the parent Gateway's
+        listener. Resolve the Gateway address with:
+          kubectl get gateway -A
+{{- end }}
+{{- else if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
   {{- range .paths }}
   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}

--- a/charts/topograph/templates/NOTES.txt
+++ b/charts/topograph/templates/NOTES.txt
@@ -1,8 +1,9 @@
 1. Get the application URL by running these commands:
 {{- if .Values.gatewayAPI.enabled }}
 {{- if .Values.gatewayAPI.hostnames }}
+{{- $scheme := .Values.gatewayAPI.scheme | default "http" }}
 {{- range $host := .Values.gatewayAPI.hostnames }}
-  http://{{ $host }}/
+  {{ $scheme }}://{{ $host }}/
 {{- end }}
   NOTE: The above URL(s) resolve to the Gateway referenced by parentRefs.
         The Gateway is platform-owned; confirm the operator has provisioned

--- a/charts/topograph/templates/_validation.tpl
+++ b/charts/topograph/templates/_validation.tpl
@@ -4,6 +4,10 @@
   {{- fail "ingress.enabled and gatewayAPI.enabled are mutually exclusive; deploying both routing resources against the same Service is almost always a misconfiguration. Pick one." }}
 {{- end }}
 
+{{- if and .Values.gatewayAPI.enabled (not .Values.gatewayAPI.parentRefs) }}
+  {{- fail "gatewayAPI.enabled=true requires at least one entry in gatewayAPI.parentRefs referencing the existing Gateway resource this HTTPRoute should attach to. See charts/topograph/values.k8s-gateway-api-example.yaml for a complete example." }}
+{{- end }}
+
 {{- if eq .Values.global.provider.name "gcp" }}
 {{- $params := .Values.global.provider.params }}
 

--- a/charts/topograph/templates/_validation.tpl
+++ b/charts/topograph/templates/_validation.tpl
@@ -1,5 +1,9 @@
 {{- define "topograph.validation" -}}
 
+{{- if and .Values.ingress.enabled .Values.gatewayAPI.enabled }}
+  {{- fail "ingress.enabled and gatewayAPI.enabled are mutually exclusive; deploying both routing resources against the same Service is almost always a misconfiguration. Pick one." }}
+{{- end }}
+
 {{- if eq .Values.global.provider.name "gcp" }}
 {{- $params := .Values.global.provider.params }}
 

--- a/charts/topograph/templates/httproute.yaml
+++ b/charts/topograph/templates/httproute.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.gatewayAPI.enabled }}
+{{- /*
+  Note on Gateway API CRD prerequisites:
+
+  A chart-side `.Capabilities.APIVersions.Has "gateway.networking.k8s.io/v1"`
+  check is intentionally omitted here. Helm populates `.Capabilities`
+  against the cluster only at install time, not during `helm template`,
+  so such a check would false-positive on every template preview.
+
+  Operators running `helm install` on a cluster without the Gateway API
+  CRDs will get a clear Kubernetes-native error of the form
+  `no matches for kind "HTTPRoute" in version "gateway.networking.k8s.io/v1"`,
+  which is sufficient. Prerequisites are documented in values.yaml and
+  docs/engines/k8s.md.
+*/ -}}
+{{- $fullName := include "topograph.fullname" . -}}
+{{- $svcPort := .Values.global.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "topograph.labels" . | nindent 4 }}
+  {{- with .Values.gatewayAPI.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.gatewayAPI.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.gatewayAPI.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- if .Values.gatewayAPI.rules }}
+    {{- toYaml .Values.gatewayAPI.rules | nindent 4 }}
+    {{- else }}
+    - backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+    {{- end }}
+{{- end }}

--- a/charts/topograph/values.k8s-gateway-api-example.yaml
+++ b/charts/topograph/values.k8s-gateway-api-example.yaml
@@ -1,0 +1,107 @@
+# Example: expose the Topograph API via Gateway API (HTTPRoute).
+#
+# Prerequisites in the cluster (operator responsibility, outside this chart):
+#   1. Gateway API CRDs installed (gateway.networking.k8s.io/v1).
+#   2. A Gateway API implementation running (kgateway, Cilium, Istio, Envoy
+#      Gateway, Nginx Gateway Fabric, etc.). This chart's HTTPRoute uses only
+#      standard gateway.networking.k8s.io/v1 fields and is portable across
+#      any conformant implementation.
+#   3. A Gateway resource provisioned with a listener this HTTPRoute can
+#      attach to. Gateway authoring is NOT a topograph concern; it is
+#      platform-owned.
+#   4. If the Gateway lives in a different namespace from this release, a
+#      ReferenceGrant in the Gateway's namespace permitting attachment from
+#      the release namespace.
+#
+# This example uses kgateway-style resource names in the platform-owned
+# Gateway. For other implementations the Gateway side of the configuration
+# differs, but the topograph-side values below are identical.
+
+global:
+  provider:
+    name: test
+  engine:
+    name: k8s
+
+# Disable the legacy Ingress -- mutually exclusive with Gateway API in this chart.
+ingress:
+  enabled: false
+
+gatewayAPI:
+  enabled: true
+
+  # Attach the HTTPRoute to an existing Gateway. Replace with the name and
+  # namespace of the Gateway your platform operator has provisioned.
+  parentRefs:
+    - name: topograph-gateway
+      namespace: gateway-system
+      # Optional: pin to a specific listener on the Gateway, e.g. "https".
+      # sectionName: https
+
+  # Hostnames this route matches. Must be a subset of hostnames declared on
+  # the Gateway's listener(s). Remove the list to accept any hostname routed
+  # to the parent listener.
+  hostnames:
+    - topograph.example.com
+
+  # Leaving `rules` empty uses the chart's default: a single catch-all rule
+  # routing all requests to the topograph Service (which serves /v1/generate,
+  # /v1/topology, /healthz, and /metrics on a single port). To restrict to
+  # the public API only, override with path-prefix matching:
+  #
+  # rules:
+  #   - matches:
+  #       - path:
+  #           type: PathPrefix
+  #           value: /v1/
+  #     backendRefs:
+  #       - name: topograph
+  #         port: 49021
+  #   - matches:
+  #       - path:
+  #           type: PathPrefix
+  #           value: /healthz
+  #     backendRefs:
+  #       - name: topograph
+  #         port: 49021
+  rules: []
+
+  # The chart does not apply implementation-specific annotations to the
+  # HTTPRoute by default. If your platform uses annotation-based extensions,
+  # add them here.
+  annotations: {}
+
+# ---------------------------------------------------------------------------
+# Attaching authentication at the Gateway layer
+# ---------------------------------------------------------------------------
+#
+# Topograph's binary has no built-in authentication on /v1/generate. When
+# exposing the API externally, enforce authentication at the Gateway via the
+# implementation-specific policy mechanism. These are NOT topograph-chart
+# concerns -- apply them as separate resources in the platform layer.
+#
+# Example for kgateway (CNCF, Envoy-based) -- TrafficPolicy + ExtAuth,
+# attached to the HTTPRoute this chart renders:
+#
+#   apiVersion: gateway.kgateway.dev/v1alpha1
+#   kind: TrafficPolicy
+#   metadata:
+#     name: topograph-auth
+#     namespace: <release-namespace>
+#   spec:
+#     targetRefs:
+#       - group: gateway.networking.k8s.io
+#         kind: HTTPRoute
+#         name: topograph    # matches {{ include "topograph.fullname" . }}
+#     extAuth:
+#       extensionRef:
+#         name: my-oidc-extauth
+#
+# Equivalent patterns for other implementations:
+#   - Istio: RequestAuthentication + AuthorizationPolicy
+#   - Nginx Gateway Fabric: BasicAuth / JWTPolicy / ClientSettingsPolicy
+#   - Envoy Gateway: SecurityPolicy (JWT / OIDC / ExtAuth)
+#   - Cilium: CiliumNetworkPolicy at L7
+#
+# All attach to the HTTPRoute via `targetRefs` or equivalent; none require
+# changes to this chart.

--- a/charts/topograph/values.schema.json
+++ b/charts/topograph/values.schema.json
@@ -112,6 +112,34 @@
         "tls": { "type": "array" }
       }
     },
+    "gatewayAPI": {
+      "type": "object",
+      "description": "Gateway API (gateway.networking.k8s.io/v1) access. Mutually exclusive with ingress.enabled. The chart does not author Gateway or GatewayClass resources.",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "parentRefs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "namespace": { "type": "string" },
+              "sectionName": { "type": "string" },
+              "group": { "type": "string" },
+              "kind": { "type": "string" },
+              "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
+            },
+            "required": ["name"]
+          }
+        },
+        "hostnames": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "rules": { "type": "array" },
+        "annotations": { "type": "object" }
+      }
+    },
     "resources": { "type": "object" },
     "volumes": { "type": "array" },
     "volumeMounts": { "type": "array" },

--- a/charts/topograph/values.schema.json
+++ b/charts/topograph/values.schema.json
@@ -137,7 +137,12 @@
           "items": { "type": "string" }
         },
         "rules": { "type": "array" },
-        "annotations": { "type": "object" }
+        "annotations": { "type": "object" },
+        "scheme": {
+          "type": "string",
+          "enum": ["http", "https"],
+          "description": "URL scheme surfaced in NOTES.txt for the hostname-based access URL. Presentation-only; does not affect the rendered HTTPRoute. Set to 'https' when the parent Gateway terminates TLS on the listener this HTTPRoute attaches to."
+        }
       }
     },
     "resources": { "type": "object" },

--- a/charts/topograph/values.yaml
+++ b/charts/topograph/values.yaml
@@ -81,6 +81,55 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+# Gateway API (gateway.networking.k8s.io/v1) access to the Topograph API.
+# Mutually exclusive with `ingress.enabled` -- the chart refuses to render if
+# both are set to true (see templates/_validation.tpl). The default rendered
+# HTTPRoute uses only standard gateway.networking.k8s.io/v1 fields with no
+# implementation-specific annotations, so it is portable across any
+# conformant Gateway API implementation (kgateway, Cilium, Istio, Envoy
+# Gateway, Nginx Gateway Fabric, etc.).
+#
+# The chart does NOT author `Gateway` or `GatewayClass` resources -- those
+# are platform-owned. Reference an existing Gateway via `parentRefs`. An
+# operator who needs to pin implementation behavior does so by pointing
+# `parentRefs` at a Gateway that itself names a specific `GatewayClass`.
+#
+# Implementation-specific extensions (e.g., kgateway `TrafficPolicy` +
+# ExtAuth for authentication, Istio `RequestAuthentication`, Nginx Gateway
+# Fabric policies, Cilium L7 policies) typically attach to the `HTTPRoute`
+# via separate resources, not via chart-level annotations. See
+# `values.k8s-gateway-api-example.yaml` for a realistic kgateway example.
+gatewayAPI:
+  enabled: false
+  # References to existing Gateway resources this HTTPRoute attaches to.
+  # Cross-namespace references require a ReferenceGrant in the Gateway's
+  # namespace.
+  parentRefs: []
+  #  - name: example-gateway
+  #    namespace: gateway-system      # optional
+  #    sectionName: https              # optional listener name on the Gateway
+  # Hostnames this HTTPRoute matches. Leave empty to accept any hostname
+  # routed to the parent Gateway's listener.
+  hostnames: []
+  #  - topograph.example.com
+  # Optional override for the default routing rule. By default the chart
+  # emits a single catch-all rule routing all requests to the Topograph
+  # Service (which handles /v1/generate, /v1/topology, /healthz, and
+  # /metrics on a single port). Set this to provide multiple rules or
+  # path-based matching.
+  rules: []
+  #  - matches:
+  #      - path:
+  #          type: PathPrefix
+  #          value: /v1/
+  #    backendRefs:
+  #      - name: <release-fullname>
+  #        port: <service port>
+  # Annotations applied to the HTTPRoute resource. Most implementation
+  # extensions attach via separate resources rather than annotations;
+  # this is here primarily for standard annotations (e.g., monitoring).
+  annotations: {}
+
 resources:
   limits:
     cpu: 400m

--- a/charts/topograph/values.yaml
+++ b/charts/topograph/values.yaml
@@ -129,6 +129,14 @@ gatewayAPI:
   # extensions attach via separate resources rather than annotations;
   # this is here primarily for standard annotations (e.g., monitoring).
   annotations: {}
+  # URL scheme surfaced in NOTES.txt for the hostname-based access URL.
+  # Gateway TLS is configured on the Gateway's listener (platform-owned),
+  # so the chart cannot auto-detect whether the parent Gateway terminates
+  # TLS. Operators whose Gateway attaches this HTTPRoute to an HTTPS
+  # listener should set this to "https" so the install NOTES show the
+  # correct URL. No effect on the rendered HTTPRoute itself -- this is
+  # presentation-only.
+  scheme: http
 
 resources:
   limits:

--- a/docs/engines/k8s.md
+++ b/docs/engines/k8s.md
@@ -144,8 +144,7 @@ The Topograph API server listens on port `49021` by default. The Helm chart alwa
 | `ClusterIP` + in-cluster callers | Node Observer calling the API server; downstream schedulers consume node labels directly (no API call needed) | Cluster-internal; lock down with `NetworkPolicy` |
 | `NodePort` / `LoadBalancer` | External access without Ingress — simple, but lacks hostname routing and TLS without extra setup | Expect to add an L7 auth layer in front |
 | Traditional `Ingress` (`networking.k8s.io/v1`) | Most common production pattern — works with nginx-ingress, Traefik, cloud-managed ingress | Add via ingress auth annotations, oauth2-proxy, or mesh |
-
-Gateway API (`HTTPRoute`) support is not yet implemented in the chart — follow the repository issues for status.
+| Gateway API (`gateway.networking.k8s.io/v1` `HTTPRoute`) | Newer clusters running a Gateway API implementation (kgateway, Cilium, Istio, Envoy Gateway, Nginx Gateway Fabric, etc.); role-oriented separation between platform-owned `Gateway` and workload-owned `HTTPRoute`; cross-namespace routing via `ReferenceGrant` | Attach implementation-specific policy (kgateway `TrafficPolicy`, Istio `RequestAuthentication`, Envoy Gateway `SecurityPolicy`, Nginx Gateway Fabric `ClientSettingsPolicy`, Cilium L7) to the rendered `HTTPRoute` via `targetRefs` |
 
 ### Default: ClusterIP
 
@@ -189,6 +188,54 @@ Authentication must be added at the Ingress or mesh layer. Common patterns:
 - nginx-ingress `nginx.ingress.kubernetes.io/auth-url` + oauth2-proxy
 - Istio `RequestAuthentication` + `AuthorizationPolicy`
 - mTLS termination at the ingress with client certificate validation
+
+### Exposing via Gateway API (`HTTPRoute`)
+
+The chart ships an optional `HTTPRoute` template (`charts/topograph/templates/httproute.yaml`) that attaches to an existing platform-owned `Gateway`. Enable with:
+
+```yaml
+# values.yaml
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: topograph-gateway
+      namespace: gateway-system
+  hostnames:
+    - topograph.example.com
+```
+
+**Mutually exclusive with `ingress.enabled`.** The chart refuses to render if both are enabled — deploying both routing resources against the same Service is almost always a misconfiguration.
+
+A complete example values file is provided at `charts/topograph/values.k8s-gateway-api-example.yaml`.
+
+**Prerequisites** (operator responsibility, outside this chart):
+
+1. **Gateway API CRDs installed** in the cluster — standard channel `gateway.networking.k8s.io/v1`. The chart fails cleanly with a clear error if they are absent.
+2. **A Gateway API implementation running** — kgateway, Cilium, Istio, Envoy Gateway, Nginx Gateway Fabric, or any other conformant implementation. The chart's `HTTPRoute` uses only standard `gateway.networking.k8s.io/v1` fields with no implementation-specific annotations, so it is portable across any of them.
+3. **A `Gateway` resource provisioned** with a listener this `HTTPRoute` can attach to. The chart does **not** author `Gateway` or `GatewayClass` resources — both are platform-owned.
+4. **A `ReferenceGrant`** in the Gateway's namespace if it lives in a different namespace from the release, per Gateway API cross-namespace attachment rules.
+
+**Default routing.** If `gatewayAPI.rules` is empty, the chart emits a single catch-all rule routing all requests to the Topograph Service (which serves `/v1/generate`, `/v1/topology`, `/healthz`, and `/metrics` on a single port). Override `gatewayAPI.rules` to provide path-specific matching — for example, to expose only `/v1/`:
+
+```yaml
+gatewayAPI:
+  enabled: true
+  parentRefs:
+    - name: topograph-gateway
+      namespace: gateway-system
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1/
+      backendRefs:
+        - name: topograph
+          port: 49021
+```
+
+**Authentication.** Topograph's binary has no built-in authentication on `/v1/generate`. When exposing the API externally, enforce authentication at the Gateway layer via the implementation's policy mechanism (kgateway `TrafficPolicy` + ExtAuth, Istio `RequestAuthentication`, Envoy Gateway `SecurityPolicy`, Nginx Gateway Fabric `ClientSettingsPolicy`, Cilium L7). These attach to the rendered `HTTPRoute` via `targetRefs` (or equivalent) as separate resources — no chart changes required. See `values.k8s-gateway-api-example.yaml` for a concrete kgateway example.
+
+**GRPCRoute, TLSRoute, BackendTLSPolicy** are not supported in this chart. Topograph's API is HTTP-only; TLS termination (when needed) happens at the Gateway listener.
 
 ### Metrics endpoint
 

--- a/docs/engines/slinky.md
+++ b/docs/engines/slinky.md
@@ -22,7 +22,7 @@ Topograph is configured using a configuration file stored in a ConfigMap and mou
 In addition, when sending a topology request, the request payload includes additional parameters.
 The parameters for the configuration file and topology request are defined in the `global` section of the Helm values file, as shown below:
 
-> **Shared with the Kubernetes engine:** because the Topograph API server runs as a Kubernetes workload regardless of the engine, anything about the chart's deployment surface — values-schema validation, `helm test` hooks, Prometheus `ServiceMonitor`, `NetworkPolicy` guidance, the chart's `README.md`, and access patterns (ClusterIP port-forward, Ingress) — is shared with the Kubernetes engine and documented authoritatively in [`engines/k8s.md`](./k8s.md#validation-and-testing) and [`engines/k8s.md#exposing-the-topograph-api`](./k8s.md#exposing-the-topograph-api). Those sections apply equally to Slinky deployments.
+> **Shared with the Kubernetes engine:** because the Topograph API server runs as a Kubernetes workload regardless of the engine, anything about the chart's deployment surface — values-schema validation, `helm test` hooks, access patterns (ClusterIP port-forward, Ingress, Gateway API `HTTPRoute`), Prometheus `ServiceMonitor`, `NetworkPolicy` guidance, and the chart's `README.md` — is shared with the Kubernetes engine and documented authoritatively in [`engines/k8s.md`](./k8s.md#validation-and-testing) and [`engines/k8s.md#exposing-the-topograph-api`](./k8s.md#exposing-the-topograph-api). Those sections apply equally to Slinky deployments.
 
 ```yaml
 global:


### PR DESCRIPTION
## Summary

Adds optional Gateway API (`gateway.networking.k8s.io/v1` `HTTPRoute`) access to the Helm chart, side-by-side with the existing `Ingress` support. The chart does not author `Gateway` or `GatewayClass` resources — those are platform-owned. The rendered `HTTPRoute` uses only standard Gateway API v1 fields and is portable across any conformant implementation (kgateway, Cilium, Istio, Envoy Gateway, Nginx Gateway Fabric, etc.).

**Stacks on #275** (chart-maturity artifacts: `values.schema.json`, `helm test` hooks, chart README). When #275 merges, this branch will be rebased onto the updated main and the diff reduces to just the Gateway API changes. A reviewer who wants to see only the net-new changes from this PR can use:

```bash
git fetch origin
git diff origin/chore/chart-maturity-helm4-followup..origin/feat/chart-gateway-api
```

## Design notes

- **Implementation-abstract.** The `HTTPRoute` template uses only standard `gateway.networking.k8s.io/v1` fields with no implementation-specific annotations, CRDs, or extensions. Implementation-specific examples (e.g., kgateway `TrafficPolicy` + ExtAuth for auth) live in `values.k8s-gateway-api-example.yaml` as separate attached resources, not in the default template.
- **No chart-side `.Capabilities.APIVersions.Has` check for Gateway API CRDs.** Helm populates `Capabilities` against the cluster only at install time, not during `helm template`; a chart-side check would false-positive on every preview. Operators installing on a cluster without the CRDs get a clear Kubernetes-native `no matches for kind "HTTPRoute" in version "gateway.networking.k8s.io/v1"` error instead. Prerequisites documented in `values.yaml` and `docs/engines/k8s.md`.
- **Mutually exclusive with `ingress.enabled`.** Enforced by `templates/_validation.tpl`. Deploying both routing resources against the same Service is almost always a misconfiguration.
- **Not in scope for v1:** `GRPCRoute`, `TLSRoute`, `BackendTLSPolicy`. Topograph's API is HTTP-only; TLS termination happens at the Gateway listener.

## Files changed

### New

- `charts/topograph/templates/httproute.yaml` — 45 lines. Conditional on `.Values.gatewayAPI.enabled`. Default rule: catch-all to the topograph Service (overridable via `.Values.gatewayAPI.rules` for path-based matching).
- `charts/topograph/values.k8s-gateway-api-example.yaml` — 107 lines. Realistic example with kgateway-style Gateway target plus a commented `TrafficPolicy` + ExtAuth pattern and equivalent references for Istio, Envoy Gateway, Nginx Gateway Fabric, and Cilium.

### Modified

- `charts/topograph/values.yaml` — new `gatewayAPI` block (enabled=false, parentRefs, hostnames, rules, annotations) with inline documentation of prerequisites and design constraints.
- `charts/topograph/values.schema.json` — schema extensions for `gatewayAPI` (enabled boolean; parentRefs items requiring `name`; hostnames string array; port range 1-65535 on optional port; etc.).
- `charts/topograph/templates/_validation.tpl` — mutual-exclusivity check failing render with a clear error when both `ingress.enabled` and `gatewayAPI.enabled` are true.
- `charts/topograph/templates/NOTES.txt` — Gateway API access-pattern output when `gatewayAPI.enabled`.
- `docs/engines/k8s.md` — new "Exposing the Topograph API / Gateway API (HTTPRoute)" subsection + access-pattern matrix gains a Gateway API row.
- `AGENTS.md` + `.claude/CLAUDE.md` — repository map and anti-patterns table updated (paired edit; bodies remain byte-identical from line 5). New anti-patterns: enabling both `ingress.enabled` and `gatewayAPI.enabled`; adding implementation-specific content to the default `HTTPRoute` template.

## Validation

Verified against **Helm 3.20.0** and **Helm 4.1.4** side-by-side, with **kgateway v2.2.1** on **Gateway API v1.4.0** CRDs, on a representative Kubernetes cluster.

### Chart-level (static)

| Check | Result |
|---|---|
| `helm lint .` (H3 + H4) | pass, INFO: icon recommended |
| `helm template` — default values (gatewayAPI disabled), H3 vs H4 | 440 lines, **0 diff** |
| `helm template -f values.k8s-gateway-api-example.yaml`, H3 vs H4 | 462 lines, **0 diff** |
| Schema rejects `gatewayAPI.enabled=yes` (string not bool) | `got string, want boolean` |
| Schema rejects `parentRefs=[{}]` (missing required `name`) | `missing property 'name'` |
| Mutual-exclusivity check — both `ingress.enabled=true` and `gatewayAPI.enabled=true` | `Error: ingress.enabled and gatewayAPI.enabled are mutually exclusive; deploying both routing resources against the same Service is almost always a misconfiguration. Pick one.` |

### Rendered HTTPRoute

```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: test-topograph
  labels:
    helm.sh/chart: topograph-0.3.0
    app.kubernetes.io/name: topograph
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "v0.3.0"
    app.kubernetes.io/managed-by: Helm
spec:
  parentRefs:
    - name: topograph-gateway
      namespace: gateway-system
  hostnames:
    - topograph.example.com
  rules:
    - backendRefs:
        - name: test-topograph
          port: 49021
```

### Level 2 implementation-specific string scan

Searched the rendered HTTPRoute for any of `kgateway`, `solo.io`, `gloo`, `istio.io`, `cilium`, `nginx.com`, `nginx-gateway`, `envoyproxy`, `trafficpolicy`. Result: **clean** — no implementation-specific references in the default template.

### Level 3b functional routing — in-cluster pod probe

HTTPRoute status after install:
```
Accepted=True, message "Successfully accepted Route"
ResolvedRefs=True, message "Successfully resolved all references"
```

`ghcr.io/nvidia/topograph:v0.3.0` pod → `http://topograph-gateway.gateway-system.svc.cluster.local:80/...` with `Host: topograph.example.com`:

```
--- /healthz via Gateway ---
body: OK                        → LIVENESS PASS
--- /metrics via Gateway ---
topograph_version{...} 1         → IDENTITY PASS (distinguishes topograph from any other 200-returning service)
```

### Level 3b functional routing — port-forward from outside the cluster

`kubectl port-forward -n gateway-system svc/topograph-gateway 18080:80` + curl from the other end:

```
/healthz + Host: topograph.example.com  →  body="OK"                          → LIVENESS PASS
/metrics + Host: topograph.example.com  →  body contains ^topograph_version   → IDENTITY PASS
/healthz + Host: wrong.example.com      →  HTTP 404                           → hostname routing enforced
```

### Baseline regression check (default values, gatewayAPI disabled)

Install + rollout + `helm test` + uninstall under both H3 and H4:

```
TEST SUITE:     test-topograph-test-healthz   Phase: Succeeded
TEST SUITE:     test-topograph-test-metrics   Phase: Succeeded
helm test exit: 0
```

No regression from #275's chart-maturity additions.

### Packaged chart artifacts

`helm package charts/topograph` → tgz contents include all new and prior artifacts:

- `topograph/values.schema.json` (from #275; extended here)
- `topograph/templates/httproute.yaml` (new)
- `topograph/templates/tests/test-healthz.yaml` (from #275)
- `topograph/templates/tests/test-metrics.yaml` (from #275)
- `topograph/README.md` (from #275)
- `topograph/values.k8s-gateway-api-example.yaml` (new)

### Skipped validation — rationale

- **Level 3a (second-impl CRDs side-by-side dry-run).** On closer inspection: both kgateway and NGINX Gateway Fabric rely on the *same* upstream Gateway API v1 CRDs and their shared validating webhook. NGF's `crds.yaml` ships NGF-specific extension CRDs (ClientSettingsPolicy etc.), not a second HTTPRoute validator. Adding it would not provide additional webhook validation. Level 2 static scan + Level 3b against kgateway's admission webhook is sufficient defensible evidence that the HTTPRoute is portable.
- **Level 4 (full cross-implementation functional test).** Not performed. Operators running Cilium, Istio, Envoy Gateway, or Nginx Gateway Fabric can verify in their own environments without any chart change. The implementation-abstract claim rests on the Gateway API v1 conformance of the rendered template.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes. (`helm test` hooks cover the baseline install; Gateway API functional routing verified via in-cluster and port-forward probes; schema negative tests run in validation above.)
- [x] The documentation is up to date with these changes. (New subsection in `docs/engines/k8s.md`, example values file, `values.yaml` inline docs, AGENTS.md + CLAUDE.md repository map and anti-patterns table.)
- [x] All commits are signed off per DCO (`git commit -s`).

Closes #262
