### PR TITLE
fix(slinky): Skip exec scontrol show partition for DynamicNodes

### DIFF
--- a/pkg/engines/slinky/engine.go
+++ b/pkg/engines/slinky/engine.go
@@ -48,6 +48,8 @@ const (
 
 	ConfigUpdateModeNone         = "none"
 	ConfigUpdateModeSkeletonOnly = "skeleton-only"
+
+	dynamicShowPartitionNodes = "\tNodes=NONE"
 )
 
 type SlinkyEngine struct {
@@ -428,6 +430,11 @@ func (eng *SlinkyEngine) listPartitionNodes(ctx context.Context, sel *metav1.Lab
 }
 
 func (eng *SlinkyEngine) getPartitionNodes(ctx context.Context, partition string, params []any) (string, error) {
+	if eng.params.UseDynamicNodes {
+		klog.Infof("Skipping - scontrol show partition - when using useDynamicNodes flag")
+		return dynamicShowPartitionNodes, nil
+	}
+
 	if len(params) != 1 {
 		return "", fmt.Errorf("getPartitionNodes expects a namespace as a parameter")
 	}

--- a/pkg/engines/slurm/slurm.go
+++ b/pkg/engines/slurm/slurm.go
@@ -205,6 +205,10 @@ func GetPartitionNodes(ctx context.Context, partition string, f *TopologyNodeFin
 func parsePartitionNodes(partition string, data string) ([]string, error) {
 	match := partitionNodesRe.FindStringSubmatch(data)
 	if len(match) > 1 {
+		// If the nodes are NONE, return an empty list
+		if match[1] == "NONE" {
+			return []string{}, nil
+		}
 		return cluset.Compact(cluset.ExpandList(match[1])), nil
 	}
 


### PR DESCRIPTION
Skip `exec scontrol show partition` when useDynamicNodes is set

## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).
