### PR TITLE
fix(build): quote DEB_OUTPUT_DIR-derived paths in build-deb.sh

### DIFF
--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -58,6 +58,6 @@ DEB_OUTPUT_DIR="${DEB_OUTPUT_DIR:-${REPO_HOME}/bin}"
 DEB_FILE_PATH="${DEB_OUTPUT_DIR}/topograph-$1.${ARCH}.deb"
 
 # Create package parent directory
-mkdir -p $(dirname ${DEB_FILE_PATH})
-mv $REPO_HOME/deb/topograph.deb ${DEB_FILE_PATH}
+mkdir -p "$(dirname "${DEB_FILE_PATH}")"
+mv "$REPO_HOME/deb/topograph.deb" "${DEB_FILE_PATH}"
 echo "Created ${DEB_FILE_PATH}"


### PR DESCRIPTION
## Description

Follow-up to #333. `DEB_OUTPUT_DIR` became caller-supplied in that PR, but the `mkdir` and `mv` operations that consume `DEB_FILE_PATH` stayed unquoted from the pre-existing pattern. A path containing spaces would silently misbehave (`mkdir` would create the wrong directory tree; `mv` would interpret the destination as multiple words).

Spotted in Greptile's review of #333.

```diff
-mkdir -p $(dirname ${DEB_FILE_PATH})
-mv $REPO_HOME/deb/topograph.deb ${DEB_FILE_PATH}
+mkdir -p "$(dirname "${DEB_FILE_PATH}")"
+mv "$REPO_HOME/deb/topograph.deb" "${DEB_FILE_PATH}"
```

## Checklist

- [x] `bash -n scripts/build-deb.sh` — syntax clean.
- [x] Default behavior (no `DEB_OUTPUT_DIR` set) unchanged — the variable expansions resolve to identical strings; quoting only affects how the shell splits them.
- [x] Every commit has a DCO sign-off.