### PR TITLE
feat(fern): add versioned docs dropdown with CI version stamping

### DIFF
--- a/.github/workflows/publish-fern-docs.yml
+++ b/.github/workflows/publish-fern-docs.yml
@@ -51,6 +51,15 @@ jobs:
       - name: Install Fern CLI
         run: npm install -g fern-api@$(jq -r .version fern/fern.config.json)
 
+      - name: Stamp version in docs.yml
+        run: |
+          VERSION=$(curl -sf https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r .tag_name)
+          if [ -n "$VERSION" ] && [ "$VERSION" != "null" ]; then
+            sed -i 's/display-name: "Latest"/display-name: "Latest · '"${VERSION}"'"/' fern/docs.yml
+          fi
+          echo "--- docs.yml versions after stamp ---"
+          grep "display-name:" fern/docs.yml
+
       - name: Publish Docs
         env:
           FERN_TOKEN: ${{ secrets.DOCS_FERN_TOKEN }}

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -17,8 +17,15 @@ products:
     slug: /
     path: ../docs/index.yml
     versions:
-      - display-name: v0.3.0
+      # display-name is stamped by publish-fern-docs.yml at publish time
+      - display-name: "Latest"
         path: ../docs/index.yml
+        slug: latest
+        availability: stable
+      - display-name: "v0.3.0"
+        path: versions/v0.3.0.yml
+        slug: v0.3.0
+        availability: stable
 
 redirects:
   - source: "/topograph/index.html"

--- a/fern/versions/v0.3.0.yml
+++ b/fern/versions/v0.3.0.yml
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+navigation:
+  - section: Getting Started
+    contents:
+      - page: Overview
+        path: ../../docs/overview.md
+      - page: Install on Kubernetes
+        path: ../../docs/get-started/quickstart-k8s.md
+      - page: Install on Slurm
+        path: ../../docs/get-started/quickstart-slurm.md
+
+  - section: Architecture
+    contents:
+      - page: Architecture
+        path: ../../docs/architecture.md
+      - page: Config and API
+        path: ../../docs/api.md
+
+  - section: Providers
+    contents:
+      - page: AWS
+        path: ../../docs/providers/aws.md
+      - page: GCP
+        path: ../../docs/providers/gcp.md
+      - page: OCI
+        path: ../../docs/providers/oci.md
+      - page: Nebius
+        path: ../../docs/providers/nebius.md
+      - page: InfiniBand
+        path: ../../docs/providers/infiniband.md
+      - page: NetQ
+        path: ../../docs/providers/netq.md
+      - page: DRA
+        path: ../../docs/providers/dra.md
+      - page: Test
+        path: ../../docs/providers/test.md
+
+  - section: Engines
+    contents:
+      - page: SLURM
+        path: ../../docs/engines/slurm.md
+      - page: Kubernetes
+        path: ../../docs/engines/k8s.md
+      - page: Slinky
+        path: ../../docs/engines/slinky.md
+
+  - section: Reference
+    contents:
+      - page: Node Labels and Annotations
+        path: ../../docs/reference/node-labels.md


### PR DESCRIPTION
## Description

Add multi-version support to the Fern docs site, following the NeMo Curator pattern:

- `fern/docs.yml`: "Latest" version entry (stamped at publish time) plus frozen v0.3.0, both with `availability: stable` green badges
- `fern/versions/v0.3.0.yml`: frozen nav snapshot for the v0.3.0 release
- `publish-fern-docs.yml`: new "Stamp version" step queries the latest GitHub release and seds the display-name from `"Latest"` to `"Latest · vX.Y.Z"` before fern generate

At release time for future versions: copy `docs/index.yml` to `fern/versions/vX.Y.Z.yml` (adjusting paths to `../../docs/` prefix), add entry to `docs.yml`. Automation of the snapshot step is deferred.

Validated with `fern check` and local `fern docs dev` preview — dropdown shows both versions with Stable badges and correct navigation.

Fixes #312

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).