### PR TITLE
fix(k8s): prefer GPU clique label for accelerator domains

### DIFF
--- a/charts/topograph/charts/node-data-broker/templates/daemonset.yaml
+++ b/charts/topograph/charts/node-data-broker/templates/daemonset.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.enabled }}
+{{- $providerParams := default dict .Values.global.provider.params }}
+{{- $useGpuCliqueLabel := and (eq .Values.global.provider.name "infiniband-k8s") (eq (lower (toString (get $providerParams "useGpuCliqueLabel"))) "true") }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -31,6 +33,9 @@ spec:
           args:
             - --provider={{ .Values.global.provider.name }}
             - -v={{ .Values.verbosity }}
+            {{- if $useGpuCliqueLabel }}
+            - --set=useGpuCliqueLabel=true
+            {{- end }}
             {{- range .Values.initc.extraArgs }}
             - --set={{ . }}
             {{- end }}

--- a/charts/topograph/charts/node-data-broker/templates/rbac.yaml
+++ b/charts/topograph/charts/node-data-broker/templates/rbac.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.enabled }}
+{{- $providerParams := default dict .Values.global.provider.params }}
+{{- $useGpuCliqueLabel := and (eq .Values.global.provider.name "infiniband-k8s") (eq (lower (toString (get $providerParams "useGpuCliqueLabel"))) "true") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -7,7 +9,7 @@ rules:
 - apiGroups: [""]
   resources: [nodes]
   verbs: [get,list,update]
-{{- if eq .Values.global.provider.name "infiniband-k8s" }}
+{{- if and (eq .Values.global.provider.name "infiniband-k8s") (not $useGpuCliqueLabel) }}
 - apiGroups: [apps]
   resources: [daemonsets]
   verbs: [get,list]

--- a/charts/topograph/values.schema.json
+++ b/charts/topograph/values.schema.json
@@ -35,6 +35,10 @@
                 "oci-sim",
                 "test"
               ]
+            },
+            "params": {
+              "type": "object",
+              "description": "Provider-specific parameters. For infiniband-k8s, useGpuCliqueLabel=true reads nvidia.com/gpu.clique as the accelerator-domain source."
             }
           },
           "required": ["name"]

--- a/charts/topograph/values.yaml
+++ b/charts/topograph/values.yaml
@@ -6,6 +6,11 @@ global:
   provider:
     # name: "aws", "oci", "gcp", "nebius", "nscale", "netq", "infiniband-k8s", "dra" or "test".
     name: test
+    # params:
+    #   # For infiniband-k8s, use an existing Kubernetes node label as the
+    #   # accelerator-domain source instead of running nvidia-smi through the
+    #   # GPU Operator device-plugin DaemonSet.
+    #   useGpuCliqueLabel: true
   engine:
     # name: "k8s", "slinky", "slurm" or "graph"
     name: k8s

--- a/docs/api.md
+++ b/docs/api.md
@@ -72,6 +72,7 @@ Topograph exposes three endpoints for interacting with the service. Below are th
     - **name**: (optional) A string specifying the Service Provider, such as `aws`, `oci`, `gcp`, `nebius`, `nscale`, `netq`, `dra`, `infiniband-k8s`, `infiniband-bm` or `test`. This parameter will override the provider set in the topograph config.
     - **creds**: (optional) A key-value map with provider-specific parameters for authentication.
     - **params**: (optional) A key-value map with provider-specific parameters. The `test` provider uses these parameters for response simulation; for complete behavior and examples, see [Test Mode and Test Provider](./providers/test.md).
+      - **useGpuCliqueLabel**: (optional) Used in: [`infiniband-k8s`]. If `true`, reads the GPU Operator's `nvidia.com/gpu.clique` node label as the accelerator-domain source instead of using the `topograph.nvidia.com/cluster-id` node annotation.
   - **engine**: (optional) Selects the topology output and provides any engine-specific parameters.
     - **name**: (optional) A string specifying the topology output, either `slurm`, `k8s`, `slinky`, or `graph`. This parameter will override the engine set in the topograph config.
     - **params**: (optional) A key-value map with engine-specific parameters.

--- a/docs/engines/k8s.md
+++ b/docs/engines/k8s.md
@@ -6,7 +6,7 @@ Topograph is a tool designed to enhance scheduling decisions in Kubernetes clust
 
 Topograph maps both the multi-tier network hierarchy and accelerated network domains (such as NVLink) using node labels.
 Most cloud providers expose three levels of network topology through their APIs. To provide a unified view, Topograph assigns four labels to each node:
-* `network.topology.nvidia.com/accelerator`: Identifies high-speed interconnect domains, such as NVLink.
+* `network.topology.nvidia.com/accelerator`: Identifies high-speed interconnect domains, such as NVLink. If the node already has `nvidia.com/gpu.clique`, Topograph leaves the accelerator label unset and uses the GPU Operator label as the accelerator-domain signal.
 * `network.topology.nvidia.com/leaf`: Indicates the switches directly connected to compute nodes.
 * `network.topology.nvidia.com/spine`: Represents the next tier of switches above the leaf level.
 * `network.topology.nvidia.com/core`: Denotes the top-level switches.
@@ -57,12 +57,14 @@ graph TB
 
 The GPU Operator device plugin sets `nvidia.com/gpu.clique` on nodes with Multi-Node NVLink (MNNVL) GPUs (e.g., GB200 NVL72). This label identifies the NVLink clique a node belongs to and can be used as a topology key for Pod placement.
 
-Topograph's `network.topology.nvidia.com/accelerator` label and `nvidia.com/gpu.clique` are complementary:
+Topograph treats `nvidia.com/gpu.clique` as the authoritative accelerator-domain node label when it is already present:
 
-- On **MNNVL systems**: the InfiniBand provider's `accelerator` value is derived from the same `ClusterUUID.CliqueId` hardware identifiers as `gpu.clique`. The two labels carry the same value and can be correlated.
-- On **non-MNNVL systems** (e.g., DGX B200, B300): `nvidia.com/gpu.clique` is not set (see the [node labels reference](../reference/node-labels.md) for the Fabric Manager init and `GPU_FABRIC_STATE_COMPLETED` details). Topograph with an InfiniBand provider is the only source of network topology labels on these clusters.
+- On **MNNVL systems**: if `nvidia.com/gpu.clique` exists on a node, the k8s engine does not write Topograph's configured accelerator label for that node. It still writes `leaf`, `spine`, and `core` labels from the provider topology.
+- On **non-MNNVL systems** (e.g., DGX B200, B300): `nvidia.com/gpu.clique` is not set (see the [node labels reference](../reference/node-labels.md) for the Fabric Manager init and `GPU_FABRIC_STATE_COMPLETED` details). Topograph writes the configured accelerator label when the selected provider supplies an accelerator domain.
 
 In addition to NVLink domain membership, Topograph provides the IB switch hierarchy (`leaf`, `spine`, `core`) — giving schedulers both dimensions of topology simultaneously.
+
+For `infiniband-k8s`, operators can set `global.provider.params.useGpuCliqueLabel: true` so the provider reads the GPU Operator's existing clique label instead of collecting the same value through a `nvidia-smi` exec in the GPU Operator device-plugin DaemonSet.
 
 ## Use of Topograph
 

--- a/docs/providers/infiniband.md
+++ b/docs/providers/infiniband.md
@@ -17,7 +17,7 @@ For **Multi-Node NVLink (MNNVL) Kubernetes clusters** (e.g. GB200 NVL72), use th
 |---|---|---|
 | **Auth** | None | In-cluster service account |
 | **Node access** | `pdsh` (SSH-based) | Kubernetes pod exec |
-| **NVLink clique source** | `nvidia-smi` via pdsh | Node annotations (set by node-data-broker) |
+| **NVLink clique source** | `nvidia-smi` via pdsh | Node annotations (set by node-data-broker), or a configured Kubernetes node label |
 | **Target environment** | Bare-metal / Slurm | Kubernetes |
 
 Both variants are presently single-region only (multi-region requests return a `400 Bad Request` error). No CSP credentials are required.
@@ -78,13 +78,13 @@ For the Slurm engine, verify the generated `topology.conf` reflects the expected
 
 ### Prerequisites
 
-- Topograph deployed via Helm — the node-data-broker DaemonSet (a Topograph subchart, enabled by default) collects NVLink clique IDs from each node and stores them as Kubernetes node annotations (`topograph.nvidia.com/cluster-id`)
+- Topograph deployed via Helm — the node-data-broker DaemonSet (a Topograph subchart, enabled by default) collects NVLink clique IDs from each node and stores them as Kubernetes node annotations (`topograph.nvidia.com/cluster-id`). If `useGpuCliqueLabel` is enabled, Topograph reads `nvidia.com/gpu.clique` directly instead and the node-data-broker skips NVLink clique collection.
 - NVIDIA GPU Operator — standard on NVIDIA GPU Kubernetes clusters; manages the device plugin DaemonSet used to read NVLink clique IDs. Required only for NVLink domain discovery; on clusters without NVLink-connected GPUs this does not apply and the provider will still discover the IB switch tree.
 
 ### How It Works
 
 1. Runs `ibnetdiscover` by exec-ing into a node-data-broker pod on each node to map the switch tree
-2. On NVIDIA GPU nodes: reads NVLink clique IDs from the `topograph.nvidia.com/cluster-id` node annotations set by the node-data-broker. The resulting `accelerator` label value is `ClusterUUID.CliqueId` — the same format as `nvidia.com/gpu.clique` set by the GPU Operator device plugin on MNNVL systems.
+2. On NVIDIA GPU nodes: reads NVLink clique IDs from the `topograph.nvidia.com/cluster-id` node annotations set by the node-data-broker. If `useGpuCliqueLabel` is enabled, it reads `nvidia.com/gpu.clique` directly instead. The accelerator domain value is `ClusterUUID.CliqueId` — the same format as `nvidia.com/gpu.clique` set by the GPU Operator device plugin on MNNVL systems. When the k8s engine sees `nvidia.com/gpu.clique` already present on a node, it does not write a duplicate Topograph accelerator label for that node.
 3. Combines the switch tree and any NVLink clique data into the topology graph
 
 ### Configuration
@@ -109,8 +109,21 @@ The following optional parameter can be passed in the topology request payload:
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `nodeSelector` | `map[string]string` | — | Label selector to filter which nodes participate in topology discovery |
+| `useGpuCliqueLabel` | `bool` | `false` | Use `nvidia.com/gpu.clique` as the accelerator-domain ID source instead of the `topograph.nvidia.com/cluster-id` annotation. |
 
-To override the GPU Operator namespace or device plugin DaemonSet name (defaults: `gpu-operator` and `nvidia-device-plugin-daemonset`), set these via `node-data-broker.initc.extraArgs` in your Helm values — they are init container arguments, not provider request parameters:
+With Helm, configure `useGpuCliqueLabel` under `global.provider.params`. The chart also passes it to the node-data-broker init container so it skips NVLink clique collection instead of exec-ing into the GPU Operator device-plugin DaemonSet to run `nvidia-smi`:
+
+```yaml
+global:
+  provider:
+    name: infiniband-k8s
+    params:
+      useGpuCliqueLabel: true
+  engine:
+    name: k8s
+```
+
+When `useGpuCliqueLabel` is not set, the node-data-broker init container uses the GPU Operator device-plugin DaemonSet as before. To override the GPU Operator namespace or device plugin DaemonSet name (defaults: `gpu-operator` and `nvidia-device-plugin-daemonset`), set these via `node-data-broker.initc.extraArgs` in your Helm values — they are init container arguments, not provider request parameters:
 
 ```yaml
 node-data-broker:

--- a/docs/reference/node-labels.md
+++ b/docs/reference/node-labels.md
@@ -10,12 +10,12 @@ Labels are set by the [Kubernetes engine](../engines/k8s.md) (`engine: k8s`) and
 
 | Label key | Topology type | Semantics |
 |---|---|---|
-| `network.topology.nvidia.com/accelerator` | Block (`topology/block`) | Accelerated interconnect domain identifier — nodes that share the same value are in the same accelerated domain. Exact semantics are provider-dependent: for MNNVL-aware providers (DRA, InfiniBand, Lambda AI) the value is an NVL Partition identifier (Fabric-Manager-derived `<ClusterUUID>.<CliqueID>`, identifying a logical sub-domain within the physical NVL Domain); for the AWS provider it is the AWS CapacityBlockId (a reservation-scoped identifier co-extensive with an UltraServer — i.e., the NVL Domain — on P6e-GB200). See the provider matrix below. |
+| `network.topology.nvidia.com/accelerator` | Block (`topology/block`) | Accelerated interconnect domain identifier — nodes that share the same value are in the same accelerated domain. Exact semantics are provider-dependent: for MNNVL-aware providers (DRA, InfiniBand, Lambda AI) the value is an NVL Partition identifier (Fabric-Manager-derived `<ClusterUUID>.<CliqueID>`, identifying a logical sub-domain within the physical NVL Domain); for the AWS provider it is the AWS CapacityBlockId (a reservation-scoped identifier co-extensive with an UltraServer — i.e., the NVL Domain — on P6e-GB200). If `nvidia.com/gpu.clique` already exists on a Kubernetes node, the k8s engine does not write this label for that node. See the provider matrix below. |
 | `network.topology.nvidia.com/leaf` | Tree (`topology/tree`) | Leaf switch identifier — top-of-rack or first-tier fabric switch |
 | `network.topology.nvidia.com/spine` | Tree (`topology/tree`) | Spine switch identifier — second-tier aggregation switch |
 | `network.topology.nvidia.com/core` | Tree (`topology/tree`) | Core switch identifier — third tier, present in large three-tier fabrics |
 
-Labels are **additive**: a node that belongs to both a block topology (NVLink domain) and a tree topology (switch fabric) carries both `accelerator` and `leaf`/`spine`/`core` simultaneously.
+Labels are **additive**: a node that belongs to both a block topology (NVLink domain) and a tree topology (switch fabric) normally carries both `accelerator` and `leaf`/`spine`/`core` simultaneously. The exception is nodes that already have `nvidia.com/gpu.clique`; for those, the k8s engine leaves the accelerator domain on `nvidia.com/gpu.clique` and only writes the switch-hierarchy labels.
 
 Not all providers produce both topology types:
 
@@ -33,7 +33,7 @@ Not all providers produce both topology types:
 | `infiniband-bm` | Yes (`ClusterUUID.CliqueId`) | Yes (IB switch hierarchy) |
 | `infiniband-k8s` | Yes (`ClusterUUID.CliqueId`) | Yes (IB switch hierarchy) |
 
-**Relationship to `nvidia.com/gpu.clique`**: The GPU Operator device plugin sets `nvidia.com/gpu.clique` on nodes with Multi-Node NVLink (MNNVL) GPUs. The `infiniband-bm` and `infiniband-k8s` providers derive their `accelerator` value from the same `ClusterUUID.CliqueId` hardware identifiers, so the values are directly comparable. The `netq` provider uses a `DomainUUID` from the NMX management API — a different identifier that refers to the same physical domain but cannot be compared as a string.
+**Relationship to `nvidia.com/gpu.clique`**: The GPU Operator device plugin sets `nvidia.com/gpu.clique` on nodes with Multi-Node NVLink (MNNVL) GPUs. The k8s engine treats that label as authoritative when present and does not write Topograph's configured accelerator label for that node, regardless of whether the selected provider also returned an accelerator domain from API data. For `infiniband-k8s`, setting `global.provider.params.useGpuCliqueLabel: true` also makes the provider read that existing node label instead of collecting the same value through `nvidia-smi`. The `netq` provider uses a `DomainUUID` from the NMX management API — a different identifier that refers to the same physical domain but cannot be compared as a string.
 
 [NVIDIA Fabric Manager](https://docs.nvidia.com/datacenter/tesla/fabric-manager-user-guide/) runs at node init on MNNVL-capable hardware, discovers the NVLink fabric across GPUs, and registers each GPU with [NVML](https://docs.nvidia.com/deploy/nvml-api/) (NVIDIA Management Library — a C API that exposes per-GPU state). The GPU Operator's IMEX labeler writes `nvidia.com/gpu.clique` only once NVML reports the node's fabric state as `GPU_FABRIC_STATE_COMPLETED` — meaning Fabric Manager finished initialization successfully and the node is part of an NVLink domain.
 
@@ -41,9 +41,9 @@ On non-MNNVL systems (e.g., DGX B200, B300), the GPU fabric never reaches `GPU_F
 
 ### Choosing between `accelerator` and `nvidia.com/gpu.clique` for scheduling
 
-Workload schedulers consuming topology labels may need to choose between Topograph's `network.topology.nvidia.com/accelerator` and the NVIDIA GPU Operator's `nvidia.com/gpu.clique`. The right choice depends on the provider and the desired granularity:
+Workload schedulers consuming topology labels may need to choose between Topograph's `network.topology.nvidia.com/accelerator` and the NVIDIA GPU Operator's `nvidia.com/gpu.clique`. The k8s engine automatically avoids writing `accelerator` on nodes where `nvidia.com/gpu.clique` is already present, so schedulers can use `gpu.clique` for those nodes and fall back to `accelerator` where it is absent:
 
-- **MNNVL hardware + Fabric Manager completed + NVL Partition granularity desired:** prefer `nvidia.com/gpu.clique`. On the AWS provider this is finer granularity than `accelerator` (which carries the CapacityBlockId, i.e., the NVL Domain). On DRA, InfiniBand, and Lambda AI providers the two labels carry the same value.
+- **MNNVL hardware + Fabric Manager completed + NVL Partition granularity desired:** use `nvidia.com/gpu.clique`. On the AWS provider this is finer granularity than `accelerator` (which carries the CapacityBlockId, i.e., the NVL Domain). On DRA, InfiniBand, and Lambda AI providers the two labels carry the same value.
 - **MNNVL but Fabric Manager not yet completed, or non-MNNVL hardware:** `nvidia.com/gpu.clique` is absent. Use `network.topology.nvidia.com/accelerator`.
 - **Slurm clusters (no Kubernetes node labels):** neither label applies. Consumers read Slurm's `topology.conf` directly.
 

--- a/internal/k8s/utils.go
+++ b/internal/k8s/utils.go
@@ -47,7 +47,7 @@ func IsPodReady(pod *corev1.Pod) bool {
 	return false
 }
 
-func GetDaemonSetPods(ctx context.Context, client *kubernetes.Clientset, name, namespace, nodename string) (*corev1.PodList, error) {
+func GetDaemonSetPods(ctx context.Context, client kubernetes.Interface, name, namespace, nodename string) (*corev1.PodList, error) {
 	ds, err := client.AppsV1().DaemonSets(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err

--- a/pkg/engines/k8s/kubernetes.go
+++ b/pkg/engines/k8s/kubernetes.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"maps"
 	"net/http"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -85,5 +86,22 @@ func MergeNodeLabels(node *corev1.Node, labels map[string]string) {
 	if node.Labels == nil {
 		node.Labels = make(map[string]string)
 	}
+
+	labels = skipAcceleratorLabelWhenGPUCliqueExists(node, labels)
 	maps.Copy(node.Labels, labels)
+}
+
+func skipAcceleratorLabelWhenGPUCliqueExists(node *corev1.Node, labels map[string]string) map[string]string {
+	if labelAccelerator == "" || strings.TrimSpace(node.Labels[topology.KeyNvidiaGPUClique]) == "" {
+		return labels
+	}
+
+	filtered := maps.Clone(labels)
+	delete(filtered, labelAccelerator)
+
+	if labelAccelerator != topology.KeyNvidiaGPUClique {
+		delete(node.Labels, labelAccelerator)
+	}
+
+	return filtered
 }

--- a/pkg/engines/k8s/kubernetes_test.go
+++ b/pkg/engines/k8s/kubernetes_test.go
@@ -71,11 +71,14 @@ func TestGetComputeInstances(t *testing.T) {
 }
 
 func TestMergeNodeLabels(t *testing.T) {
+	InitLabels(DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+
 	testCases := []struct {
-		name string
-		node *corev1.Node
-		in   map[string]string
-		out  map[string]string
+		name             string
+		acceleratorLabel string
+		node             *corev1.Node
+		in               map[string]string
+		out              map[string]string
 	}{
 		{
 			name: "Case 1: no labels",
@@ -99,10 +102,59 @@ func TestMergeNodeLabels(t *testing.T) {
 			in:  map[string]string{"c": "3", "d": "4"},
 			out: map[string]string{"a": "1", "b": "2", "c": "3", "d": "4"},
 		},
+		{
+			name: "Case 4: skip accelerator when GPU clique exists",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						topology.KeyNvidiaGPUClique: "cluster-a.0",
+						DefaultLabelAccelerator:     "old-domain",
+						DefaultLabelLeaf:            "old-leaf",
+						"workload.example/label":    "keep",
+					},
+				},
+			},
+			in: map[string]string{
+				DefaultLabelAccelerator: "api-domain",
+				DefaultLabelLeaf:        "new-leaf",
+				DefaultLabelSpine:       "new-spine",
+			},
+			out: map[string]string{
+				topology.KeyNvidiaGPUClique: "cluster-a.0",
+				DefaultLabelLeaf:            "new-leaf",
+				DefaultLabelSpine:           "new-spine",
+				"workload.example/label":    "keep",
+			},
+		},
+		{
+			name:             "Case 5: do not overwrite GPU clique when it is the configured accelerator label",
+			acceleratorLabel: topology.KeyNvidiaGPUClique,
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						topology.KeyNvidiaGPUClique: "cluster-a.0",
+					},
+				},
+			},
+			in: map[string]string{
+				topology.KeyNvidiaGPUClique: "api-domain",
+				DefaultLabelLeaf:            "new-leaf",
+				DefaultLabelSpine:           "new-spine",
+			},
+			out: map[string]string{
+				topology.KeyNvidiaGPUClique: "cluster-a.0",
+				DefaultLabelLeaf:            "new-leaf",
+				DefaultLabelSpine:           "new-spine",
+			},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			if tc.acceleratorLabel != "" {
+				InitLabels(tc.acceleratorLabel, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+				defer InitLabels(DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+			}
 			MergeNodeLabels(tc.node, tc.in)
 			require.Equal(t, tc.out, tc.node.Labels)
 		})

--- a/pkg/providers/dra/provider.go
+++ b/pkg/providers/dra/provider.go
@@ -25,7 +25,7 @@ import (
 const (
 	NAME = "dra"
 
-	DomainLabel = "nvidia.com/gpu.clique"
+	DomainLabel = topology.KeyNvidiaGPUClique
 )
 
 type Provider struct {

--- a/pkg/providers/infiniband/k8s.go
+++ b/pkg/providers/infiniband/k8s.go
@@ -24,6 +24,7 @@ import (
 const (
 	gpuOperatorNamespaceArg  = "gpu-operator-namespace"
 	devicePluginDaemonSetArg = "device-plugin-daemonset"
+	useGPUCliqueLabelArg     = "useGpuCliqueLabel"
 
 	defaultGpuOperatorNamespace  = "gpu-operator"
 	defaultDevicePluginDaemonSet = "nvidia-device-plugin-daemonset"
@@ -56,7 +57,7 @@ func (h *IBNetDiscoverK8S) Run(ctx context.Context, node string) (*bytes.Buffer,
 	return k8s.ExecInPod(ctx, h.client, h.config, pods.Items[0].Name, dataBrokerNamespace, []string{"ibnetdiscover"})
 }
 
-func GetClusterID(ctx context.Context, client *kubernetes.Clientset, config *rest.Config, hostname string, overrides map[string]string) (string, error) {
+func GetGpuClusterID(ctx context.Context, client kubernetes.Interface, config *rest.Config, hostname string, overrides map[string]string) (string, error) {
 	ds, namespace := getDevicePluginInfo(overrides)
 
 	pods, err := k8s.GetDaemonSetPods(ctx, client, ds, namespace, hostname)
@@ -123,17 +124,25 @@ func parseClusterID(txt string) (string, error) {
 	return clusterUUID + "." + cliqueId, nil
 }
 
-func GetNodeAnnotations(ctx context.Context, client *kubernetes.Clientset, config *rest.Config, hostname string, overrides map[string]string) (map[string]string, error) {
+func GetNodeAnnotations(ctx context.Context, client kubernetes.Interface, config *rest.Config, hostname string, overrides map[string]string) (map[string]string, error) {
 	annotations := map[string]string{
 		topology.KeyNodeInstance: hostname,
 		topology.KeyNodeRegion:   "local",
 	}
 
-	if clusterID, err := GetClusterID(ctx, client, config, hostname, overrides); err != nil {
+	if useGPUCliqueLabel(overrides) {
+		return annotations, nil
+	}
+
+	if clusterID, err := GetGpuClusterID(ctx, client, config, hostname, overrides); err != nil {
 		klog.Warningf("No clusterID for node %s: %v", hostname, err)
-	} else {
-		annotations[topology.KeyNodeClusterID] = clusterID
+	} else if clusterID != "" {
+		annotations[topology.KeyGpuClusterID] = clusterID
 	}
 
 	return annotations, nil
+}
+
+func useGPUCliqueLabel(overrides map[string]string) bool {
+	return strings.EqualFold(strings.TrimSpace(overrides[useGPUCliqueLabelArg]), "true")
 }

--- a/pkg/providers/infiniband/k8s_test.go
+++ b/pkg/providers/infiniband/k8s_test.go
@@ -6,9 +6,12 @@
 package infiniband
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/topograph/pkg/topology"
 )
 
 func TestGetDevicePluginInfo(t *testing.T) {
@@ -104,4 +107,15 @@ func TestParseClusterID(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetNodeAnnotationsWithGPUCliqueLabel(t *testing.T) {
+	ctx := context.TODO()
+
+	annotations, err := GetNodeAnnotations(ctx, nil, nil, "node-1", map[string]string{useGPUCliqueLabelArg: "true"})
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{
+		topology.KeyNodeInstance: "node-1",
+		topology.KeyNodeRegion:   "local",
+	}, annotations)
 }

--- a/pkg/providers/infiniband/provider_k8s.go
+++ b/pkg/providers/infiniband/provider_k8s.go
@@ -9,7 +9,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
@@ -33,6 +35,10 @@ type ProviderK8S struct {
 type Params struct {
 	// NodeSelector (optional) specifies nodes participating in the topology
 	NodeSelector map[string]string `mapstructure:"nodeSelector"`
+
+	// UseGPUCliqueLabel uses the GPU Operator's nvidia.com/gpu.clique node label
+	// as the accelerator domain ID instead of Topograph's node annotation.
+	UseGPUCliqueLabel bool `mapstructure:"useGpuCliqueLabel"`
 
 	// derived fields
 	nodeListOpt *metav1.ListOptions
@@ -92,7 +98,7 @@ func (p *ProviderK8S) GenerateTopologyConfig(ctx context.Context, _ *int, cis []
 
 	domainMap := topology.NewDomainMap()
 	for _, node := range nodes.Items {
-		if clusterID, ok := node.Annotations[topology.KeyNodeClusterID]; ok {
+		if clusterID := getGPUClusterID(node, p.params.UseGPUCliqueLabel); clusterID != "" {
 			domainMap.AddHost(clusterID, node.Name, node.Name)
 		}
 	}
@@ -107,4 +113,12 @@ func (p *ProviderK8S) GenerateTopologyConfig(ctx context.Context, _ *int, cis []
 		Tiers:   treeRoot,
 		Domains: domainMap,
 	}, nil
+}
+
+func getGPUClusterID(node corev1.Node, useGPUCliqueLabel bool) string {
+	if useGPUCliqueLabel {
+		return strings.TrimSpace(node.Labels[topology.KeyNvidiaGPUClique])
+	}
+
+	return strings.TrimSpace(node.Annotations[topology.KeyGpuClusterID])
 }

--- a/pkg/providers/infiniband/provider_k8s_test.go
+++ b/pkg/providers/infiniband/provider_k8s_test.go
@@ -9,7 +9,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/NVIDIA/topograph/pkg/topology"
 )
 
 func TestGetParameters(t *testing.T) {
@@ -39,6 +42,20 @@ func TestGetParameters(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:   "Case 4: valid GPU clique label toggle",
+			params: map[string]any{"useGpuCliqueLabel": true},
+			ret: &Params{
+				UseGPUCliqueLabel: true,
+			},
+		},
+		{
+			name:   "Case 5: valid GPU clique label toggle from string",
+			params: map[string]any{"useGpuCliqueLabel": "true"},
+			ret: &Params{
+				UseGPUCliqueLabel: true,
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -52,4 +69,20 @@ func TestGetParameters(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetGPUClusterID(t *testing.T) {
+	node := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				topology.KeyNvidiaGPUClique: "label-domain.0",
+			},
+			Annotations: map[string]string{
+				topology.KeyGpuClusterID: "annotation-domain.0",
+			},
+		},
+	}
+
+	require.Equal(t, "annotation-domain.0", getGPUClusterID(node, false))
+	require.Equal(t, "label-domain.0", getGPUClusterID(node, true))
 }

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -40,9 +40,12 @@ const (
 	TopologyFlat  = "topology/flat"
 	NoTopology    = "no-topology"
 
-	KeyNodeInstance  = "topograph.nvidia.com/instance"
-	KeyNodeRegion    = "topograph.nvidia.com/region"
-	KeyNodeClusterID = "topograph.nvidia.com/cluster-id"
+	KeyNodeInstance = "topograph.nvidia.com/instance"
+	KeyNodeRegion   = "topograph.nvidia.com/region"
+	KeyGpuClusterID = "topograph.nvidia.com/cluster-id"
+
+	// NVIDIA GPU Operator node labels
+	KeyNvidiaGPUClique = "nvidia.com/gpu.clique"
 
 	// ConfigMap annotation keys for metadata tracking
 	KeyConfigMapEngine            = "topograph.nvidia.com/engine"


### PR DESCRIPTION
## Description
Use nvidia.com/gpu.clique as the authoritative accelerator-domain
signal when it is already present on Kubernetes nodes. In that case,
skip writing the Topograph accelerator label while still applying
leaf, spine, and core topology labels.

For infiniband-k8s, add an optional clusterIDLabel provider parameter
so deployments can reuse the GPU Operator clique label instead of
collecting the same value through nvidia-smi.


## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).
