### PR TITLE
fix(server): snapshot queue completion results

### DIFF
--- a/pkg/server/trailing_delay_queue.go
+++ b/pkg/server/trailing_delay_queue.go
@@ -122,7 +122,8 @@ func (q *TrailingDelayQueue) Get(hash string) *Completion {
 	defer q.mutex.Unlock()
 
 	if res, ok := q.store.Get(hash); ok {
-		return res.(*Completion)
+		completion := *(res.(*Completion))
+		return &completion
 	}
 
 	return &Completion{

--- a/pkg/server/trailing_delay_queue_test.go
+++ b/pkg/server/trailing_delay_queue_test.go
@@ -166,3 +166,42 @@ func TestSubmitRunningCallbackDoesNotDeleteReplacementTimer(t *testing.T) {
 	defer queue.mutex.Unlock()
 	require.Same(t, replacement, queue.timers[hash])
 }
+
+func TestGetReturnsCompletionSnapshot(t *testing.T) {
+	const hash = "same-request"
+
+	started := make(chan struct{})
+	unblock := make(chan struct{})
+
+	queue := NewTrailingDelayQueue(func(item any) (any, *httperr.Error) {
+		close(started)
+		<-unblock
+		return item, nil
+	}, 10*time.Millisecond)
+	defer queue.Shutdown()
+
+	uid, err := queue.Submit(trailingDelayQueueTestItem{hash: hash})
+	require.NoError(t, err)
+	require.Equal(t, hash, uid)
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-started:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+
+	pending := queue.Get(uid)
+	require.Equal(t, http.StatusAccepted, pending.Status)
+	require.Nil(t, pending.Ret)
+
+	close(unblock)
+	require.Eventually(t, func() bool {
+		return queue.Get(uid).Status == http.StatusOK
+	}, time.Second, 10*time.Millisecond)
+
+	require.Equal(t, http.StatusAccepted, pending.Status)
+	require.Nil(t, pending.Ret)
+}


### PR DESCRIPTION
## Description
Split out from #350 at maintainer request.

`TrailingDelayQueue.Get` returned the live `*Completion` stored in the queue cache. The queue lock protected the lookup itself, but callers read the returned pointer after the lock was released while the timer callback could still update the same `Completion`. That showed up as a race between polling `/v1/topology` and request completion.

This PR returns a shallow snapshot of the cached completion instead. It also adds a focused regression test that proves an accepted-result snapshot does not mutate after the worker completes.

Validation:
- `go test -race ./pkg/server`
- `make qualify LINTER_BIN=/Users/hoangvu/go/bin/golangci-lint`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).
