### PR TITLE
fix(ci): use yq for YAML manipulation in publish workflow

### DIFF
--- a/.github/workflows/publish-fern-docs.yml
+++ b/.github/workflows/publish-fern-docs.yml
@@ -41,6 +41,9 @@ concurrency:
   group: fern-publish
   cancel-in-progress: true
 
+env:
+  YQ_VERSION: v4.53.2
+
 jobs:
   publish:
     runs-on: linux-amd64-cpu8
@@ -53,7 +56,7 @@ jobs:
 
       - name: Install yq
         run: |
-          curl -sSfL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o /usr/local/bin/yq
+          curl -sSfL "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -o /usr/local/bin/yq
           chmod +x /usr/local/bin/yq
 
       - name: Register new version from tag
@@ -80,7 +83,8 @@ jobs:
             sed "s|path: |path: ${TAG_VERSION}-content/|g" > "fern/versions/${TAG_VERSION}.yml"
 
           # Add version entry to docs.yml (insert after Latest, before older versions)
-          yq -i '.products[0].versions |= [.[0]] + [{"display-name": "'"${TAG_VERSION}"'", "path": "versions/'"${TAG_VERSION}"'.yml", "slug": "'"${TAG_VERSION}"'", "availability": "stable"}] + .[1:]' fern/docs.yml
+          export TAG_VERSION
+          yq -i '.products[0].versions |= [.[0]] + [{"display-name": env(TAG_VERSION), "path": "versions/" + env(TAG_VERSION) + ".yml", "slug": env(TAG_VERSION), "availability": "stable"}] + .[1:]' fern/docs.yml
 
           echo "--- docs.yml versions ---"
           grep "display-name:" fern/docs.yml
@@ -134,7 +138,8 @@ jobs:
         run: |
           VERSION=$(curl -sf https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r .tag_name)
           if [ -n "$VERSION" ] && [ "$VERSION" != "null" ]; then
-            yq -i '(.products[0].versions[] | select(.slug == "latest")).display-name = "Latest · '"${VERSION}"'"' fern/docs.yml
+            export VERSION
+            yq -i '(.products[0].versions[] | select(.slug == "latest")).display-name = "Latest · " + env(VERSION)' fern/docs.yml
           fi
           echo "--- docs.yml versions after stamp ---"
           yq '.products[0].versions[].display-name' fern/docs.yml

--- a/.github/workflows/publish-fern-docs.yml
+++ b/.github/workflows/publish-fern-docs.yml
@@ -51,6 +51,11 @@ jobs:
           fetch-tags: true
           ref: main
 
+      - name: Install yq
+        run: |
+          curl -sSfL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o /usr/local/bin/yq
+          chmod +x /usr/local/bin/yq
+
       - name: Register new version from tag
         if: startsWith(github.ref, 'refs/tags/docs/v')
         run: |
@@ -74,23 +79,8 @@ jobs:
           git archive "$TAG_VERSION" -- docs/index.yml | tar -xO docs/index.yml | \
             sed "s|path: |path: ${TAG_VERSION}-content/|g" > "fern/versions/${TAG_VERSION}.yml"
 
-          # Add version entry to docs.yml after the first "availability: stable" line
-          python3 - "$TAG_VERSION" <<'PYEOF'
-import sys
-v = sys.argv[1]
-entry = (
-    '      - display-name: "' + v + '"\n'
-    '        path: versions/' + v + '.yml\n'
-    '        slug: ' + v + '\n'
-    '        availability: stable\n'
-)
-lines = open('fern/docs.yml').readlines()
-for i, line in enumerate(lines):
-    if 'availability: stable' in line:
-        lines.insert(i + 1, entry)
-        break
-open('fern/docs.yml', 'w').writelines(lines)
-PYEOF
+          # Add version entry to docs.yml (insert after Latest, before older versions)
+          yq -i '.products[0].versions |= [.[0]] + [{"display-name": "'"${TAG_VERSION}"'", "path": "versions/'"${TAG_VERSION}"'.yml", "slug": "'"${TAG_VERSION}"'", "availability": "stable"}] + .[1:]' fern/docs.yml
 
           echo "--- docs.yml versions ---"
           grep "display-name:" fern/docs.yml
@@ -144,10 +134,10 @@ PYEOF
         run: |
           VERSION=$(curl -sf https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r .tag_name)
           if [ -n "$VERSION" ] && [ "$VERSION" != "null" ]; then
-            sed -i 's/display-name: "Latest"/display-name: "Latest · '"${VERSION}"'"/' fern/docs.yml
+            yq -i '(.products[0].versions[] | select(.slug == "latest")).display-name = "Latest · '"${VERSION}"'"' fern/docs.yml
           fi
           echo "--- docs.yml versions after stamp ---"
-          grep "display-name:" fern/docs.yml
+          yq '.products[0].versions[].display-name' fern/docs.yml
 
       - name: Publish Docs
         env:


### PR DESCRIPTION
## Description

The heredoc approach from #327 still has YAML parse issues. Replace all sed/python YAML manipulation in the publish workflow with `yq` for proper structured read/write.

- New `Install yq` step
- Version entry insertion uses `yq` array splice (insert after Latest, before older versions)
- Latest display-name stamp uses `yq` select + update
- Tested locally with simulated tag versions — correct ordering, valid YAML output

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).