### PR TITLE
feat(build): opt-in env-var knobs for downstream packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,4 +95,4 @@ ssl:
 
 .PHONY: deb rpm
 deb rpm: build
-	ARCH=$(GOARCH) scripts/build-$@.sh $(GIT_REF)
+	ARCH=$(GOARCH) scripts/build-$@.sh $(GIT_REF) $(PACKAGE_REVISION)

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -46,8 +46,16 @@ cp $REPO_HOME/config/topograph.service \
 # Build Debian package
 chmod -R 0755 $REPO_HOME/deb/topograph/DEBIAN
 
-dpkg-deb --build $REPO_HOME/deb/topograph
-DEB_FILE_PATH="${REPO_HOME}/bin/topograph-$1.${ARCH}.deb"
+# Optional overrides for downstream packagers:
+#   DEB_COMPRESSION  - passed to dpkg-deb -Z (default: dpkg-deb's xz)
+#   DEB_OUTPUT_DIR   - directory the .deb is written to (default: ${REPO_HOME}/bin)
+if [[ -n "${DEB_COMPRESSION}" ]]; then
+  dpkg-deb --build -Z"${DEB_COMPRESSION}" $REPO_HOME/deb/topograph
+else
+  dpkg-deb --build $REPO_HOME/deb/topograph
+fi
+DEB_OUTPUT_DIR="${DEB_OUTPUT_DIR:-${REPO_HOME}/bin}"
+DEB_FILE_PATH="${DEB_OUTPUT_DIR}/topograph-$1.${ARCH}.deb"
 
 # Create package parent directory
 mkdir -p $(dirname ${DEB_FILE_PATH})

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -32,5 +32,10 @@ cp $REPO_HOME/bin/topograph \
 
 rpmbuild --define "_topdir $REPO_HOME/rpmbuild" -bb --clean $REPO_HOME/rpmbuild/SPECS/topograph.spec
 
-mv $REPO_HOME/rpmbuild/RPMS/${ARCH}/topograph-${VERSION}-${RELEASE}.${ARCH}.rpm $REPO_HOME/bin/topograph-$1.${ARCH}.rpm
-echo "Created $REPO_HOME/bin/topograph-$1.${ARCH}.rpm"
+# Optional override for downstream packagers:
+#   RPM_OUTPUT_DIR - directory the .rpm is written to (default: ${REPO_HOME}/bin)
+RPM_OUTPUT_DIR="${RPM_OUTPUT_DIR:-${REPO_HOME}/bin}"
+mkdir -p "${RPM_OUTPUT_DIR}"
+RPM_OUTPUT_FILE="${RPM_OUTPUT_DIR}/topograph-$1.${ARCH}.rpm"
+mv $REPO_HOME/rpmbuild/RPMS/${ARCH}/topograph-${VERSION}-${RELEASE}.${ARCH}.rpm "${RPM_OUTPUT_FILE}"
+echo "Created ${RPM_OUTPUT_FILE}"


### PR DESCRIPTION
## Description

Adds four optional environment-variable knobs to `Makefile`, `scripts/build-deb.sh`, and `scripts/build-rpm.sh` so downstream packagers can customize the package suffix, `.deb` compression, and output paths without patching:

| Env var | Default | Effect |
|---|---|---|
| `PACKAGE_REVISION` | unset | Passed as `$2` to `build-{deb,rpm}.sh` (`RELEASE`) — both scripts already accept this |
| `DEB_COMPRESSION` | unset (`dpkg-deb` default) | Passed to `dpkg-deb -Z<value>` |
| `DEB_OUTPUT_DIR` | `${REPO_HOME}/bin` | Directory for the `.deb` |
| `RPM_OUTPUT_DIR` | `${REPO_HOME}/bin` | Directory for the `.rpm` |

Default behavior (no env vars set) is unchanged: `make deb` and `make rpm` produce the same file name, path, and compression as before. Context and motivation in #332.

Closes #332

## Checklist

- [x] Documentation Impact Evaluation — `make deb` / `make rpm` flow documented in `docs/get-started/quickstart-slurm.md`; the new knobs are advisory env-vars that don't change the documented happy path. No doc changes required.
- [x] `make qualify` — `fmt` and `vet` clean locally; `test` green; `lint` requires `golangci-lint` not installed in the local env, will run in CI. Patch is Makefile + shell only (no Go code), so all Go-targets are effectively no-ops for this change.
- [x] Every commit has a DCO sign-off