### PR TITLE
fix(build): quote remaining $REPO_HOME-derived paths in build-deb.sh

### DIFF
--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -17,42 +17,42 @@ fi
 
 echo "Setting Debian package version to $VERSION"
 
-cp $REPO_HOME/deb/control $REPO_HOME/deb/topograph/DEBIAN/control
+cp "$REPO_HOME/deb/control" "$REPO_HOME/deb/topograph/DEBIAN/control"
 
-sed -i "s/__VERSION__/$VERSION/g" $REPO_HOME/deb/topograph/DEBIAN/control
-sed -i "s/__ARCH__/$ARCH/g" $REPO_HOME/deb/topograph/DEBIAN/control
+sed -i "s/__VERSION__/$VERSION/g" "$REPO_HOME/deb/topograph/DEBIAN/control"
+sed -i "s/__ARCH__/$ARCH/g" "$REPO_HOME/deb/topograph/DEBIAN/control"
 if [[ -n "${RELEASE}" ]]; then
-    sed -i "s/__RELEASE__/-${RELEASE}/g" $REPO_HOME/deb/topograph/DEBIAN/control
+    sed -i "s/__RELEASE__/-${RELEASE}/g" "$REPO_HOME/deb/topograph/DEBIAN/control"
 else
-    sed -i "s/__RELEASE__//g" $REPO_HOME/deb/topograph/DEBIAN/control
+    sed -i "s/__RELEASE__//g" "$REPO_HOME/deb/topograph/DEBIAN/control"
 fi
 
 # Copy binary
-mkdir -p $REPO_HOME/deb/topograph/usr/local/bin
-cp $REPO_HOME/bin/topograph $REPO_HOME/deb/topograph/usr/local/bin/
+mkdir -p "$REPO_HOME/deb/topograph/usr/local/bin"
+cp "$REPO_HOME/bin/topograph" "$REPO_HOME/deb/topograph/usr/local/bin/"
 
 # Copy config file and helper scripts
-mkdir -p $REPO_HOME/deb/topograph/etc/topograph
-cp $REPO_HOME/config/topograph-config.yaml \
-  $REPO_HOME/scripts/configure-ssl.sh \
-  $REPO_HOME/scripts/create-topology-update-script.sh \
-  $REPO_HOME/deb/topograph/etc/topograph
+mkdir -p "$REPO_HOME/deb/topograph/etc/topograph"
+cp "$REPO_HOME/config/topograph-config.yaml" \
+  "$REPO_HOME/scripts/configure-ssl.sh" \
+  "$REPO_HOME/scripts/create-topology-update-script.sh" \
+  "$REPO_HOME/deb/topograph/etc/topograph"
 
 # Copy service file
-mkdir -p $REPO_HOME/deb/topograph/lib/systemd/system
-cp $REPO_HOME/config/topograph.service \
-  $REPO_HOME/deb/topograph/lib/systemd/system
+mkdir -p "$REPO_HOME/deb/topograph/lib/systemd/system"
+cp "$REPO_HOME/config/topograph.service" \
+  "$REPO_HOME/deb/topograph/lib/systemd/system"
 
 # Build Debian package
-chmod -R 0755 $REPO_HOME/deb/topograph/DEBIAN
+chmod -R 0755 "$REPO_HOME/deb/topograph/DEBIAN"
 
 # Optional overrides for downstream packagers:
 #   DEB_COMPRESSION  - passed to dpkg-deb -Z (default: dpkg-deb's xz)
 #   DEB_OUTPUT_DIR   - directory the .deb is written to (default: ${REPO_HOME}/bin)
 if [[ -n "${DEB_COMPRESSION}" ]]; then
-  dpkg-deb --build -Z"${DEB_COMPRESSION}" $REPO_HOME/deb/topograph
+  dpkg-deb --build -Z"${DEB_COMPRESSION}" "$REPO_HOME/deb/topograph"
 else
-  dpkg-deb --build $REPO_HOME/deb/topograph
+  dpkg-deb --build "$REPO_HOME/deb/topograph"
 fi
 DEB_OUTPUT_DIR="${DEB_OUTPUT_DIR:-${REPO_HOME}/bin}"
 DEB_FILE_PATH="${DEB_OUTPUT_DIR}/topograph-$1.${ARCH}.deb"


### PR DESCRIPTION
## Description

Companion to #334. Quotes the rest of the `cp`/`sed`/`mkdir`/`chmod`/`dpkg-deb` arguments that consume `$REPO_HOME` so the script behaves correctly if the repository is ever checked out under a path containing spaces.

Greptile flagged these (lines 20-47, 53, 55 of the pre-#334 numbering) during review of #334 as worth a follow-up pass; this is that pass. No logic change — purely a defensive-quoting hygiene cleanup.

### What's covered

| Line(s) | Operation | Change |
|---|---|---|
| 20 | `cp` source + destination | both quoted |
| 22, 23, 25, 27 | `sed -i ... <file>` | file path quoted |
| 31 | `mkdir -p <dir>` | quoted |
| 32 | `cp` source + destination | both quoted |
| 35 | `mkdir -p <dir>` | quoted |
| 36-39 | multi-line `cp` (3 sources + 1 dest) | all 4 quoted |
| 42 | `mkdir -p <dir>` | quoted |
| 43-44 | multi-line `cp` (1 source + 1 dest) | both quoted |
| 47 | `chmod -R 0755 <dir>` | quoted |
| 53, 55 | `dpkg-deb --build <dir>` | argument quoted |

### What's not covered

- Lines 60-62 (the `mkdir -p $(dirname ${DEB_FILE_PATH})` + `mv ... ${DEB_FILE_PATH}` block) are the subject of #334 and not touched here. Both PRs can land in either order without conflict.
- `scripts/build-rpm.sh` has similar unquoted-`$REPO_HOME` patterns. Not in scope for this PR; happy to file a third tiny PR for parity if useful.

## Checklist

- [x] `bash -n scripts/build-deb.sh` — syntax clean.
- [x] 18 insertions / 18 deletions — pure 1:1 substitution, no logic delta.
- [x] Every commit has a DCO sign-off.