### PR TITLE
fix(ci): use heredoc for version entry insertion to avoid YAML parse error

### DIFF
--- a/.github/workflows/publish-fern-docs.yml
+++ b/.github/workflows/publish-fern-docs.yml
@@ -74,16 +74,23 @@ jobs:
           git archive "$TAG_VERSION" -- docs/index.yml | tar -xO docs/index.yml | \
             sed "s|path: |path: ${TAG_VERSION}-content/|g" > "fern/versions/${TAG_VERSION}.yml"
 
-          # Add version entry to docs.yml (insert before the first existing version)
-          # Find the line number of the first versioned entry (after "Latest")
-          INSERT_LINE=$(grep -n 'availability: stable' fern/docs.yml | head -1 | cut -d: -f1)
-          if [ -n "$INSERT_LINE" ]; then
-            sed -i "${INSERT_LINE}a\\
-      - display-name: \"${TAG_VERSION}\"\\
-        path: versions/${TAG_VERSION}.yml\\
-        slug: ${TAG_VERSION}\\
-        availability: stable" fern/docs.yml
-          fi
+          # Add version entry to docs.yml after the first "availability: stable" line
+          python3 - "$TAG_VERSION" <<'PYEOF'
+import sys
+v = sys.argv[1]
+entry = (
+    '      - display-name: "' + v + '"\n'
+    '        path: versions/' + v + '.yml\n'
+    '        slug: ' + v + '\n'
+    '        availability: stable\n'
+)
+lines = open('fern/docs.yml').readlines()
+for i, line in enumerate(lines):
+    if 'availability: stable' in line:
+        lines.insert(i + 1, entry)
+        break
+open('fern/docs.yml', 'w').writelines(lines)
+PYEOF
 
           echo "--- docs.yml versions ---"
           grep "display-name:" fern/docs.yml


### PR DESCRIPTION
## Description

The `Register new version from tag` step in `publish-fern-docs.yml` uses `sed -i` to insert a version entry into `fern/docs.yml`. The inserted lines (`display-name:`, `path:`, `slug:`, `availability:`) sit at the workflow step indentation level, causing GitHub Actions' YAML parser to interpret them as step properties rather than string content inside the `run:` block.

This broke the publish workflow on the `docs/v0.4.0` tag push: https://github.com/NVIDIA/topograph/actions/runs/25889196025

Fix: replace the sed append with a `python3` heredoc block (`<<'PYEOF'`) that the Actions YAML parser won't interpret.

Fixes #324

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).