### PR TITLE
fix(fern): align v0.3.0 nav with actual tag content

### DIFF
--- a/.github/workflows/publish-fern-docs.yml
+++ b/.github/workflows/publish-fern-docs.yml
@@ -53,8 +53,14 @@ jobs:
             if git rev-parse "$version" >/dev/null 2>&1; then
               mkdir -p "fern/versions/${version}-content"
               git archive "$version" -- docs/ | tar -x --strip-components=1 -C "fern/versions/${version}-content"
-              # Fix MDX issues in older tags (e.g. non-self-closing <img> tags)
+              # Fix MDX issues in older tags
               find "fern/versions/${version}-content" -name '*.md' -exec sed -i 's/<img \([^>]*[^/]\)>/<img \1 \/>/g' {} +
+              # Fix broken relative image paths (e.g. engines/slinky.md referencing assets/ instead of ../assets/)
+              for subdir in "fern/versions/${version}-content"/*/; do
+                if [ ! -d "${subdir}assets" ] && [ -d "fern/versions/${version}-content/assets" ]; then
+                  ln -sf ../assets "${subdir}assets"
+                fi
+              done
               echo "Extracted docs from $version"
             else
               echo "::warning::Tag $version not found — skipping content checkout"

--- a/.github/workflows/publish-fern-docs.yml
+++ b/.github/workflows/publish-fern-docs.yml
@@ -53,6 +53,8 @@ jobs:
             if git rev-parse "$version" >/dev/null 2>&1; then
               mkdir -p "fern/versions/${version}-content"
               git archive "$version" -- docs/ | tar -x --strip-components=1 -C "fern/versions/${version}-content"
+              # Fix MDX issues in older tags (e.g. non-self-closing <img> tags)
+              find "fern/versions/${version}-content" -name '*.md' -exec sed -i 's/<img \([^>]*[^/]\)>/<img \1 \/>/g' {} +
               echo "Extracted docs from $version"
             else
               echo "::warning::Tag $version not found — skipping content checkout"

--- a/fern/versions/v0.3.0.yml
+++ b/fern/versions/v0.3.0.yml
@@ -2,22 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 navigation:
-  - section: Getting Started
-    contents:
-      - page: Overview
-        path: v0.3.0-content/overview.md
-      - page: Install on Kubernetes
-        path: v0.3.0-content/get-started/quickstart-k8s.md
-      - page: Install on Slurm
-        path: v0.3.0-content/get-started/quickstart-slurm.md
-
-  - section: Architecture
-    contents:
-      - page: Architecture
-        path: v0.3.0-content/architecture.md
-      - page: Config and API
-        path: v0.3.0-content/api.md
-
   - section: Providers
     contents:
       - page: AWS
@@ -28,14 +12,6 @@ navigation:
         path: v0.3.0-content/providers/oci.md
       - page: Nebius
         path: v0.3.0-content/providers/nebius.md
-      - page: InfiniBand
-        path: v0.3.0-content/providers/infiniband.md
-      - page: NetQ
-        path: v0.3.0-content/providers/netq.md
-      - page: DRA
-        path: v0.3.0-content/providers/dra.md
-      - page: Test
-        path: v0.3.0-content/providers/test.md
 
   - section: Engines
     contents:
@@ -45,8 +21,3 @@ navigation:
         path: v0.3.0-content/engines/k8s.md
       - page: Slinky
         path: v0.3.0-content/engines/slinky.md
-
-  - section: Reference
-    contents:
-      - page: Node Labels and Annotations
-        path: v0.3.0-content/reference/node-labels.md


### PR DESCRIPTION
## Description

The v0.3.0 frozen version nav was written against the current docs, not what existed at the `v0.3.0` git tag. The tag contains only 4 providers (aws, gcp, oci, nebius) and 3 engines (slurm, k8s, slinky). Pages added after v0.3.0 (overview, architecture, api, quickstarts, infiniband, netq, dra, test, node-labels) would cause Fern to fail when the publish workflow extracts content via `git archive`.

Strips the nav to match the tag content exactly.

Fixes #317

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).