### PR TITLE
fix(ci): extract PR metadata from ref_name for copy-PR-bot push trigger

### DIFF
--- a/.github/workflows/fern-docs-preview-build.yml
+++ b/.github/workflows/fern-docs-preview-build.yml
@@ -15,9 +15,12 @@
 
 # Workflow 1 of 2 for Fern doc previews.
 #
-# Collects the fern/ sources and PR metadata from the (possibly untrusted) PR
-# branch and uploads them as an artifact. No secrets are used here, so this is
-# safe to run on fork PRs via the regular pull_request trigger.
+# Collects the fern/ sources and PR metadata from the PR branch and uploads
+# them as an artifact. No secrets are used here.
+#
+# Triggers on push to pull-request/<n> branches (NVIDIA copy-PR-bot pattern).
+# On push events github.head_ref and github.event.pull_request.number are
+# empty — PR number and branch name are extracted from github.ref_name instead.
 #
 # The companion workflow (fern-docs-preview-comment.yml) picks up the artifact,
 # builds the preview with DOCS_FERN_TOKEN, and posts the PR comment.
@@ -47,14 +50,12 @@ jobs:
 
       - name: Save PR metadata
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          HEAD_REF: ${{ github.head_ref }}
-          BASE_REF: ${{ github.base_ref }}
+          BRANCH_NAME: ${{ github.ref_name }}
         run: |
           mkdir -p preview-metadata
-          echo "$PR_NUMBER" > preview-metadata/pr_number
-          echo "$HEAD_REF" > preview-metadata/head_ref
-          git diff --name-only "origin/${BASE_REF}...HEAD" -- '*.md' > preview-metadata/changed_md_files 2>/dev/null || true
+          echo "${BRANCH_NAME#pull-request/}" > preview-metadata/pr_number
+          echo "$BRANCH_NAME" > preview-metadata/head_ref
+          git diff --name-only "origin/main...HEAD" -- '*.md' > preview-metadata/changed_md_files 2>/dev/null || true
 
       - name: Upload fern sources and metadata
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2


### PR DESCRIPTION
## Description

The `Save PR metadata` step in `fern-docs-preview-build.yml` used `github.head_ref`, `github.base_ref`, and `github.event.pull_request.number` — context variables that are only populated on `pull_request` events. The workflow triggers on `push` to `pull-request/[0-9]+` branches (NVIDIA's copy-PR-bot pattern), where all three are empty. This caused `fern generate --docs --preview --id ""` to fail with exit code 1 on every PR that touched docs.

Fix: extract PR number and branch name from `github.ref_name` (e.g. `pull-request/249`) and hardcode `origin/main` for the changed-files diff.

Observed failure: https://github.com/NVIDIA/topograph/actions/runs/24644817796

Fixes #279

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).