### PR TITLE
fix(ci): populate frozen version content in preview build and surface fern errors

### DIFF
--- a/.github/workflows/fern-docs-preview-build.yml
+++ b/.github/workflows/fern-docs-preview-build.yml
@@ -60,6 +60,27 @@ jobs:
           echo "$BRANCH_NAME" > preview-metadata/head_ref
           git diff --name-only "origin/main...HEAD" -- '*.md' > preview-metadata/changed_md_files 2>/dev/null || true
 
+      - name: Checkout frozen version content
+        run: |
+          set -eo pipefail
+          for version_file in fern/versions/v*.yml; do
+            [ -f "$version_file" ] || continue
+            version=$(basename "$version_file" .yml)
+            if git rev-parse "$version" >/dev/null 2>&1; then
+              mkdir -p "fern/versions/${version}-content"
+              git archive "$version" -- docs/ | tar -x --strip-components=1 -C "fern/versions/${version}-content"
+              find "fern/versions/${version}-content" -name '*.md' -exec sed -i 's/<img \([^>]*[^/]\)>/<img \1 \/>/g' {} +
+              for subdir in "fern/versions/${version}-content"/*/; do
+                if [ ! -d "${subdir}assets" ] && [ -d "fern/versions/${version}-content/assets" ]; then
+                  ln -sf ../assets "${subdir}assets"
+                fi
+              done
+              echo "Extracted docs from $version"
+            else
+              echo "::warning::Tag $version not found — skipping content checkout"
+            fi
+          done
+
       - name: Upload fern sources and metadata
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/.github/workflows/fern-docs-preview-comment.yml
+++ b/.github/workflows/fern-docs-preview-comment.yml
@@ -67,9 +67,9 @@ jobs:
           HEAD_REF: ${{ steps.metadata.outputs.head_ref }}
         working-directory: ./fern
         run: |
-          OUTPUT=$(fern generate --docs --preview --id "$HEAD_REF" 2>&1)
-          echo "$OUTPUT"
-          URL=$(echo "$OUTPUT" | grep -oP 'Published docs to \K.*(?= \()')
+          set -o pipefail
+          fern generate --docs --preview --id "$HEAD_REF" 2>&1 | tee /tmp/fern-output.log
+          URL=$(grep -oP 'Published docs to \K.*(?= \()' /tmp/fern-output.log || true)
           if [ -z "$URL" ]; then
             echo "::error::Failed to generate preview URL. See fern output above."
             exit 1


### PR DESCRIPTION
## Description

Two fixes for the Fern preview pipeline:

1. **Preview build missing frozen version content** — Since #316, `fern/versions/v0.3.0.yml` references `v0.3.0-content/` which is populated by `git archive` at publish time. The preview build workflow (`fern-docs-preview-build.yml`) did not include this step, so the artifact shipped an empty directory. Every PR touching `docs/` or `fern/` has been failing preview generation since #316 merged. Adds the same `git archive` loop from the publish workflow.

2. **Preview comment swallows fern errors** — The `Generate preview URL` step in `fern-docs-preview-comment.yml` used `OUTPUT=$(fern generate --docs --preview ... 2>&1)`, which swallows fern's error output on failure (`bash -e` aborts before `echo "$OUTPUT"` runs). Switches to `tee`-based streaming, matching the pattern already in the publish workflow since #284.

Fixes #321

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).