### PR TITLE
chore: standardize SPDX file headers

### DIFF
--- a/fern/assets/NVIDIA_dark.svg
+++ b/fern/assets/NVIDIA_dark.svg
@@ -1,3 +1,5 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: LicenseRef-NvidiaProprietary -->
 <svg version="1.1" id="Layer_1" xmlns:x="ns_extend;" xmlns:i="ns_ai;" xmlns:graph="ns_graphs;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 585.8 108" style="enable-background:new 0 0 585.8 108;" xml:space="preserve">
  <style type="text/css">
   .st0{fill:#FFFFFF;}

--- a/fern/assets/NVIDIA_light.svg
+++ b/fern/assets/NVIDIA_light.svg
@@ -1,3 +1,5 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: LicenseRef-NvidiaProprietary -->
 <svg version="1.1" id="Layer_1" xmlns:x="ns_extend;" xmlns:i="ns_ai;" xmlns:graph="ns_graphs;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 585.8 108" style="enable-background:new 0 0 585.8 108;" xml:space="preserve">
  <style type="text/css">
   .st0{fill:#76B900;}

--- a/fern/assets/NVIDIA_symbol.svg
+++ b/fern/assets/NVIDIA_symbol.svg
@@ -1,3 +1,5 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: LicenseRef-NvidiaProprietary -->
 <svg version="1.1" id="Layer_1" xmlns:x="ns_extend;" xmlns:i="ns_ai;" xmlns:graph="ns_graphs;" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 163.3 108" style="enable-background:new 0 0 163.3 108;" xml:space="preserve">
  <style type="text/css">
   .st0{fill:#76B900;}

--- a/fern/components/BadgeLinks.tsx
+++ b/fern/components/BadgeLinks.tsx
@@ -1,4 +1,9 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
  * Badge links for GitHub, License, PyPI, etc.
  * Uses a flex wrapper to display badges horizontally and hides Fern's
  * external-link icon that otherwise stacks under each badge image.

--- a/fern/components/CustomFooter.tsx
+++ b/fern/components/CustomFooter.tsx
@@ -1,4 +1,9 @@
 /**
+ * SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+ */
+
+/**
  * Custom footer for NVIDIA docs (Fern native header/footer).
  * Markup and class names match the original custom-app footer 1:1 so that
  * fern/main.css (footer + Built with Fern styles) applies correctly:


### PR DESCRIPTION
## Summary

- Replace ad-hoc copyright blocks with proper SPDX identifiers
- Add missing SPDX headers to files that had none

Fixes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)