### PR TITLE
docs(reference): clarify gpu.clique distinguishability vs proximity

### DIFF
--- a/docs/reference/node-labels.md
+++ b/docs/reference/node-labels.md
@@ -48,12 +48,12 @@ Workload schedulers consuming topology labels may need to choose between Topogra
 
 **Caveats when preferring `nvidia.com/gpu.clique`:**
 
-- The label covers only placement within a single MNNVL domain (one GB200 NVL72 rack): NVL Partition via the full `<ClusterUUID>.<CliqueID>` value, NVL Domain via the `ClusterUUID` prefix. Locality beyond that scope is not reflected:
-    - **Same top-of-rack switch** (cross-rack within a first-tier fabric) — see Topograph's `leaf` label.
-    - **Same second-tier aggregation** (typically Scalable-Unit / pod-scale grouping above individual racks) — see Topograph's `spine` label.
-    - **Same third-tier aggregation** (present in large three-tier fabrics — typically cross-SU grouping in multi-SU SuperPOD deployments) — see Topograph's `core` label.
+- The label encodes node identity within MNNVL domains, not fabric proximity between them. NVL Partition is encoded as the full `<ClusterUUID>.<CliqueID>` value; NVL Domain is encoded as the `ClusterUUID` prefix. A scheduler can therefore distinguish racks — two nodes with different `ClusterUUID` are in different NVL Domains — and act on that distinction (same-Domain affinity to pack a job onto a single rack, cross-Domain anti-affinity to spread independent jobs across racks). What the label does **not** encode is the *physical proximity* between Domains: `ClusterUUID`s are opaque identifiers, so the label cannot tell a scheduler which racks share a top-of-rack switch, an aggregation tier, or a core. For cross-rack proximity-aware placement, Topograph populates the following labels from the InfiniBand or NetQ providers regardless of whether `gpu.clique` is present:
+    - **Same top-of-rack switch** (cross-rack within a first-tier fabric) — Topograph's `leaf` label.
+    - **Same second-tier aggregation** (typically Scalable-Unit / pod-scale grouping above individual racks) — Topograph's `spine` label.
+    - **Same third-tier aggregation** (present in large three-tier fabrics — typically cross-SU grouping in multi-SU SuperPOD deployments) — Topograph's `core` label.
 
-  These labels are populated by the InfiniBand or NetQ providers regardless of whether `gpu.clique` is present, and are also relevant for mixed-workload fragmentation avoidance (see [`docs/engines/k8s.md` § Mixed Workload Considerations](../engines/k8s.md#mixed-workload-considerations)).
+  These labels are also relevant for mixed-workload fragmentation avoidance (see [`docs/engines/k8s.md` § Mixed Workload Considerations](../engines/k8s.md#mixed-workload-considerations)).
 - The label is refreshed by GPU Feature Discovery at its configured interval (the k8s-device-plugin default is 60s) rather than propagated instantly. Fabric-state changes in the window between refreshes are not yet reflected in the label.
 - Persistence of `ClusterUUID` / `CliqueID` across node reboots is administratively controlled via Fabric Manager's `FABRIC_MODE_RESTART` configuration (default: preserve partition configurations). Deployments that disable preservation may see identifiers change across restarts, which can invalidate scheduler state cached on those values.
 


### PR DESCRIPTION
## Description

The "Caveats when preferring `nvidia.com/gpu.clique`" bullet in `docs/reference/node-labels.md` previously read:

> The label covers only placement within a single MNNVL domain (one GB200 NVL72 rack) ... Locality beyond that scope is not reflected.

This wording conflated two distinct properties of the label and produced reader disagreement: by one reading the label cannot say anything across racks, by another it clearly *can* (different `ClusterUUID` → different rack, fully distinguishable).

Both readings are partially right but talking past each other:

- **Distinguishability across racks**: `gpu.clique` *does* support this. The `ClusterUUID` prefix uniquely identifies a Domain, so a scheduler can do **same-Domain affinity** ("pack a job onto a single rack") and **cross-Domain anti-affinity** ("spread independent jobs across racks").
- **Fabric proximity between racks**: `gpu.clique` does *not* encode this. `ClusterUUID`s are opaque identifiers, so the label cannot tell a scheduler which racks share a top-of-rack switch, which racks are in the same Scalable-Unit, etc. That information lives in `network.topology.nvidia.com/{leaf,spine,core}`, populated by the InfiniBand or NetQ providers.

This PR restructures the bullet to make the distinction explicit:

- distinguishability is acknowledged (and the affinity / anti-affinity uses it enables are named);
- the absent property is identified specifically as *physical/fabric proximity between Domains*, with a one-line justification (opaque identifiers);
- the `leaf` / `spine` / `core` sub-bullets are framed as the labels that *do* encode proximity, rather than as labels covering some unspecified missing "locality."

No content removed; no provider or scheduler behavior changes. Reference to `docs/engines/k8s.md` Mixed Workload Considerations preserved.

## Doc Impact

This *is* the doc change — `docs/reference/node-labels.md` only.

## Checklist

- [x] Documentation impact evaluated (per AGENTS.md table) — only `node-labels.md` touched.
- [x] DCO sign-off present.
- [x] No `pkg/topology/` or `protos/` changes.