### PR TITLE
fix(ci): harden Fern docs CI and configure custom domain

### DIFF
--- a/.github/workflows/fern-docs-ci.yml
+++ b/.github/workflows/fern-docs-ci.yml
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check markdown filename conventions
         run: |
@@ -47,7 +47,7 @@ jobs:
           fi
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
 
@@ -58,7 +58,7 @@ jobs:
         # Intentionally inline — a composite action would add indirection without benefit for a single grep.
         # Single-line grep is intentional — multiline <img> tags do not occur in practice in markdown docs.
         run: |
-          BAD=$(grep -rn '<img\b[^>]*[^/]>' docs/ fern/ --include="*.md" --include="*.mdx" || true)
+          BAD=$(grep -rn '<img\b[^>]*[^/]>\|<img>' docs/ fern/ --include="*.md" --include="*.mdx" || true)
           if [ -n "$BAD" ]; then
             echo "::error::Non-self-closing <img> tags found (MDX requires <img ... />):"
             echo "$BAD"
@@ -69,7 +69,7 @@ jobs:
         run: fern check
 
       - name: Check links
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           args: --offline --no-progress 'docs/**/*.md'
           fail: true

--- a/.github/workflows/fern-docs-preview-comment.yml
+++ b/.github/workflows/fern-docs-preview-comment.yml
@@ -53,7 +53,7 @@ jobs:
           echo "head_ref=$(cat preview-metadata/head_ref)" >> "$GITHUB_OUTPUT"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
 

--- a/.github/workflows/publish-fern-docs.yml
+++ b/.github/workflows/publish-fern-docs.yml
@@ -13,10 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Publishes the Fern documentation site when docs/ or fern/ changes land on
-# main, when a docs tag is pushed, or when manually triggered.
+# Publishes the Fern documentation site when a docs tag is pushed or manually triggered.
 #
-# To publish a versioned release: git tag docs/v1.2.0 && git push origin docs/v1.2.0
+# To publish:  git tag docs/v1.2.0 && git push origin docs/v1.2.0
 # Or use the "Run workflow" button in the Actions tab.
 #
 # Required configuration:
@@ -26,11 +25,6 @@ name: Publish Fern Docs
 
 on:
   push:
-    branches:
-      - main
-    paths:
-      - 'docs/**'
-      - 'fern/**'
     tags:
       - 'docs/v*'
   workflow_dispatch: {}
@@ -47,10 +41,10 @@ jobs:
     runs-on: linux-amd64-cpu8
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
 

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -5,8 +5,12 @@
 
 instances:
   - url: topograph.docs.buildwithfern.com/topograph
+    custom-domain: docs.nvidia.com/topograph
 
 title: NVIDIA Topograph
+
+metadata:
+  canonical-host: "docs.nvidia.com/topograph"
 
 products:
   - display-name: Topograph


### PR DESCRIPTION
## Description

Harden the Fern docs CI workflows and configure the production custom domain.

Closes #307

- Added MDX safety check step (non-self-closing `<img>` tags break Fern's MDX parser). Includes the bare `<img>` alternation found during nvcf-mono review.
- Pinned all GitHub Actions in Fern workflows to commit hashes (checkout v6.0.2, setup-node v6.4.0, lychee-action v2.8.0).
- Restricted publish trigger to `docs/v*` tag push only. To publish: `git tag docs/v1.2.0 && git push origin docs/v1.2.0`
- Added `custom-domain: docs.nvidia.com/topograph` and `canonical-host` metadata.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).