### PR TITLE
feat(fern): add v0.4.0 version entry and automate version registration

### DIFF
--- a/.github/workflows/publish-fern-docs.yml
+++ b/.github/workflows/publish-fern-docs.yml
@@ -15,6 +15,11 @@
 
 # Publishes the Fern documentation site when a docs tag is pushed or manually triggered.
 #
+# On a docs/vX.Y.Z tag push the workflow also:
+#   1. Generates fern/versions/vX.Y.Z.yml from the tag's docs/index.yml
+#   2. Adds a version entry to fern/docs.yml
+#   3. Commits both back to main so future publishes include the new version
+#
 # To publish:  git tag docs/v1.2.0 && git push origin docs/v1.2.0
 # Or use the "Run workflow" button in the Actions tab.
 #
@@ -30,7 +35,7 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: fern-publish
@@ -44,11 +49,64 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-tags: true
+          ref: main
+
+      - name: Register new version from tag
+        if: startsWith(github.ref, 'refs/tags/docs/v')
+        run: |
+          set -eo pipefail
+          TAG_VERSION="${GITHUB_REF#refs/tags/docs/}"  # e.g. v0.4.0
+
+          # Skip if version file already exists
+          if [ -f "fern/versions/${TAG_VERSION}.yml" ]; then
+            echo "Version file fern/versions/${TAG_VERSION}.yml already exists — skipping"
+            exit 0
+          fi
+
+          # Extract index.yml from the matching release tag
+          if ! git rev-parse "$TAG_VERSION" >/dev/null 2>&1; then
+            echo "::warning::Release tag $TAG_VERSION not found — cannot create version entry"
+            exit 0
+          fi
+
+          # Generate version nav from the tag's docs/index.yml
+          echo "Generating fern/versions/${TAG_VERSION}.yml from tag $TAG_VERSION"
+          git archive "$TAG_VERSION" -- docs/index.yml | tar -xO docs/index.yml | \
+            sed "s|path: |path: ${TAG_VERSION}-content/|g" > "fern/versions/${TAG_VERSION}.yml"
+
+          # Add version entry to docs.yml (insert before the first existing version)
+          # Find the line number of the first versioned entry (after "Latest")
+          INSERT_LINE=$(grep -n 'availability: stable' fern/docs.yml | head -1 | cut -d: -f1)
+          if [ -n "$INSERT_LINE" ]; then
+            sed -i "${INSERT_LINE}a\\
+      - display-name: \"${TAG_VERSION}\"\\
+        path: versions/${TAG_VERSION}.yml\\
+        slug: ${TAG_VERSION}\\
+        availability: stable" fern/docs.yml
+          fi
+
+          echo "--- docs.yml versions ---"
+          grep "display-name:" fern/docs.yml
+
+      - name: Commit new version entry
+        if: startsWith(github.ref, 'refs/tags/docs/v')
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/docs/}"
+          if git diff --quiet fern/; then
+            echo "No version changes to commit"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add fern/versions/ fern/docs.yml
+          git commit -m "chore(fern): add ${TAG_VERSION} version entry [automated]"
+          git push origin main
 
       - name: Checkout frozen version content
         run: |
           set -eo pipefail
           for version_file in fern/versions/v*.yml; do
+            [ -f "$version_file" ] || continue
             version=$(basename "$version_file" .yml)
             if git rev-parse "$version" >/dev/null 2>&1; then
               mkdir -p "fern/versions/${version}-content"
@@ -89,11 +147,6 @@ jobs:
           FERN_TOKEN: ${{ secrets.DOCS_FERN_TOKEN }}
         working-directory: ./fern
         run: |
-          # Stream fern's output to both the Actions log (via tee) and a temp
-          # file for URL extraction. The prior shape `OUTPUT=$(fern ... 2>&1)`
-          # swallowed fern's error output on failure because `bash -e` would
-          # abort on fern's non-zero exit before the subsequent `echo "$OUTPUT"`
-          # ran, leaving failed publishes with no diagnostic in the log.
           set -o pipefail
           fern generate --docs 2>&1 | tee /tmp/fern-output.log
           URL=$(grep -oP 'Published docs to \K.*(?= \()' /tmp/fern-output.log || true)

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -22,6 +22,10 @@ products:
         path: ../docs/index.yml
         slug: latest
         availability: stable
+      - display-name: "v0.4.0"
+        path: versions/v0.4.0.yml
+        slug: v0.4.0
+        availability: stable
       - display-name: "v0.3.0"
         path: versions/v0.3.0.yml
         slug: v0.3.0

--- a/fern/versions/v0.4.0.yml
+++ b/fern/versions/v0.4.0.yml
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+navigation:
+  - section: Getting Started
+    contents:
+      - page: Overview
+        path: v0.4.0-content/overview.md
+      - page: Install on Kubernetes
+        path: v0.4.0-content/get-started/quickstart-k8s.md
+      - page: Install on Slurm
+        path: v0.4.0-content/get-started/quickstart-slurm.md
+
+  - section: Architecture
+    contents:
+      - page: Architecture
+        path: v0.4.0-content/architecture.md
+      - page: Config and API
+        path: v0.4.0-content/api.md
+      - page: Modeling and API Simulation
+        path: v0.4.0-content/modeling.md
+
+  - section: Providers
+    contents:
+      - page: AWS
+        path: v0.4.0-content/providers/aws.md
+      - page: GCP
+        path: v0.4.0-content/providers/gcp.md
+      - page: OCI
+        path: v0.4.0-content/providers/oci.md
+      - page: Nebius
+        path: v0.4.0-content/providers/nebius.md
+      - page: Nscale
+        path: v0.4.0-content/providers/nscale.md
+      - page: InfiniBand
+        path: v0.4.0-content/providers/infiniband.md
+      - page: NetQ
+        path: v0.4.0-content/providers/netq.md
+      - page: DRA
+        path: v0.4.0-content/providers/dra.md
+      - page: Test
+        path: v0.4.0-content/providers/test.md
+
+  - section: Engines
+    contents:
+      - page: SLURM
+        path: v0.4.0-content/engines/slurm.md
+      - page: Kubernetes
+        path: v0.4.0-content/engines/k8s.md
+      - page: Slinky
+        path: v0.4.0-content/engines/slinky.md
+
+  - section: Reference
+    contents:
+      - page: Node Labels and Annotations
+        path: v0.4.0-content/reference/node-labels.md


### PR DESCRIPTION
## Description

v0.4.0 was tagged and released but no version entry was created in the docs dropdown. The publish workflow only stamped "Latest" and extracted content for existing version entries — it did not register new ones.

This PR:
- Adds `fern/versions/v0.4.0.yml` with full nav (manually includes `providers/nscale.md` which exists in the tag but was omitted from the tag's `docs/index.yml`)
- Adds v0.4.0 entry to `fern/docs.yml`
- Automates future version registration: on `docs/vX.Y.Z` tag push, the publish workflow generates the version nav from the tag's `index.yml`, adds the entry to `docs.yml`, and commits both back to main
- Bumps permissions to `contents: write` for the commit-back step

After merge, trigger the publish workflow manually from the Actions tab to publish v0.4.0 content.

Fixes #324

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).