### PR TITLE
fix: Docker buildkit proxy setting for nv-gh-runners

### DIFF
--- a/.github/workflows/docker-ib.yml
+++ b/.github/workflows/docker-ib.yml
@@ -50,6 +50,8 @@ jobs:
       # Set up Docker Buildx
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-config: /etc/buildkit/buildkitd.toml
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,6 +50,8 @@ jobs:
       # Set up Docker Buildx
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-config: /etc/buildkit/buildkitd.toml
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action


### PR DESCRIPTION
## Description
Adds the proxy settings for the docker build kit setup to avoid issues while using Nvidia GH runners.  

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).
