### PR TITLE
fix(slinky): tighten pods exec RBAC for partition discovery

### DIFF
--- a/charts/topograph/templates/rbac.yaml
+++ b/charts/topograph/templates/rbac.yaml
@@ -1,4 +1,29 @@
 {{- if .Values.serviceAccount.create -}}
+{{- /*
+pods/exec is needed by providers that exec inside pods, and by Slinky only for
+legacy partition discovery through `scontrol show partition` in a login pod.
+Slinky skips that path when dynamic nodes are enabled or when a topology entry
+already supplies nodes, a pod selector, or the default flat topology.
+*/ -}}
+{{- $needsPodExec := dict "value" false -}}
+{{- if eq .Values.global.provider.name "infiniband-k8s" -}}
+{{- $_ := set $needsPodExec "value" true -}}
+{{- end -}}
+{{- if eq .Values.global.engine.name "slinky" -}}
+{{- $params := default dict .Values.global.engine.params -}}
+{{- if not (get $params "useDynamicNodes") -}}
+{{- range $topology := (default dict (get $params "topologies")) -}}
+{{- $spec := default dict $topology -}}
+{{- $hasNodes := hasKey $spec "nodes" -}}
+{{- $podSelector := get $spec "podSelector" -}}
+{{- $hasPodSelector := and $podSelector (or (get $podSelector "matchLabels") (get $podSelector "matchExpressions")) -}}
+{{- $isDefaultFlat := and (get $spec "clusterDefault") (eq (get $spec "plugin") "topology/flat") (not (get $spec "partition")) -}}
+{{- if and (not $hasNodes) (not $hasPodSelector) (not $isDefaultFlat) -}}
+{{- $_ := set $needsPodExec "value" true -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -7,9 +32,11 @@ rules:
 - apiGroups: [""]
   resources: [pods]
   verbs: [get,list]
+{{- if $needsPodExec.value }}
 - apiGroups: [""]
   resources: [pods/exec]
   verbs: [create]
+{{- end }}
 - apiGroups: [""]
   resources: [nodes]
   verbs: [get,list,update]

--- a/pkg/engines/slinky/engine.go
+++ b/pkg/engines/slinky/engine.go
@@ -159,7 +159,7 @@ func getParameters(params engines.Config) (*Params, error) {
 		if t == nil {
 			return nil, fmt.Errorf("topology %q: nil entry", name)
 		}
-		if len(t.Nodes) != 0 && !isEmptySelector(&t.PodSelector) {
+		if t.Nodes != nil && !isEmptySelector(&t.PodSelector) {
 			return nil, fmt.Errorf("topology %q: cannot set both nodes and podSelector", name)
 		}
 	}

--- a/pkg/engines/slinky/engine_test.go
+++ b/pkg/engines/slinky/engine_test.go
@@ -823,22 +823,40 @@ func TestResolveTopologies(t *testing.T) {
 }
 
 func TestGetParametersTopologyValidation(t *testing.T) {
-	params := map[string]any{
-		topology.KeyNamespace:         "test-ns",
-		topology.KeyPodSelector:       map[string]any{"matchLabels": map[string]string{"app": "slurm"}},
-		topology.KeyTopoConfigPath:    "topology.conf",
-		topology.KeyTopoConfigmapName: "slurm-config",
-		"topologies": map[string]any{
-			"bad": map[string]any{
-				"plugin": topology.TopologyTree,
-				"nodes":  []string{"n1"},
-				"podSelector": map[string]any{
-					"matchLabels": map[string]string{"partition": "a"},
-				},
-			},
+	testCases := []struct {
+		name  string
+		nodes any
+	}{
+		{
+			name:  "non-empty nodes and pod selector",
+			nodes: []string{"n1"},
+		},
+		{
+			name:  "empty nodes and pod selector",
+			nodes: []string{},
 		},
 	}
 
-	_, err := getParameters(params)
-	require.ErrorContains(t, err, `cannot set both nodes and podSelector`)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			params := map[string]any{
+				topology.KeyNamespace:         "test-ns",
+				topology.KeyPodSelector:       map[string]any{"matchLabels": map[string]string{"app": "slurm"}},
+				topology.KeyTopoConfigPath:    "topology.conf",
+				topology.KeyTopoConfigmapName: "slurm-config",
+				"topologies": map[string]any{
+					"bad": map[string]any{
+						"plugin": topology.TopologyTree,
+						"nodes":  tc.nodes,
+						"podSelector": map[string]any{
+							"matchLabels": map[string]string{"partition": "a"},
+						},
+					},
+				},
+			}
+
+			_, err := getParameters(params)
+			require.ErrorContains(t, err, `cannot set both nodes and podSelector`)
+		})
+	}
 }

--- a/pkg/engines/slurm/slurm.go
+++ b/pkg/engines/slurm/slurm.go
@@ -292,7 +292,7 @@ func GetTranslateConfig(ctx context.Context, params *BaseParams, topologies map[
 				ClusterDefault: sect.Default,
 			}
 			klog.InfoS("Adding partition topology", "name", topo, "plugin", sect.Plugin, "default", sect.Default, "partition", sect.Partition)
-			if len(sect.Nodes) != 0 {
+			if sect.Nodes != nil {
 				klog.V(4).Infof("%s %q provides nodes %v", sect.Plugin, topo, sect.Nodes)
 				spec.Nodes = sect.Nodes
 			} else {

--- a/pkg/engines/slurm/slurm_test.go
+++ b/pkg/engines/slurm/slurm_test.go
@@ -19,6 +19,7 @@ package slurm
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"testing"
 
@@ -226,6 +227,7 @@ func TestGetTranslateConfig(t *testing.T) {
 		name       string
 		params     *BaseParams
 		topologies map[string]*Topology
+		finder     *TopologyNodeFinder
 		cfg        *translate.Config
 		err        string
 	}{
@@ -289,11 +291,35 @@ func TestGetTranslateConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:   "Case 5: explicit empty nodes do not use partition discovery",
+			params: &BaseParams{},
+			topologies: map[string]*Topology{
+				"topo": {
+					Plugin:    topology.TopologyFlat,
+					Partition: "would-fallback-without-explicit-nodes",
+					Nodes:     []string{},
+				},
+			},
+			finder: &TopologyNodeFinder{
+				GetPartitionNodes: func(context.Context, string, []any) (string, error) {
+					return "", errors.New("unexpected partition discovery")
+				},
+			},
+			cfg: &translate.Config{
+				Topologies: map[string]*translate.TopologySpec{
+					"topo": {
+						Plugin: topology.TopologyFlat,
+						Nodes:  []string{},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg, err := GetTranslateConfig(ctx, tc.params, tc.topologies, nil)
+			cfg, err := GetTranslateConfig(ctx, tc.params, tc.topologies, tc.finder)
 			if len(tc.err) != 0 {
 				require.EqualError(t, err, tc.err)
 			} else {


### PR DESCRIPTION
## Description
Grant pods/exec only when Slinky may use legacy partition discovery.
Treat explicit empty node lists as resolved so they do not fall back to
scontrol, keeping runtime behavior aligned with rendered RBAC.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).
