### PR TITLE
feat(ci): port AICR publish pattern — tag resolution, pruning, PR persistence

### DIFF
--- a/.github/workflows/fern-docs-preview-build.yml
+++ b/.github/workflows/fern-docs-preview-build.yml
@@ -66,10 +66,13 @@ jobs:
           for version_file in fern/versions/v*.yml; do
             [ -f "$version_file" ] || continue
             version=$(basename "$version_file" .yml)
-            if git rev-parse "$version" >/dev/null 2>&1; then
+            if git show-ref --verify --quiet "refs/tags/${version}"; then
               mkdir -p "fern/versions/${version}-content"
-              git archive "$version" -- docs/ | tar -x --strip-components=1 -C "fern/versions/${version}-content"
-              find "fern/versions/${version}-content" -name '*.md' -exec sed -i 's/<img \([^>]*[^/]\)>/<img \1 \/>/g' {} +
+              git archive "refs/tags/${version}" -- docs/ | tar -x --strip-components=1 -C "fern/versions/${version}-content"
+              find "fern/versions/${version}-content" -name '*.md' -print0 | xargs -0 -r sed -i \
+                -e 's/{/\\{/g' \
+                -e 's/}/\\}/g' \
+                -e 's/</\&lt;/g'
               for subdir in "fern/versions/${version}-content"/*/; do
                 if [ ! -d "${subdir}assets" ] && [ -d "fern/versions/${version}-content/assets" ]; then
                   ln -sf ../assets "${subdir}assets"

--- a/.github/workflows/publish-fern-docs.yml
+++ b/.github/workflows/publish-fern-docs.yml
@@ -13,15 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Publishes the Fern documentation site when a docs tag is pushed or manually triggered.
+# Publishes the Fern documentation site on release tag push or manual dispatch.
 #
-# On a docs/vX.Y.Z tag push the workflow also:
+# Manual dispatch accepts an optional `tag` input:
+#   - empty: resolves to the latest GitHub release tag
+#   - explicit (e.g. v0.5.0): publishes that tag
+#
+# On a vX.Y.Z release tag (push or dispatch), the workflow also:
 #   1. Generates fern/versions/vX.Y.Z.yml from the tag's docs/index.yml
 #   2. Adds a version entry to fern/docs.yml
-#   3. Commits both back to main so future publishes include the new version
+#   3. Prunes older versions to keep only the 3 most recent (plus Latest)
+#   4. Opens a PR to persist registry changes back to main (after publish)
 #
-# To publish:  git tag docs/v1.2.0 && git push origin docs/v1.2.0
-# Or use the "Run workflow" button in the Actions tab.
+# Pre-release tags (e.g. v0.5.0-rc1) trigger publish but skip version registration.
 #
 # Required configuration:
 # - Organization secret: DOCS_FERN_TOKEN (from `fern token` for the nvidia Fern org)
@@ -31,11 +35,17 @@ name: Publish Fern Docs
 on:
   push:
     tags:
-      - 'docs/v*'
-  workflow_dispatch: {}
+      - "v[0-9]*.[0-9]*.[0-9]*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (e.g. v0.5.0). Leave empty to use the latest GitHub release tag."
+        required: false
+        type: string
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: fern-publish
@@ -43,6 +53,7 @@ concurrency:
 
 env:
   YQ_VERSION: v4.53.2
+  MAX_VERSIONS: 3
 
 jobs:
   publish:
@@ -51,8 +62,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-tags: true
           ref: main
+          fetch-tags: true
 
       - name: Install yq
         run: |
@@ -71,49 +82,92 @@ jobs:
             echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           fi
 
-      - name: Register new version from tag
-        if: startsWith(github.ref, 'refs/tags/docs/v')
+      - name: Resolve target tag
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
           set -eo pipefail
-          TAG_VERSION="${GITHUB_REF#refs/tags/docs/}"  # e.g. v0.4.0
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+          elif [ -n "${INPUT_TAG}" ]; then
+            TAG="${INPUT_TAG}"
+          else
+            TAG=$(gh release view --repo "${GITHUB_REPOSITORY}" --json tagName -q .tagName)
+            if [ -z "$TAG" ] || [ "$TAG" = "null" ]; then
+              echo "::error::Could not determine latest release tag"
+              exit 1
+            fi
+          fi
+          if ! [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$ ]]; then
+            echo "::error::Tag '${TAG}' is not a valid semver tag (expected vMAJOR.MINOR.PATCH[-PRERELEASE])"
+            exit 1
+          fi
+          if ! git show-ref --verify --quiet "refs/tags/${TAG}"; then
+            echo "::error::Tag '${TAG}' does not exist in this repository"
+            exit 1
+          fi
+          if [[ "$TAG" == *-* ]]; then
+            IS_RELEASE=false
+          else
+            IS_RELEASE=true
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "is_release=$IS_RELEASE" >> "$GITHUB_OUTPUT"
+          echo "Resolved target tag: $TAG (is_release=$IS_RELEASE)"
+
+      - name: Register new version from tag
+        if: steps.resolve.outputs.is_release == 'true'
+        env:
+          TAG_VERSION: ${{ steps.resolve.outputs.tag }}
+        run: |
+          set -eo pipefail
 
           # Skip if version file already exists
           if [ -f "fern/versions/${TAG_VERSION}.yml" ]; then
-            echo "Version file fern/versions/${TAG_VERSION}.yml already exists — skipping"
-            exit 0
-          fi
-
-          # Extract index.yml from the matching release tag
-          if ! git rev-parse "$TAG_VERSION" >/dev/null 2>&1; then
-            echo "::warning::Release tag $TAG_VERSION not found — cannot create version entry"
+            echo "Version ${TAG_VERSION} already registered — skipping"
             exit 0
           fi
 
           # Generate version nav from the tag's docs/index.yml
           echo "Generating fern/versions/${TAG_VERSION}.yml from tag $TAG_VERSION"
-          git archive "$TAG_VERSION" -- docs/index.yml | tar -xO docs/index.yml | \
+          git archive "refs/tags/${TAG_VERSION}" -- docs/index.yml | tar -xO docs/index.yml | \
             sed "s|path: |path: ${TAG_VERSION}-content/|g" > "fern/versions/${TAG_VERSION}.yml"
 
           # Add version entry to docs.yml (insert after Latest, before older versions)
           export TAG_VERSION
-          yq -i '.products[0].versions |= [.[0]] + [{"display-name": env(TAG_VERSION), "path": "versions/" + env(TAG_VERSION) + ".yml", "slug": env(TAG_VERSION), "availability": "stable"}] + .[1:]' fern/docs.yml
+          EXPR='.products[0].versions |= [.[0]] + [{"display-name": env(TAG_VERSION),'
+          EXPR+=' "path": "versions/" + env(TAG_VERSION) + ".yml",'
+          EXPR+=' "slug": env(TAG_VERSION), "availability": "stable"}] + .[1:]'
+          yq -i "$EXPR" fern/docs.yml
 
-          echo "--- docs.yml versions ---"
-          grep "display-name:" fern/docs.yml
+          echo "--- docs.yml versions after insert ---"
+          yq '.products[0].versions[].display-name' fern/docs.yml
 
-      - name: Commit new version entry
-        if: startsWith(github.ref, 'refs/tags/docs/v')
+      - name: Prune old versions
+        if: steps.resolve.outputs.is_release == 'true'
         run: |
-          TAG_VERSION="${GITHUB_REF#refs/tags/docs/}"
-          if git diff --quiet fern/; then
-            echo "No version changes to commit"
+          set -eo pipefail
+          KEEP=$((MAX_VERSIONS + 1))  # +1 for the Latest entry at index 0
+          TOTAL=$(yq '.products[0].versions | length' fern/docs.yml)
+
+          if [ "$TOTAL" -le "$KEEP" ]; then
+            echo "Only $TOTAL versions — nothing to prune (keeping $KEEP)"
             exit 0
           fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add fern/versions/ fern/docs.yml
-          git commit -m "chore(fern): add ${TAG_VERSION} version entry [automated]"
-          git push origin main
+
+          # Remove excess entries from the end (oldest) and their version files
+          PRUNED=$(yq ".products[0].versions[$KEEP:][].slug" fern/docs.yml)
+          yq -i ".products[0].versions |= .[:$KEEP]" fern/docs.yml
+
+          for slug in $PRUNED; do
+            rm -f "fern/versions/${slug}.yml"
+            echo "Pruned $slug"
+          done
+
+          echo "--- docs.yml versions after prune ---"
+          yq '.products[0].versions[].display-name' fern/docs.yml
 
       - name: Checkout frozen version content
         run: |
@@ -121,12 +175,14 @@ jobs:
           for version_file in fern/versions/v*.yml; do
             [ -f "$version_file" ] || continue
             version=$(basename "$version_file" .yml)
-            if git rev-parse "$version" >/dev/null 2>&1; then
+            if git show-ref --verify --quiet "refs/tags/${version}"; then
               mkdir -p "fern/versions/${version}-content"
-              git archive "$version" -- docs/ | tar -x --strip-components=1 -C "fern/versions/${version}-content"
-              # Fix MDX issues in older tags
-              find "fern/versions/${version}-content" -name '*.md' -exec sed -i 's/<img \([^>]*[^/]\)>/<img \1 \/>/g' {} +
-              # Fix broken relative image paths (e.g. engines/slinky.md referencing assets/ instead of ../assets/)
+              git archive "refs/tags/${version}" -- docs/ | tar -x --strip-components=1 -C "fern/versions/${version}-content"
+              find "fern/versions/${version}-content" -name '*.md' -print0 | xargs -0 -r sed -i \
+                -e 's/{/\\{/g' \
+                -e 's/}/\\}/g' \
+                -e 's/</\&lt;/g'
+              # Fix broken relative image paths in older tags
               for subdir in "fern/versions/${version}-content"/*/; do
                 if [ ! -d "${subdir}assets" ] && [ -d "fern/versions/${version}-content/assets" ]; then
                   ln -sf ../assets "${subdir}assets"
@@ -134,9 +190,25 @@ jobs:
               done
               echo "Extracted docs from $version"
             else
-              echo "::warning::Tag $version not found — skipping content checkout"
+              echo "::error::Tag $version not found — cannot pin frozen docs content"
+              exit 1
             fi
           done
+
+      - name: Stamp version in docs.yml
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cp fern/docs.yml /tmp/docs.yml.preStamp
+          VERSION=$(gh api repos/${{ github.repository }}/releases/latest --jq .tag_name 2>/dev/null || true)
+          if [ -n "$VERSION" ] && [ "$VERSION" != "null" ]; then
+            export VERSION
+            yq -i '(.products[0].versions[] | select(.slug == "latest")).display-name = "Latest · " + env(VERSION)' fern/docs.yml
+          else
+            echo "::warning::Could not resolve latest GitHub release tag; continuing without stamping"
+          fi
+          echo "--- docs.yml versions after stamp ---"
+          yq '.products[0].versions[].display-name' fern/docs.yml
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -146,17 +218,7 @@ jobs:
       - name: Install Fern CLI
         run: npm install -g fern-api@$(jq -r .version fern/fern.config.json)
 
-      - name: Stamp version in docs.yml
-        run: |
-          VERSION=$(curl -sf https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r .tag_name)
-          if [ -n "$VERSION" ] && [ "$VERSION" != "null" ]; then
-            export VERSION
-            yq -i '(.products[0].versions[] | select(.slug == "latest")).display-name = "Latest · " + env(VERSION)' fern/docs.yml
-          fi
-          echo "--- docs.yml versions after stamp ---"
-          yq '.products[0].versions[].display-name' fern/docs.yml
-
-      - name: Publish Docs
+      - name: Publish docs
         env:
           FERN_TOKEN: ${{ secrets.DOCS_FERN_TOKEN }}
         working-directory: ./fern
@@ -167,3 +229,25 @@ jobs:
           if [ -n "$URL" ]; then
             echo "### Published: [$URL]($URL)" >> "$GITHUB_STEP_SUMMARY"
           fi
+
+      - name: Restore unstamped docs.yml for persistence
+        if: steps.resolve.outputs.is_release == 'true'
+        run: cp /tmp/docs.yml.preStamp fern/docs.yml
+
+      - name: Open PR for version registry changes
+        if: steps.resolve.outputs.is_release == 'true'
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          base: main
+          branch: chore/fern-register-${{ steps.resolve.outputs.tag }}
+          delete-branch: true
+          sign-commits: true
+          commit-message: "chore(fern): register ${{ steps.resolve.outputs.tag }}, keep latest ${{ env.MAX_VERSIONS }} versions [automated]"
+          title: "chore(fern): register ${{ steps.resolve.outputs.tag }}"
+          body: |
+            Automated registration of `${{ steps.resolve.outputs.tag }}` in the Fern docs versions registry.
+
+            Generated by the `Publish Fern Docs` workflow.
+          add-paths: |
+            fern/versions/v*.yml
+            fern/docs.yml


### PR DESCRIPTION
## Description

Port the AICR publish workflow pattern (NVIDIA/aicr#940, NVIDIA/NVSentinel#1293) to topograph. Addresses all 9 parity gaps identified in the cross-repo Fern CI assessment.

Changes to `publish-fern-docs.yml`:
- **Release tag trigger** — `v[0-9]*.[0-9]*.[0-9]*` instead of `docs/v*`
- **Resolve target tag** — semver validation, `workflow_dispatch` tag input, `gh release view` fallback
- **Pre-release handling** — tags like `v0.5.0-rc1` publish but skip version registration
- **Version pruning** — `MAX_VERSIONS: 3` keeps Latest + 3 most recent, prunes oldest
- **PR-based persistence** — `peter-evans/create-pull-request` instead of direct push to main
- **Pre-stamp backup** — restores unstamped `docs.yml` for persistence so transient stamp isn't committed
- **Full MDX sanitization** — escapes `{`, `}`, `<` in frozen content (not just `<img>` self-closing)
- **`git show-ref --verify`** — consistent tag verification
- **`gh api`** — replaces `curl` for release tag resolution

Changes to `fern-docs-preview-build.yml`:
- Full MDX sanitization (matching publish workflow)
- `git show-ref --verify` for tag checks

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).