### PR TITLE
fix(providers): reuse retrying HTTP helper

### DIFF
--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -30,6 +29,7 @@ import (
 
 	"github.com/NVIDIA/topograph/internal/component"
 	"github.com/NVIDIA/topograph/internal/httperr"
+	"github.com/NVIDIA/topograph/internal/httpreq"
 	"github.com/NVIDIA/topograph/pkg/topology"
 )
 
@@ -59,24 +59,11 @@ func (r Registry) Get(name string) (Loader, *httperr.Error) {
 }
 
 func HttpReq(ctx context.Context, method, url string, headers map[string]string) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, method, url, nil)
+	reqFunc := httpreq.GetRequestFunc(ctx, method, headers, nil, nil, url)
+	data, err := httpreq.DoRequestWithRetries(reqFunc, false)
 	if err != nil {
 		return "", err
 	}
-	for key, val := range headers {
-		req.Header.Add(key, val)
-	}
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	data, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-
 	return strings.TrimSpace(string(data)), nil
 }
 

--- a/pkg/providers/providers_test.go
+++ b/pkg/providers/providers_test.go
@@ -18,6 +18,9 @@ package providers
 
 import (
 	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
@@ -42,6 +45,51 @@ node4: instance4
 	output, err = ParsePdshOutput(bytes.NewBufferString(input), true)
 	require.NoError(t, err)
 	require.Equal(t, expected, output)
+}
+
+func TestHttpReqRetries(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if r.Header.Get("X-Test-Header") != "test-value" {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte("missing header"))
+			return
+		}
+		if attempts < 3 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("try again"))
+			return
+		}
+
+		_, _ = w.Write([]byte("instance-123\n"))
+	}))
+	defer server.Close()
+
+	body, err := HttpReq(context.Background(), http.MethodGet, server.URL, map[string]string{
+		"X-Test-Header": "test-value",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "instance-123", body)
+	require.Equal(t, 3, attempts)
+}
+
+func TestHttpReqReturnsHTTPError(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts++
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("not found"))
+	}))
+	defer server.Close()
+
+	body, err := HttpReq(context.Background(), http.MethodGet, server.URL, nil)
+
+	require.Empty(t, body)
+	require.EqualError(t, err, "not found")
+	require.Equal(t, 1, attempts)
 }
 
 func TestReadFile(t *testing.T) {


### PR DESCRIPTION
## Description
Route provider HttpReq through internal/httpreq so IMDS calls inherit retryable status handling and consistent HTTP error behavior.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).
