### PR TITLE
fix(ci): extend MDX img check to fern/ and .mdx files

### DIFF
--- a/.github/workflows/fern-docs-ci.yml
+++ b/.github/workflows/fern-docs-ci.yml
@@ -55,8 +55,10 @@ jobs:
         run: npm install -g fern-api@$(jq -r .version fern/fern.config.json)
 
       - name: Check MDX safety
+        # Intentionally inline — a composite action would add indirection without benefit for a single grep.
+        # Single-line grep is intentional — multiline <img> tags do not occur in practice in markdown docs.
         run: |
-          BAD=$(grep -rn '<img\b[^>]*[^/]>' docs/ --include="*.md" || true)
+          BAD=$(grep -rn '<img\b[^>]*[^/]>' docs/ fern/ --include="*.md" --include="*.mdx" || true)
           if [ -n "$BAD" ]; then
             echo "::error::Non-self-closing <img> tags found (MDX requires <img ... />):"
             echo "$BAD"


### PR DESCRIPTION
## Description

Extends the `Check MDX safety` grep step added in #282 to also cover `fern/` and `*.mdx` files, not just `docs/*.md`. Adds comments explaining the intentionally inline and single-line design choices.

Matches the pattern settled on in NVIDIA/NVSentinel#1215 and NVIDIA/aicr#620.

Fixes #281

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).