### PR TITLE
fix(ci): include docs/ in Fern preview artifact

### DIFF
--- a/.github/workflows/fern-docs-preview-build.yml
+++ b/.github/workflows/fern-docs-preview-build.yml
@@ -15,8 +15,11 @@
 
 # Workflow 1 of 2 for Fern doc previews.
 #
-# Collects the fern/ sources and PR metadata from the PR branch and uploads
-# them as an artifact. No secrets are used here.
+# Collects the fern/ and docs/ sources plus PR metadata from the PR branch and
+# uploads them as an artifact. Both directories are needed because
+# fern/docs.yml references ../docs/index.yml; omitting docs/ causes
+# `fern generate --docs` to fail in the companion workflow. No secrets are
+# used here.
 #
 # Triggers on push to pull-request/<n> branches (NVIDIA copy-PR-bot pattern).
 # On push events github.head_ref and github.event.pull_request.number are
@@ -63,5 +66,6 @@ jobs:
           name: fern-preview
           path: |
             fern/
+            docs/
             preview-metadata/
           retention-days: 1


### PR DESCRIPTION
## Description

The Fern preview `Preview Fern Docs: Comment` workflow has been failing on every PR — see the [Comment workflow runs](https://github.com/NVIDIA/topograph/actions/workflows/fern-docs-preview-comment.yml), all recent runs \`conclusion=failure\`. That's why PRs against this repo don't get a `:herb: Preview your docs: <URL>` comment the way docs-related PRs on sibling NVIDIA OSS repos do.

**Root cause.** The `Build` workflow uploads only `fern/` and `preview-metadata/` as the artifact:

\`\`\`yaml
# .github/workflows/fern-docs-preview-build.yml (before)
path: |
  fern/
  preview-metadata/
\`\`\`

But `fern/docs.yml` references \`../docs/index.yml\`:

\`\`\`yaml
\$ grep docs/ fern/docs.yml
    path: ../docs/index.yml
        path: ../docs/index.yml
\`\`\`

So when the `Comment` workflow downloads the artifact and runs \`fern generate --docs --preview\`, the relative path doesn't resolve and the generate step exits 1. The `Comment` workflow intentionally never checks out the PR branch (to isolate secrets from untrusted code), so the missing directory can't be recovered there — it has to come from the artifact.

**Fix.** Add `docs/` to the `upload-artifact` path list so both directories ride along into the artifact. Secret-isolation boundary is unchanged.

Pattern verified against the NVSentinel Fern pipeline, which uploads both directories and produces working preview comments. Example preview on a recent NVSentinel PR: https://github.com/NVIDIA/NVSentinel/pull/1226#issuecomment-4301208326

## Checklist

- [x] Documentation Impact Evaluation — N/A (CI workflow change only)
- [x] `make qualify` — N/A (no Go/chart changes)
- [x] Every commit has a DCO sign-off

## Next preview comment

This PR should be the first one to actually receive a `:herb: Preview your docs:` comment once the updated `Build` workflow runs on the `pull-request/<n>` copy branch.