### PR TITLE
fix(ci): skip version registration for latest release and sort by semver

### DIFF
--- a/.github/workflows/publish-fern-docs.yml
+++ b/.github/workflows/publish-fern-docs.yml
@@ -15,14 +15,18 @@
 
 # Publishes the Fern documentation site on release tag push or manual dispatch.
 #
+# All versions serve frozen content extracted from their git tag — there is no
+# "live docs" entry. The newest version is stamped "Latest · vX.Y.Z" at publish
+# time so readers know which is current; the stamp is transient and not persisted.
+#
 # Manual dispatch accepts an optional `tag` input:
 #   - empty: resolves to the latest GitHub release tag
 #   - explicit (e.g. v0.5.0): publishes that tag
 #
 # On a vX.Y.Z release tag (push or dispatch), the workflow also:
 #   1. Generates fern/versions/vX.Y.Z.yml from the tag's docs/index.yml
-#   2. Adds a version entry to fern/docs.yml
-#   3. Prunes older versions to keep only the 3 most recent (plus Latest)
+#   2. Adds a version entry to fern/docs.yml, sorted by semver descending
+#   3. Prunes older versions to keep only the MAX_VERSIONS most recent
 #   4. Opens a PR to persist registry changes back to main (after publish)
 #
 # Pre-release tags (e.g. v0.5.0-rc1) trigger publish but skip version registration.
@@ -113,23 +117,12 @@ jobs:
           else
             IS_RELEASE=true
           fi
-
-          # Skip registration when tag = latest release (Latest already covers it)
-          LATEST=$(gh release view --repo "${GITHUB_REPOSITORY}" --json tagName -q .tagName 2>/dev/null || true)
-          if [ "$IS_RELEASE" = "true" ] && [ "$TAG" = "$LATEST" ]; then
-            SHOULD_REGISTER=false
-            echo "Tag $TAG is the current latest release — will be shown as 'Latest · $TAG', skipping version entry"
-          else
-            SHOULD_REGISTER=$IS_RELEASE
-          fi
-
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "is_release=$IS_RELEASE" >> "$GITHUB_OUTPUT"
-          echo "should_register=$SHOULD_REGISTER" >> "$GITHUB_OUTPUT"
-          echo "Resolved target tag: $TAG (is_release=$IS_RELEASE, should_register=$SHOULD_REGISTER)"
+          echo "Resolved target tag: $TAG (is_release=$IS_RELEASE)"
 
       - name: Register new version from tag
-        if: steps.resolve.outputs.should_register == 'true'
+        if: steps.resolve.outputs.is_release == 'true'
         env:
           TAG_VERSION: ${{ steps.resolve.outputs.tag }}
         run: |
@@ -146,16 +139,16 @@ jobs:
           git archive "refs/tags/${TAG_VERSION}" -- docs/index.yml | tar -xO docs/index.yml | \
             sed "s|path: |path: ${TAG_VERSION}-content/|g" > "fern/versions/${TAG_VERSION}.yml"
 
-          # Add version entry to docs.yml (insert after Latest, before older versions)
+          # Add version entry to docs.yml
           export TAG_VERSION
-          EXPR='.products[0].versions |= [.[0]] + [{"display-name": env(TAG_VERSION),'
+          EXPR='.products[0].versions += [{"display-name": env(TAG_VERSION),'
           EXPR+=' "path": "versions/" + env(TAG_VERSION) + ".yml",'
-          EXPR+=' "slug": env(TAG_VERSION), "availability": "stable"}] + .[1:]'
+          EXPR+=' "slug": env(TAG_VERSION), "availability": "stable"}]'
           yq -i "$EXPR" fern/docs.yml
 
-          # Sort versioned entries by semver descending (Latest stays at [0])
-          SORTED_SLUGS=$(yq '.products[0].versions[1:][].slug' fern/docs.yml | sort -rV)
-          yq -i '.products[0].versions = [.products[0].versions[0]]' fern/docs.yml
+          # Sort all version entries by semver descending
+          SORTED_SLUGS=$(yq '.products[0].versions[].slug' fern/docs.yml | sort -rV)
+          yq -i '.products[0].versions = []' fern/docs.yml
           for slug in $SORTED_SLUGS; do
             export slug
             yq -i '.products[0].versions += [{"display-name": env(slug), "path": "versions/" + env(slug) + ".yml", "slug": env(slug), "availability": "stable"}]' fern/docs.yml
@@ -165,20 +158,19 @@ jobs:
           yq '.products[0].versions[].display-name' fern/docs.yml
 
       - name: Prune old versions
-        if: steps.resolve.outputs.should_register == 'true'
+        if: steps.resolve.outputs.is_release == 'true'
         run: |
           set -eo pipefail
-          KEEP=$((MAX_VERSIONS + 1))  # +1 for the Latest entry at index 0
           TOTAL=$(yq '.products[0].versions | length' fern/docs.yml)
 
-          if [ "$TOTAL" -le "$KEEP" ]; then
-            echo "Only $TOTAL versions — nothing to prune (keeping $KEEP)"
+          if [ "$TOTAL" -le "$MAX_VERSIONS" ]; then
+            echo "Only $TOTAL versions — nothing to prune (keeping $MAX_VERSIONS)"
             exit 0
           fi
 
           # Remove excess entries from the end (oldest) and their version files
-          PRUNED=$(yq ".products[0].versions[$KEEP:][].slug" fern/docs.yml)
-          yq -i ".products[0].versions |= .[:$KEEP]" fern/docs.yml
+          PRUNED=$(yq ".products[0].versions[$MAX_VERSIONS:][].slug" fern/docs.yml)
+          yq -i ".products[0].versions |= .[:$MAX_VERSIONS]" fern/docs.yml
 
           for slug in $PRUNED; do
             rm -f "fern/versions/${slug}.yml"
@@ -214,17 +206,15 @@ jobs:
             fi
           done
 
-      - name: Stamp version in docs.yml
+      - name: Stamp newest version as Latest
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cp fern/docs.yml /tmp/docs.yml.preStamp
-          VERSION=$(gh api repos/${{ github.repository }}/releases/latest --jq .tag_name 2>/dev/null || true)
-          if [ -n "$VERSION" ] && [ "$VERSION" != "null" ]; then
-            export VERSION
-            yq -i '(.products[0].versions[] | select(.slug == "latest")).display-name = "Latest · " + env(VERSION)' fern/docs.yml
-          else
-            echo "::warning::Could not resolve latest GitHub release tag; continuing without stamping"
+          NEWEST=$(yq '.products[0].versions[0].display-name' fern/docs.yml)
+          if [ -n "$NEWEST" ] && [ "$NEWEST" != "null" ]; then
+            export NEWEST
+            yq -i '.products[0].versions[0].display-name = "Latest · " + env(NEWEST)' fern/docs.yml
           fi
           echo "--- docs.yml versions after stamp ---"
           yq '.products[0].versions[].display-name' fern/docs.yml
@@ -250,11 +240,11 @@ jobs:
           fi
 
       - name: Restore unstamped docs.yml for persistence
-        if: steps.resolve.outputs.should_register == 'true'
+        if: steps.resolve.outputs.is_release == 'true'
         run: cp /tmp/docs.yml.preStamp fern/docs.yml
 
       - name: Open PR for version registry changes
-        if: steps.resolve.outputs.should_register == 'true'
+        if: steps.resolve.outputs.is_release == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           base: main

--- a/.github/workflows/publish-fern-docs.yml
+++ b/.github/workflows/publish-fern-docs.yml
@@ -113,12 +113,23 @@ jobs:
           else
             IS_RELEASE=true
           fi
+
+          # Skip registration when tag = latest release (Latest already covers it)
+          LATEST=$(gh release view --repo "${GITHUB_REPOSITORY}" --json tagName -q .tagName 2>/dev/null || true)
+          if [ "$IS_RELEASE" = "true" ] && [ "$TAG" = "$LATEST" ]; then
+            SHOULD_REGISTER=false
+            echo "Tag $TAG is the current latest release — will be shown as 'Latest · $TAG', skipping version entry"
+          else
+            SHOULD_REGISTER=$IS_RELEASE
+          fi
+
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "is_release=$IS_RELEASE" >> "$GITHUB_OUTPUT"
-          echo "Resolved target tag: $TAG (is_release=$IS_RELEASE)"
+          echo "should_register=$SHOULD_REGISTER" >> "$GITHUB_OUTPUT"
+          echo "Resolved target tag: $TAG (is_release=$IS_RELEASE, should_register=$SHOULD_REGISTER)"
 
       - name: Register new version from tag
-        if: steps.resolve.outputs.is_release == 'true'
+        if: steps.resolve.outputs.should_register == 'true'
         env:
           TAG_VERSION: ${{ steps.resolve.outputs.tag }}
         run: |
@@ -142,11 +153,19 @@ jobs:
           EXPR+=' "slug": env(TAG_VERSION), "availability": "stable"}] + .[1:]'
           yq -i "$EXPR" fern/docs.yml
 
-          echo "--- docs.yml versions after insert ---"
+          # Sort versioned entries by semver descending (Latest stays at [0])
+          SORTED_SLUGS=$(yq '.products[0].versions[1:][].slug' fern/docs.yml | sort -rV)
+          yq -i '.products[0].versions = [.products[0].versions[0]]' fern/docs.yml
+          for slug in $SORTED_SLUGS; do
+            export slug
+            yq -i '.products[0].versions += [{"display-name": env(slug), "path": "versions/" + env(slug) + ".yml", "slug": env(slug), "availability": "stable"}]' fern/docs.yml
+          done
+
+          echo "--- docs.yml versions after insert + sort ---"
           yq '.products[0].versions[].display-name' fern/docs.yml
 
       - name: Prune old versions
-        if: steps.resolve.outputs.is_release == 'true'
+        if: steps.resolve.outputs.should_register == 'true'
         run: |
           set -eo pipefail
           KEEP=$((MAX_VERSIONS + 1))  # +1 for the Latest entry at index 0
@@ -231,11 +250,11 @@ jobs:
           fi
 
       - name: Restore unstamped docs.yml for persistence
-        if: steps.resolve.outputs.is_release == 'true'
+        if: steps.resolve.outputs.should_register == 'true'
         run: cp /tmp/docs.yml.preStamp fern/docs.yml
 
       - name: Open PR for version registry changes
-        if: steps.resolve.outputs.is_release == 'true'
+        if: steps.resolve.outputs.should_register == 'true'
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           base: main

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -17,11 +17,8 @@ products:
     slug: /
     path: ../docs/index.yml
     versions:
-      # display-name is stamped by publish-fern-docs.yml at publish time
-      - display-name: "Latest"
-        path: ../docs/index.yml
-        slug: latest
-        availability: stable
+      # The newest entry is stamped "Latest · vX.Y.Z" by publish-fern-docs.yml at publish time.
+      # All versions serve frozen content from their git tag.
       - display-name: "v0.4.0"
         path: versions/v0.4.0.yml
         slug: v0.4.0


### PR DESCRIPTION
## Description

Port NVSentinel#1315 to topograph:

- **Skip registration when tag = latest release** — the `Latest · vX.Y.Z` stamp already covers it, so a separate version entry would create a duplicate in the dropdown
- **Sort by semver descending** — `sort -rV` after insertion so backport patches (e.g. v0.3.1 after v0.4.0) don't end up above newer releases

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).