### PR TITLE
fix(docs/ci): self-close img tags and add MDX safety check to CI

### DIFF
--- a/.github/workflows/fern-docs-ci.yml
+++ b/.github/workflows/fern-docs-ci.yml
@@ -54,6 +54,15 @@ jobs:
       - name: Install Fern CLI
         run: npm install -g fern-api@$(jq -r .version fern/fern.config.json)
 
+      - name: Check MDX safety
+        run: |
+          BAD=$(grep -rn '<img\b[^>]*[^/]>' docs/ --include="*.md" || true)
+          if [ -n "$BAD" ]; then
+            echo "::error::Non-self-closing <img> tags found (MDX requires <img ... />):"
+            echo "$BAD"
+            exit 1
+          fi
+
       - name: Fern check
         run: fern check
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,7 @@ Topograph consists of five major components:
 4. **Provider**
 5. **Engine**
 
-<p align="center"><img src="assets/design.png" width="600" alt="Design"></p>
+<p align="center"><img src="assets/design.png" width="600" alt="Design" /></p>
 
 ## Components
 


### PR DESCRIPTION
## Description

`docs/architecture.md:11` had a non-self-closing `<img>` tag, causing an MDX parse error at `fern generate` time. `fern check` does not validate MDX content so this slipped through CI.

Two-part fix:
- Self-close the `<img>` tag in `architecture.md`
- Add a `Check MDX safety` step to `fern-docs-ci.yml` that greps for non-self-closing `<img>` tags and fails CI before merge — so this class of error can't recur undetected

Fixes #281

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).