### PR TITLE
docs(get-started): add install-path quickstarts for Kubernetes and Slurm

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@
 
 Topograph is a component that discovers the physical network topology of a cluster and exposes it to schedulers, enabling topology-aware scheduling decisions. It abstracts multiple topology sources and translates them into the format required by each scheduler.
 
+## Quick Start
+
+Pick the install path that matches your scheduler:
+
+- **Kubernetes** — the same Helm chart covers native Kubernetes scheduling (`k8s` engine) and [Slinky](https://github.com/SlinkyProject) (Slurm-on-Kubernetes, `slinky` engine). See [Install on Kubernetes](docs/get-started/quickstart-k8s.md).
+- **Slurm (bare metal)** — install a `.deb` or `.rpm` package on the Slurm head node and run Topograph as a systemd service. See [Install on Slurm](docs/get-started/quickstart-slurm.md).
+
 ## Learn more
 
 - [Overview](docs/overview.md)

--- a/docs/get-started/quickstart-k8s.md
+++ b/docs/get-started/quickstart-k8s.md
@@ -1,0 +1,101 @@
+# Install on Kubernetes
+
+Topograph installs on a Kubernetes cluster via a Helm chart. The same chart supports two engines:
+
+- **[`k8s` engine](#engine-k8s)** — labels Kubernetes nodes with topology keys so schedulers (native `podAffinity`, KAI Scheduler, Kueue TAS, etc.) can make topology-aware placement decisions
+- **[`slinky` engine](#engine-slinky)** — writes Slurm topology configuration into a `ConfigMap` for [Slinky](https://github.com/SlinkyProject) (Slurm-on-Kubernetes) deployments
+
+Prerequisites, install flow, and verification are common to both — the engines differ only in a few `global.engine.*` values and in what downstream artifact is produced.
+
+## Prerequisites
+
+- **Kubernetes**: 1.27 or later
+- **Helm**: 3.8+ or 4.x
+- **`kubectl`** with permission to install a chart and create a `Namespace`
+- **A supported provider** for your environment — see the [provider documentation](../providers/) for per-provider setup (credentials, required cluster state, etc.)
+- **For the `slinky` engine only**: a Slinky cluster already deployed in the target Kubernetes cluster — Topograph does not deploy Slinky itself
+
+## Install
+
+Base install command (pick the engine-specific flags from the two sections below):
+
+```bash
+helm install topograph \
+  oci://ghcr.io/nvidia/topograph/topograph \
+  --version <chart-version> \
+  --namespace topograph --create-namespace \
+  --set global.provider.name=<provider> \
+  --set global.engine.name=<engine> \
+  # ... engine-specific flags ...
+```
+
+Replace `<provider>` with one of the supported values (`aws`, `gcp`, `oci`, `nebius`, `netq`, `dra`, `infiniband-k8s`, `lambdai`, `cw`). To see available chart versions, run `helm show chart oci://ghcr.io/nvidia/topograph/topograph`.
+
+Provider-specific credentials and parameters are passed via Helm values. See the [chart README](https://github.com/NVIDIA/topograph/blob/main/charts/topograph/README.md) and [`values.yaml`](https://github.com/NVIDIA/topograph/blob/main/charts/topograph/values.yaml) for the full values shape, plus the example values files shipped in the chart directory.
+
+## Verify
+
+The `helm test` verification is the same regardless of engine:
+
+```bash
+helm test topograph --namespace topograph
+```
+
+The bundled test hooks probe `/healthz` and `/metrics` inside the cluster and expect HTTP 200 plus the `topograph_version` metric in the response body. A green result confirms the API server is running.
+
+Engine-specific verification (seeing the actual topology output) differs — see each engine's section below.
+
+## Engine: `k8s` <a name="engine-k8s"></a>
+
+Engine-specific install flag:
+
+```bash
+  --set global.engine.name=k8s
+```
+
+Nothing else is required — the `k8s` engine labels nodes directly from the default chart deployment. A few seconds after install, topology labels appear on cluster nodes:
+
+```bash
+kubectl get nodes --show-labels | grep network.topology.nvidia
+```
+
+If labels are missing, inspect the Topograph logs:
+
+```bash
+kubectl logs -n topograph -l app.kubernetes.io/name=topograph
+```
+
+## Engine: `slinky` <a name="engine-slinky"></a>
+
+Engine-specific install flags point the `slinky` engine at the Slinky deployment:
+
+```bash
+  --set global.engine.name=slinky \
+  --set global.engineParams.namespace=<slinky-namespace> \
+  --set global.engineParams.topologyConfigmapName=<configmap-name> \
+  --set global.engineParams.topologyConfigPath=topology.conf
+```
+
+The full engine-parameter shape (`podSelector`, `plugin`, `block_sizes`, per-partition topologies, …) is documented in the [chart README](https://github.com/NVIDIA/topograph/blob/main/charts/topograph/README.md). Example values files for common Slinky scenarios ship in the chart directory:
+
+- [`values.slinky.tree-example.yaml`](https://github.com/NVIDIA/topograph/blob/main/charts/topograph/values.slinky.tree-example.yaml) — tree topology
+- [`values.slinky.block-example.yaml`](https://github.com/NVIDIA/topograph/blob/main/charts/topograph/values.slinky.block-example.yaml) — block topology
+- [`values.slinky.partition-example.yaml`](https://github.com/NVIDIA/topograph/blob/main/charts/topograph/values.slinky.partition-example.yaml) — per-partition topologies (Slurm 25.05+)
+
+To confirm the topology was written to the target `ConfigMap`:
+
+```bash
+kubectl get configmap -n <slinky-namespace> <configmap-name> -o yaml
+```
+
+The key configured via `topologyConfigPath` (by default `topology.conf`) should contain the generated Slurm topology configuration.
+
+## Where to go next
+
+- **[Kubernetes engine reference](../engines/k8s.md)** — configuration, access patterns (`Ingress`, `HTTPRoute`, `NetworkPolicy`, `ServiceMonitor`), mixed workload considerations
+- **[Slinky engine reference](../engines/slinky.md)** — `slinky` engine parameters, `ConfigMap` annotations, tree / block / per-partition usage examples (the chart-level deployment surface is shared with the `k8s` engine and is documented under the Kubernetes engine reference above)
+- **[Chart README](https://github.com/NVIDIA/topograph/blob/main/charts/topograph/README.md)** — full values reference, `helm test` details, air-gapped environments, subchart layout
+- **[Node labels reference](../reference/node-labels.md)** — label key semantics, value behavior (FNV hashing for long values), integration with the NVIDIA GPU Operator, downstream consumer notes (relevant primarily to the `k8s` engine)
+- **[Provider documentation](../providers/)** — per-provider prerequisites and configuration
+- **[Config and API reference](../api.md)** — `topograph-config.yaml` schema, API endpoints, request/response shape
+- **[Architecture](../architecture.md)** — how the API server, Node Observer, Node Data Broker, Provider, and Engine fit together

--- a/docs/get-started/quickstart-slurm.md
+++ b/docs/get-started/quickstart-slurm.md
@@ -1,0 +1,64 @@
+# Install on Slurm (bare metal)
+
+Install Topograph on a Slurm head node so it can generate topology configuration (`topology.conf` or per-partition `topology.yaml`) for the Slurm controller to consume.
+
+## Prerequisites
+
+- **Slurm** cluster with a head node you can install system packages on
+- **Go** and **`make`** to build the package from source (see [`go.mod`](https://github.com/NVIDIA/topograph/blob/main/go.mod) for the exact Go version), or a pre-built Debian/RPM package if your organization distributes one
+- **A supported provider** for your environment — see the [provider documentation](../providers/) for per-provider setup
+
+## Install
+
+Clone the repo and build a native package for your distribution:
+
+```bash
+git clone https://github.com/NVIDIA/topograph.git
+cd topograph
+
+make deb        # Debian / Ubuntu — produces .deb under dist/
+# or
+make rpm        # RHEL / Rocky / SUSE — produces .rpm under dist/
+```
+
+Install the resulting package:
+
+```bash
+sudo dpkg -i dist/topograph_*.deb        # Debian / Ubuntu
+# or
+sudo rpm -ivh dist/topograph-*.rpm       # RHEL / Rocky / SUSE
+```
+
+The package installs the service but does not start it. Edit `/etc/topograph/topograph-config.yaml` to set at minimum:
+
+```yaml
+http:
+  port: 49021
+provider: <provider>                     # aws, gcp, oci, nebius, netq, infiniband-bm, ...
+engine: slurm
+requestAggregationDelay: 15s
+```
+
+Then enable and start the service:
+
+```bash
+sudo systemctl enable --now topograph.service
+```
+
+## Verify
+
+Check that the service is running and the API is reachable:
+
+```bash
+curl http://localhost:49021/healthz
+```
+
+HTTP 200 means the API server is up.
+
+## Where to go next
+
+- **[Slurm engine reference](../engines/slurm.md)** — full configuration, tree vs block vs per-partition topology formats, `strigger` integration, using toposim for simulated-cluster testing
+- **[Provider documentation](../providers/)** — per-provider prerequisites and configuration
+- **[Config and API reference](../api.md)** — `topograph-config.yaml` schema, `/v1/generate` and `/v1/topology` contract
+- **[`scripts/create-topology-update-script.sh`](https://github.com/NVIDIA/topograph/blob/main/scripts/create-topology-update-script.sh)** — generates the Slurm trigger that calls `/v1/generate` automatically when the cluster's node inventory changes
+- **[Architecture](../architecture.md)** — how the API server, Provider, and Engine fit together

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -6,6 +6,10 @@ navigation:
     contents:
       - page: Overview
         path: overview.md
+      - page: Install on Kubernetes
+        path: get-started/quickstart-k8s.md
+      - page: Install on Slurm
+        path: get-started/quickstart-slurm.md
 
   - section: Architecture
     contents:


### PR DESCRIPTION
## Description

Fills the Getting Started gap that a new reader hits on `https://topograph.docs.buildwithfern.com/topograph`: the "Getting Started" section in the Fern nav currently contains only **Overview**, and the root README has no Quick Start. To actually install Topograph, a reader has to navigate to `charts/topograph/README.md` (chart-adjacent, not surfaced from the docs tree) or to `docs/engines/slurm.md` (buried under Engines, not Getting Started).

This PR adds two install-focused quickstarts under a new `docs/get-started/` directory:

- **[Install on Kubernetes](docs/get-started/quickstart-k8s.md)** — covers both the `k8s` engine (native K8s scheduling via node labels) and the `slinky` engine (Slurm-on-Kubernetes via ConfigMap) in one page with anchored subsections, since the two engines share the same Helm chart, the same prerequisites, and the same `helm test` verification. Engine-specific flags and verification are in anchored subsections so the Fern TOC exposes them.
- **[Install on Slurm](docs/get-started/quickstart-slurm.md)** — bare-metal Slurm install via `make deb` / `make rpm` + systemd. Separate file because the install mechanism, prerequisites, config surface, and verification are different paradigms from Helm-based Kubernetes installs — merging would force every section into \`if helm ... else rpm ...\` branches.

Each page is scoped narrowly: **prerequisites → install → verify → where to go next**. The Getting Started experience is the on-ramp; the existing engine references (\`docs/engines/k8s.md\`, \`docs/engines/slurm.md\`, \`docs/engines/slinky.md\`), chart README, provider docs, and API reference remain the authoritative deeper references and are linked from the "Where to go next" section on each page. Tutorial-depth content (demo workloads, KAI Scheduler gang-scheduling examples, \`podAffinity\` walkthroughs) is deliberately out of scope for these pages; that belongs in the Tech Blog tutorial and in future \`docs/integrations/\` pages.

Also adds:

- A **Quick Start** section to the root \`README.md\` that picks between the two paths (Kubernetes vs Slurm), so a reader landing via GitHub sees install guidance before the "Learn more" links.
- Two new entries under the Fern nav's existing "Getting Started" section (\`docs/index.yml\`): "Install on Kubernetes" and "Install on Slurm".

### Design notes

- **K8s + Slinky in one page**: the two engines share the Helm chart, prerequisites, install command base (varies only in \`--set global.engine.name=...\` and a few engine params), and \`helm test\` verification. A single page with section anchors avoids ~60% content duplication.
- **Slurm separate**: shares only the "pick a provider" concept and the \`/healthz\` endpoint with the K8s path. The install surface is fundamentally different.
- **Kubernetes 1.27+**: the quickstart-k8s.md Prerequisites section states 1.27+. This is enforced at install time by #291 (\`chore(chart): declare kubeVersion ">=1.27.0-0"\`). Once #291 merges, the claim is machine-checked; until then it's documentary.

## Checklist

- [x] Documentation Impact Evaluation — new docs directory added; Fern nav + root README updated in the same PR to reflect it
- [x] \`make qualify\` — N/A (docs-only, no Go changes)
- [x] Every commit has a DCO sign-off