### PR TITLE
fix(ci): restore branches filter on Fern publish push trigger

### DIFF
--- a/.github/workflows/publish-fern-docs.yml
+++ b/.github/workflows/publish-fern-docs.yml
@@ -26,6 +26,8 @@ name: Publish Fern Docs
 
 on:
   push:
+    branches:
+      - main
     paths:
       - 'docs/**'
       - 'fern/**'


### PR DESCRIPTION
## Description

PR #268 removed the `branches: [main]` push filter from `.github/workflows/publish-fern-docs.yml` while keeping the `tags: [docs/v*]` filter. With GitHub Actions, defining `tags:` without a corresponding `branches:` restricts push events to tag refs only — branch pushes (including `main`) no longer trigger the workflow even when their changed paths match the `paths:` filter.

**Symptom**: the live Fern site at <https://topograph.docs.buildwithfern.com/topograph> has not been republished since the manual `workflow_dispatch` on 2026-04-20T16:51Z. PRs #284, #289, #290, #291, and #292 all touched `docs/` but produced zero workflow runs. The Reference section restored by #284 (and the clique-semantics clarifications added by #289) are on main but invisible on the published site.

**Fix**: restore `branches: [main]` so push events to main with `docs/` or `fern/` changes resume triggering publishes. Tag pushes for `docs/v*` and manual `workflow_dispatch` continue to work unchanged.

## Verification

After this merges, the workflow should fire automatically on the next docs-touching push to main. To clear the existing backlog (#284 → #292) immediately, run once:

```bash
gh workflow run publish-fern-docs.yml --repo NVIDIA/topograph --ref main
```

## Doc Impact

None — this is a CI-config fix; no doc surfaces (per AGENTS.md Documentation Impact Evaluation table).

## Checklist

- [x] `make qualify` not applicable (workflow YAML only)
- [x] Documentation impact evaluated — none
- [x] DCO sign-off present