### PR TITLE
docs(helm): use chart repo install instructions

### DIFF
--- a/charts/topograph/README.md
+++ b/charts/topograph/README.md
@@ -12,11 +12,13 @@ Topograph discovers the physical network topology of a cluster (NVLink domains, 
 
 ## Installation
 
-From the OCI registry (recommended):
+From the Helm chart repository:
 
 ```bash
+helm repo add topograph https://NVIDIA.github.io/topograph
+helm repo update
 helm install topograph \
-  oci://ghcr.io/nvidia/topograph/topograph \
+  topograph/topograph \
   --version <chart-version> \
   --namespace topograph --create-namespace
 ```
@@ -31,7 +33,7 @@ helm install topograph charts/topograph \
 To see available chart versions:
 
 ```bash
-helm show chart oci://ghcr.io/nvidia/topograph/topograph
+helm search repo topograph/topograph --versions
 ```
 
 ## Configuration

--- a/docs/engines/k8s.md
+++ b/docs/engines/k8s.md
@@ -310,7 +310,9 @@ The chart ships two `helm test` hook pods (`charts/topograph/templates/tests/`) 
 Run the suite after installation:
 
 ```bash
-helm install topograph oci://ghcr.io/nvidia/topograph/topograph \
+helm repo add topograph https://NVIDIA.github.io/topograph
+helm repo update
+helm install topograph topograph/topograph \
   --namespace topograph --create-namespace
 helm test topograph --namespace topograph
 ```
@@ -344,4 +346,4 @@ tests:
 
 ### Chart README
 
-For installation, prerequisites, values reference, and configuration examples, see [`charts/topograph/README.md`](../../charts/topograph/README.md) — also surfaced via `helm show readme oci://ghcr.io/nvidia/topograph/topograph`.
+For installation, prerequisites, values reference, and configuration examples, see [`charts/topograph/README.md`](../../charts/topograph/README.md) — also surfaced via `helm show readme topograph/topograph`.

--- a/docs/get-started/quickstart-k8s.md
+++ b/docs/get-started/quickstart-k8s.md
@@ -20,8 +20,9 @@ Prerequisites, install flow, and verification are common to both — the engines
 Base install command (pick the engine-specific flags from the two sections below):
 
 ```bash
-helm install topograph \
-  oci://ghcr.io/nvidia/topograph/topograph \
+helm repo add topograph https://NVIDIA.github.io/topograph
+helm repo update
+helm install topograph topograph/topograph \
   --version <chart-version> \
   --namespace topograph --create-namespace \
   --set global.provider.name=<provider> \
@@ -29,7 +30,7 @@ helm install topograph \
   # ... engine-specific flags ...
 ```
 
-Replace `<provider>` with one of the supported values (`aws`, `gcp`, `oci`, `nebius`, `nscale`, `netq`, `dra`, `infiniband-k8s`, `lambdai`, `cw`). To see available chart versions, run `helm show chart oci://ghcr.io/nvidia/topograph/topograph`.
+Replace `<provider>` with one of the supported values (`aws`, `gcp`, `oci`, `nebius`, `nscale`, `netq`, `dra`, `infiniband-k8s`, `lambdai`, `cw`). To see available chart versions, run `helm search repo topograph/topograph --versions`.
 
 Provider-specific credentials and parameters are passed via Helm values. See the [chart README](https://github.com/NVIDIA/topograph/blob/main/charts/topograph/README.md) and [`values.yaml`](https://github.com/NVIDIA/topograph/blob/main/charts/topograph/values.yaml) for the full values shape, plus the example values files shipped in the chart directory.
 


### PR DESCRIPTION
## Description
Align Kubernetes install docs and chart README with the GitHub Pages Helm repo flow, and use helm search repo --versions for chart version discovery.
closes #352

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).
