### PR TITLE
chore(chart): declare kubeVersion ">=1.27.0-0" in chart + subcharts

### DIFF
--- a/charts/topograph/Chart.yaml
+++ b/charts/topograph/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 name: topograph
 description: A Helm chart for Kubernetes
+kubeVersion: ">=1.27.0-0"
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/charts/topograph/README.md
+++ b/charts/topograph/README.md
@@ -7,8 +7,8 @@ Topograph discovers the physical network topology of a cluster (NVLink domains, 
 ## Prerequisites
 
 - **Helm**: 3.8+ or 4.x. The chart has been verified against Helm 3.20.0 and Helm 4.1.4, with byte-identical `helm template` output under both.
-- **Kubernetes**: no hard floor is declared by this chart; the rendered manifests use only `apps/v1`, `rbac.authorization.k8s.io/v1`, and `v1`, all stable since Kubernetes 1.9.
-- **Provider-specific prerequisites** vary (CSP credentials, node labels, local binaries like `ibnetdiscover`, etc.). See `docs/providers/<name>.md` in the main repository for each provider's setup.
+- **Kubernetes**: 1.27 or later
+- **Provider-specific prerequisites**: see the [provider documentation](https://github.com/NVIDIA/topograph/tree/main/docs/providers) in the main repository for each provider's setup.
 
 ## Installation
 

--- a/charts/topograph/charts/node-data-broker/Chart.yaml
+++ b/charts/topograph/charts/node-data-broker/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 name: node-data-broker
 description: A Helm chart for Kubernetes
+kubeVersion: ">=1.27.0-0"
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/charts/topograph/charts/node-observer/Chart.yaml
+++ b/charts/topograph/charts/node-observer/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 name: node-observer
 description: A Helm chart for Kubernetes
+kubeVersion: ">=1.27.0-0"
 
 # A chart can be either an 'application' or a 'library' chart.
 #


### PR DESCRIPTION
## Description

Adds a machine-enforced Kubernetes version floor to the topograph chart and its `node-observer` and `node-data-broker` subcharts. Previously the chart made no `kubeVersion` declaration, so `helm install` would not reject older clusters even though Topograph  min version is Kubernetes 1.27.

### Why 1.27

Committing 1.27 as the floor in \`Chart.yaml\` makes it a machine-checked guard and prevents install on older clusters where behavior is undefined.

### Why the \`-0\` suffix

The constraint is \`">=1.27.0-0"\` rather than \`">=1.27.0"\` so that cloud providers' prerelease-style version strings — e.g., \`1.27.0-gke.100\`, \`1.28.3-eks-1234\`, \`1.29.0-eks.1\` — satisfy the constraint. Without the \`-0\` floor on the prerelease segment, Masterminds/semver's default comparison treats prerelease versions as strictly less than the base release, which causes false negatives on GKE, EKS, AKS, etc.

### Chart README tightening (same PR)

While touching the chart's Prerequisites section:

- Kubernetes bullet simplified to "1.27 or later" (now enforced, so the bullet no longer needs to argue for the floor)
- Provider-specific prerequisites bullet links to [`docs/providers/`](https://github.com/NVIDIA/topograph/tree/main/docs/providers) rather than enumerating provider-specific details inline (CSP credentials, \`ibnetdiscover\`, etc.)

## Verification

- \`helm lint charts/topograph\` — no new findings
- \`helm template test charts/topograph\` — renders cleanly

## Checklist

- [x] Documentation Impact Evaluation — chart README updated in the same PR to reflect the enforced floor and simplified the per-provider bullet
- [x] \`make qualify\` — N/A (chart YAML + markdown only; no Go changes)
- [x] Every commit has a DCO sign-off