### PR TITLE
fix(ci): install yq to user-local path with arch detection

### DIFF
--- a/.github/workflows/publish-fern-docs.yml
+++ b/.github/workflows/publish-fern-docs.yml
@@ -56,8 +56,20 @@ jobs:
 
       - name: Install yq
         run: |
-          curl -sSfL "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -o /usr/local/bin/yq
-          chmod +x /usr/local/bin/yq
+          if command -v yq &>/dev/null; then
+            echo "yq already installed: $(yq --version)"
+          else
+            OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+            ARCH=$(uname -m)
+            case "$ARCH" in
+              x86_64)  ARCH="amd64" ;;
+              aarch64) ARCH="arm64" ;;
+            esac
+            mkdir -p "$HOME/.local/bin"
+            curl -sSfL "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_${OS}_${ARCH}" -o "$HOME/.local/bin/yq"
+            chmod +x "$HOME/.local/bin/yq"
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          fi
 
       - name: Register new version from tag
         if: startsWith(github.ref, 'refs/tags/docs/v')


### PR DESCRIPTION
## Description

The yq install step in `publish-fern-docs.yml` writes to `/usr/local/bin`, which is not writable on the NVIDIA self-hosted runners. This caused the publish workflow to fail: https://github.com/NVIDIA/topograph/actions/runs/25926303353

Fix:
- Skip install if `yq` is already on the runner
- Otherwise install to `$HOME/.local/bin` and append to `$GITHUB_PATH`
- Detect OS/arch via `uname` instead of hardcoding `linux_amd64`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).