### PR TITLE
feat: Restart deployments when there are changes to config maps

### DIFF
--- a/charts/topograph/charts/node-observer/templates/deployment.yaml
+++ b/charts/topograph/charts/node-observer/templates/deployment.yaml
@@ -11,10 +11,11 @@ spec:
       {{- include "node-observer.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "node-observer.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}

--- a/charts/topograph/templates/deployment.yaml
+++ b/charts/topograph/templates/deployment.yaml
@@ -14,10 +14,11 @@ spec:
       {{- include "topograph.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "topograph.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}

--- a/tests/charts/values.k8s.gateway-api-example.yaml.golden.yaml
+++ b/tests/charts/values.k8s.gateway-api-example.yaml.golden.yaml
@@ -260,6 +260,8 @@ spec:
       app.kubernetes.io/instance: chart-ci
   template:
     metadata:
+      annotations:
+        checksum/config: 8c86665b467e950f383a161291a425c6a1a14dec5f55811a050a1365664b98bb
       labels:
         helm.sh/chart: node-observer-0.4.0
         app.kubernetes.io/name: node-observer
@@ -328,6 +330,8 @@ spec:
       app.kubernetes.io/instance: chart-ci
   template:
     metadata:
+      annotations:
+        checksum/config: 836840c11e383b7f18a9085db3cb4c200b27cc1744b098bc46b7951f0ff22471
       labels:
         helm.sh/chart: topograph-0.4.0
         app.kubernetes.io/name: topograph

--- a/tests/charts/values.k8s.gcp-federated-workload-identity-example.yaml.golden.yaml
+++ b/tests/charts/values.k8s.gcp-federated-workload-identity-example.yaml.golden.yaml
@@ -267,6 +267,8 @@ spec:
       app.kubernetes.io/instance: chart-ci
   template:
     metadata:
+      annotations:
+        checksum/config: b795bbb9a6c84b7e4d2bd5c6cde293223296918ad3882405cf3fee6fa6166c87
       labels:
         helm.sh/chart: node-observer-0.4.0
         app.kubernetes.io/name: node-observer
@@ -335,6 +337,8 @@ spec:
       app.kubernetes.io/instance: chart-ci
   template:
     metadata:
+      annotations:
+        checksum/config: 836840c11e383b7f18a9085db3cb4c200b27cc1744b098bc46b7951f0ff22471
       labels:
         helm.sh/chart: topograph-0.4.0
         app.kubernetes.io/name: topograph

--- a/tests/charts/values.k8s.gcp-service-account-example.yaml.golden.yaml
+++ b/tests/charts/values.k8s.gcp-service-account-example.yaml.golden.yaml
@@ -265,6 +265,8 @@ spec:
       app.kubernetes.io/instance: chart-ci
   template:
     metadata:
+      annotations:
+        checksum/config: 80f4a4ca0fe774a86e873eb84aa45652c5e7aa0d45d846ea86d39e9b34ecdb4c
       labels:
         helm.sh/chart: node-observer-0.4.0
         app.kubernetes.io/name: node-observer
@@ -333,6 +335,8 @@ spec:
       app.kubernetes.io/instance: chart-ci
   template:
     metadata:
+      annotations:
+        checksum/config: 836840c11e383b7f18a9085db3cb4c200b27cc1744b098bc46b7951f0ff22471
       labels:
         helm.sh/chart: topograph-0.4.0
         app.kubernetes.io/name: topograph

--- a/tests/charts/values.k8s.ib-example.yaml.golden.yaml
+++ b/tests/charts/values.k8s.ib-example.yaml.golden.yaml
@@ -288,6 +288,8 @@ spec:
       app.kubernetes.io/instance: chart-ci
   template:
     metadata:
+      annotations:
+        checksum/config: 9d0e2685aae302184e282786d4365262d8f1b2a4b1c6278e819572f234abe0fd
       labels:
         helm.sh/chart: node-observer-0.4.0
         app.kubernetes.io/name: node-observer
@@ -356,6 +358,8 @@ spec:
       app.kubernetes.io/instance: chart-ci
   template:
     metadata:
+      annotations:
+        checksum/config: 836840c11e383b7f18a9085db3cb4c200b27cc1744b098bc46b7951f0ff22471
       labels:
         helm.sh/chart: topograph-0.4.0
         app.kubernetes.io/name: topograph

--- a/tests/charts/values.slinky.block-example.yaml.golden.yaml
+++ b/tests/charts/values.slinky.block-example.yaml.golden.yaml
@@ -281,6 +281,8 @@ spec:
       app.kubernetes.io/instance: chart-ci
   template:
     metadata:
+      annotations:
+        checksum/config: 5d06d9cbac1643f15efaa7659261d182a189052a9194008d6e29712b2c898ca6
       labels:
         helm.sh/chart: node-observer-0.4.0
         app.kubernetes.io/name: node-observer
@@ -351,6 +353,8 @@ spec:
       app.kubernetes.io/instance: chart-ci
   template:
     metadata:
+      annotations:
+        checksum/config: 836840c11e383b7f18a9085db3cb4c200b27cc1744b098bc46b7951f0ff22471
       labels:
         helm.sh/chart: topograph-0.4.0
         app.kubernetes.io/name: topograph

--- a/tests/charts/values.slinky.partition-example.yaml.golden.yaml
+++ b/tests/charts/values.slinky.partition-example.yaml.golden.yaml
@@ -298,6 +298,8 @@ spec:
       app.kubernetes.io/instance: chart-ci
   template:
     metadata:
+      annotations:
+        checksum/config: 92d871f440d55edcbbf54dfbe5ae93bb13441f689d0b9c1cce7d21d53bb97ac3
       labels:
         helm.sh/chart: node-observer-0.4.0
         app.kubernetes.io/name: node-observer
@@ -368,6 +370,8 @@ spec:
       app.kubernetes.io/instance: chart-ci
   template:
     metadata:
+      annotations:
+        checksum/config: 836840c11e383b7f18a9085db3cb4c200b27cc1744b098bc46b7951f0ff22471
       labels:
         helm.sh/chart: topograph-0.4.0
         app.kubernetes.io/name: topograph

--- a/tests/charts/values.slinky.tree-example.yaml.golden.yaml
+++ b/tests/charts/values.slinky.tree-example.yaml.golden.yaml
@@ -273,6 +273,8 @@ spec:
       app.kubernetes.io/instance: chart-ci
   template:
     metadata:
+      annotations:
+        checksum/config: 6acc8cb0fdf4b308b7443ce28c6b59ad5277fd5993aee91b25c506a2f452b4e2
       labels:
         helm.sh/chart: node-observer-0.4.0
         app.kubernetes.io/name: node-observer
@@ -343,6 +345,8 @@ spec:
       app.kubernetes.io/instance: chart-ci
   template:
     metadata:
+      annotations:
+        checksum/config: 836840c11e383b7f18a9085db3cb4c200b27cc1744b098bc46b7951f0ff22471
       labels:
         helm.sh/chart: topograph-0.4.0
         app.kubernetes.io/name: topograph

--- a/tests/charts/values.yaml.golden.yaml
+++ b/tests/charts/values.yaml.golden.yaml
@@ -260,6 +260,8 @@ spec:
       app.kubernetes.io/instance: chart-ci
   template:
     metadata:
+      annotations:
+        checksum/config: 8c86665b467e950f383a161291a425c6a1a14dec5f55811a050a1365664b98bb
       labels:
         helm.sh/chart: node-observer-0.4.0
         app.kubernetes.io/name: node-observer
@@ -328,6 +330,8 @@ spec:
       app.kubernetes.io/instance: chart-ci
   template:
     metadata:
+      annotations:
+        checksum/config: 836840c11e383b7f18a9085db3cb4c200b27cc1744b098bc46b7951f0ff22471
       labels:
         helm.sh/chart: topograph-0.4.0
         app.kubernetes.io/name: topograph


### PR DESCRIPTION
## Description
Helm update to restart topograph deployment when the config map is changed.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).
