### PR TITLE
docs: post-#254 follow-ups — KEP-4962 note + Doc-Impact table rows

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -240,7 +240,9 @@ Every PR should be evaluated for documentation impact before pre-push qualificat
 |---|---|
 | New / changed / removed provider | `docs/providers/<name>.md` + `docs/overview.md` provider list + "Choosing a Provider" scenario table |
 | New / changed / removed engine | `docs/engines/<engine>.md` |
+| New / changed chart template (Ingress, HTTPRoute, NetworkPolicy, ServiceMonitor, etc.) | `docs/engines/k8s.md` "Exposing the Topograph API" section |
 | New / changed chart values schema | `charts/topograph/values.yaml` comments, `NOTES.txt` output, and any docs that reference the values |
+| New / changed label or annotation key | `docs/reference/node-labels.md` |
 | New / changed API endpoint, request parameter, or response field | `docs/api.md` |
 | New / changed config schema (`topograph-config.yaml` fields, defaults, validation) | `docs/api.md` |
 | New invariant or "do not change without discussion" surface | `AGENTS.md` + `.claude/CLAUDE.md` in the same PR |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,7 +240,9 @@ Every PR should be evaluated for documentation impact before pre-push qualificat
 |---|---|
 | New / changed / removed provider | `docs/providers/<name>.md` + `docs/overview.md` provider list + "Choosing a Provider" scenario table |
 | New / changed / removed engine | `docs/engines/<engine>.md` |
+| New / changed chart template (Ingress, HTTPRoute, NetworkPolicy, ServiceMonitor, etc.) | `docs/engines/k8s.md` "Exposing the Topograph API" section |
 | New / changed chart values schema | `charts/topograph/values.yaml` comments, `NOTES.txt` output, and any docs that reference the values |
+| New / changed label or annotation key | `docs/reference/node-labels.md` |
 | New / changed API endpoint, request parameter, or response field | `docs/api.md` |
 | New / changed config schema (`topograph-config.yaml` fields, defaults, validation) | `docs/api.md` |
 | New invariant or "do not change without discussion" surface | `AGENTS.md` + `.claude/CLAUDE.md` in the same PR |

--- a/docs/reference/node-labels.md
+++ b/docs/reference/node-labels.md
@@ -44,6 +44,10 @@ Label values are used as-is when they are 63 characters or shorter (the Kubernet
 
 The default `network.topology.nvidia.com/` prefix is configurable via the Helm `topologyNodeLabels` value. If you need to map topograph's topology layers to a custom label schema, override the keys at deploy time. The label _values_ (topology identifiers) are always derived from the provider's topology discovery and cannot be configured.
 
+### Relationship to upstream standardization (KEP-4962)
+
+An active Kubernetes Enhancement Proposal (KEP), [KEP-4962: Standardizing the Representation of Cluster Network Topology](https://github.com/kubernetes/enhancements/issues/4962) ([draft in PR #4965](https://github.com/kubernetes/enhancements/pull/4965)), advocates reserved label keys under the `topology.kubernetes.io/` namespace for a standardized representation of cluster network topology. The KEP is pre-GA and still under upstream review. Topograph's current `network.topology.nvidia.com/*` keys predate any potential upstream standard and are presently vendor-scoped — the KEP's framing allows vendor prefixes and standard labels to coexist rather than replace one another. If KEP-4962 reaches GA with stable keys, Topograph will evaluate aligning or providing both; for now, the `network.topology.nvidia.com/*` keys remain authoritative for Topograph-deployed clusters.
+
 ## Without Topograph
 
 When Topograph is not deployed, the labels commonly available for topology-aware scheduling are:


### PR DESCRIPTION
## Description

Two small follow-ups that became unblocked by PR #254 (`docs(reference): add authoritative node labels and annotations reference`) merging to `main` earlier today. Both were previously documented as "pending #254 merge" in session notes; bundled here as a single, minimal PR.

### 1. KEP-4962 upstream-alignment note (`docs/reference/node-labels.md`)

Adds a short subsection under `## Labels` covering [KEP-4962: Standardizing the Representation of Cluster Network Topology](https://github.com/kubernetes/enhancements/issues/4962) (draft in [PR #4965](https://github.com/kubernetes/enhancements/pull/4965)). The note establishes that:

- KEP-4962 is pre-GA and still under upstream review.
- Topograph's `network.topology.nvidia.com/*` keys predate any upstream standard and are presently vendor-scoped.
- The KEP's framing allows vendor prefixes and standard `topology.kubernetes.io/` keys to coexist, not replace one another.
- If KEP-4962 reaches GA with stable keys, Topograph will evaluate aligning or providing both.

This content was originally queued for PR #264 but deferred because the target file (`docs/reference/node-labels.md`) didn't exist on `main` until #254 landed.

### 2. Doc-Impact Evaluation table: restore two rows (`AGENTS.md` + `.claude/CLAUDE.md`)

Adds back two rows removed from PR #269 to avoid broken cross-references to content not yet on `main`:

| Change | Docs update required |
|---|---|
| New / changed chart template (Ingress, HTTPRoute, NetworkPolicy, ServiceMonitor, etc.) | `docs/engines/k8s.md` "Exposing the Topograph API" section |
| New / changed label or annotation key | `docs/reference/node-labels.md` |

Both target sections now exist on `main`:

- The "Exposing the Topograph API" section was added by PR #259.
- `docs/reference/node-labels.md` was added by PR #254.

Paired edit preserves the byte-identical invariant between `AGENTS.md` and `.claude/CLAUDE.md` from line 6 onward, verified with:

```bash
cmp <(tail -n +6 .claude/CLAUDE.md) <(tail -n +6 AGENTS.md)
# (empty output = match)
```

## Commits

Two logical commits on this branch, one per change:

1. `docs(reference): add KEP-4962 upstream-alignment note to node-labels.md`
2. `docs(agents): restore two Doc-Impact Evaluation table rows`

## Checklist

- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes. (Documentation-only PR; no tests applicable.)
- [x] The documentation is up to date with these changes. (This PR *is* the documentation update.)
- [x] All commits are signed off per DCO (`git commit -s`).
