### PR TITLE
docs(fern): restore Reference section, label v0.3.0, surface errors

### DIFF
--- a/.github/workflows/publish-fern-docs.yml
+++ b/.github/workflows/publish-fern-docs.yml
@@ -60,9 +60,14 @@ jobs:
           FERN_TOKEN: ${{ secrets.DOCS_FERN_TOKEN }}
         working-directory: ./fern
         run: |
-          OUTPUT=$(fern generate --docs 2>&1)
-          echo "$OUTPUT"
-          URL=$(echo "$OUTPUT" | grep -oP 'Published docs to \K.*(?= \()')
+          # Stream fern's output to both the Actions log (via tee) and a temp
+          # file for URL extraction. The prior shape `OUTPUT=$(fern ... 2>&1)`
+          # swallowed fern's error output on failure because `bash -e` would
+          # abort on fern's non-zero exit before the subsequent `echo "$OUTPUT"`
+          # ran, leaving failed publishes with no diagnostic in the log.
+          set -o pipefail
+          fern generate --docs 2>&1 | tee /tmp/fern-output.log
+          URL=$(grep -oP 'Published docs to \K.*(?= \()' /tmp/fern-output.log || true)
           if [ -n "$URL" ]; then
             echo "### Published: [$URL]($URL)" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -39,3 +39,8 @@ navigation:
         path: engines/k8s.md
       - page: Slinky
         path: engines/slinky.md
+
+  - section: Reference
+    contents:
+      - page: Node Labels and Annotations
+        path: reference/node-labels.md

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -13,14 +13,12 @@ products:
     slug: /
     path: ../docs/index.yml
     versions:
-      - display-name: dev
+      - display-name: v0.3.0
         path: ../docs/index.yml
 
 redirects:
   - source: "/topograph/index.html"
     destination: "/topograph/"
-  - source: "/topograph/dev/index.html"
-    destination: "/topograph/dev/"
 
 footer: ./components/CustomFooter.tsx
 


### PR DESCRIPTION
## Description

Three related fixes to the Fern docs pipeline, each a small independent concern but cheap to bundle for review.

### 1. Restore Reference section to Fern nav

`docs/reference/node-labels.md` has been on `main` since #254 merged (2026-04-19) but is not listed in `docs/index.yml` (the Fern nav source-of-truth). The last successful Fern publish resolved 13 pages — exactly the count the nav declares without a Reference section — confirming the page is invisible on the live site despite being on the filesystem. Add a Reference section listing `reference/node-labels.md`. This is the paired-file update #254 should have included.

### 2. Label current version as v0.3.0

The published site shows a version label of `dev` because `fern/docs.yml` declared the only version as `display-name: dev`. The repo is at tagged release v0.3.0 with no divergence between released and in-flight docs, so `dev` is misleading. Rename to `v0.3.0`. When content actually diverges later (post-v0.4.0 breaking doc changes, or a doc change that only applies to the future release), re-introduce a separate `dev` entry alongside v0.3.0 and repoint paths.

Also drops the pre-existing `/topograph/dev/index.html` → `/topograph/dev/` redirect since the `/dev/` destination no longer exists after the rename. Not adding `/dev` → new-version forwarding: site has only been live since 2026-04-17 (four days), so dev-URL bookmarks are unlikely; the Fern root redirect + sidebar recover any user who lands on a 404. If dead-bookmark reports surface later, adding a one-line redirect is trivial.

### 3. Surface fern errors in publish workflow

The publish step used `OUTPUT=$(fern generate --docs 2>&1)` to capture fern's output for URL-extraction, but on non-zero exit `bash -e` aborted the step *before* the subsequent `echo "$OUTPUT"` ran. Every failed publish between 2026-04-17 and 2026-04-20 (three from PR merges, several manual dispatches) logged only "Process completed with exit code 1" — zero diagnostic context. Switch to `tee`-based streaming so fern's stdout/stderr reaches the Actions log directly on both success and failure paths. `set -o pipefail` preserves step-failure behavior; `|| true` on grep ensures a missing URL in fern's output does not fail the step on its own.

Net effect: future publish failures are diagnosable from the Actions log directly. No behavior change on the success path.

## Validation

- `fern check` passes (0 errors; 1 pre-existing NVIDIA-green-contrast warning unrelated to this PR)
- Local `fern docs dev` renders the sidebar with all five sections (Getting Started, Architecture, Providers, Engines, **Reference**)
- `/topograph/reference/node-labels-and-annotations` serves HTTP 200 on the local dev server
- Version label reads `v0.3.0` in the rendered site
- Workflow error-surfacing behavior will be verifiable on any future failed publish (no way to fabricate a deliberate fern error locally for this test)

## Checklist

- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes. (Validation via `fern check` + local `fern docs dev`; workflow fix is diagnostic plumbing with no behavioral change on the success path.)
- [x] The documentation is up to date with these changes. (This PR *is* the documentation update — the nav restoration and version label are themselves the doc fixes.)
- [x] All commits are signed off per DCO (`git commit -s`).