### PR TITLE
feat(node-observer): wait for topograph health in-process

### DIFF
--- a/charts/topograph/charts/node-observer/templates/_helpers.tpl
+++ b/charts/topograph/charts/node-observer/templates/_helpers.tpl
@@ -38,13 +38,6 @@ Container image reference. The tag defaults to the chart appVersion when unset.
 {{- end }}
 
 {{/*
-Wait init container image reference.
-*/}}
-{{- define "node-observer.waitImage" -}}
-{{- printf "%s:%s" .Values.waitImage.repository .Values.waitImage.tag -}}
-{{- end }}
-
-{{/*
 Common labels
 */}}
 {{- define "node-observer.labels" -}}

--- a/charts/topograph/charts/node-observer/templates/deployment.yaml
+++ b/charts/topograph/charts/node-observer/templates/deployment.yaml
@@ -30,19 +30,6 @@ spec:
       serviceAccountName: {{ include "node-observer.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      initContainers:
-        - name: wait
-          image: {{ include "node-observer.waitImage" . | quote }}
-          imagePullPolicy: {{ .Values.waitImage.pullPolicy }}
-          command:
-            - sh
-          args:
-            - -c
-            - |
-              until curl -sf "{{ include "topograph.url" $ }}/healthz" ; do
-                echo "Waiting for topograph to start ..."
-                sleep 2
-              done
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/topograph/charts/node-observer/values.yaml
+++ b/charts/topograph/charts/node-observer/values.yaml
@@ -10,12 +10,6 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
-# Image for the init container that waits for the topograph API to be ready.
-waitImage:
-  repository: curlimages/curl
-  pullPolicy: IfNotPresent
-  tag: 8.13.0
-
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/charts/topograph/tests/__snapshot__/render_snapshot_test.yaml.snap
+++ b/charts/topograph/tests/__snapshot__/render_snapshot_test.yaml.snap
@@ -170,19 +170,6 @@ renders default values.yaml:
               volumeMounts:
                 - mountPath: /etc/topograph
                   name: config-volume
-          initContainers:
-            - args:
-                - -c
-                - |
-                  until curl -sf "http://chart-ci.topograph.svc.cluster.local:49021/healthz" ; do
-                    echo "Waiting for topograph to start ..."
-                    sleep 2
-                  done
-              command:
-                - sh
-              image: curlimages/curl:8.13.0
-              imagePullPolicy: IfNotPresent
-              name: wait
           securityContext: {}
           serviceAccountName: chart-ci-node-observer
           volumes:
@@ -641,19 +628,6 @@ renders values.k8s.gateway-api-example.yaml:
               volumeMounts:
                 - mountPath: /etc/topograph
                   name: config-volume
-          initContainers:
-            - args:
-                - -c
-                - |
-                  until curl -sf "http://chart-ci.topograph.svc.cluster.local:49021/healthz" ; do
-                    echo "Waiting for topograph to start ..."
-                    sleep 2
-                  done
-              command:
-                - sh
-              image: curlimages/curl:8.13.0
-              imagePullPolicy: IfNotPresent
-              name: wait
           securityContext: {}
           serviceAccountName: chart-ci-node-observer
           volumes:
@@ -1141,19 +1115,6 @@ renders values.k8s.gcp-federated-workload-identity-example.yaml:
               volumeMounts:
                 - mountPath: /etc/topograph
                   name: config-volume
-          initContainers:
-            - args:
-                - -c
-                - |
-                  until curl -sf "http://chart-ci.topograph.svc.cluster.local:49021/healthz" ; do
-                    echo "Waiting for topograph to start ..."
-                    sleep 2
-                  done
-              command:
-                - sh
-              image: curlimages/curl:8.13.0
-              imagePullPolicy: IfNotPresent
-              name: wait
           securityContext: {}
           serviceAccountName: chart-ci-node-observer
           volumes:
@@ -1635,19 +1596,6 @@ renders values.k8s.gcp-service-account-example.yaml:
               volumeMounts:
                 - mountPath: /etc/topograph
                   name: config-volume
-          initContainers:
-            - args:
-                - -c
-                - |
-                  until curl -sf "http://chart-ci.topograph.svc.cluster.local:49021/healthz" ; do
-                    echo "Waiting for topograph to start ..."
-                    sleep 2
-                  done
-              command:
-                - sh
-              image: curlimages/curl:8.13.0
-              imagePullPolicy: IfNotPresent
-              name: wait
           securityContext: {}
           serviceAccountName: chart-ci-node-observer
           volumes:
@@ -2132,19 +2080,6 @@ renders values.k8s.ib-example.yaml:
               volumeMounts:
                 - mountPath: /etc/topograph
                   name: config-volume
-          initContainers:
-            - args:
-                - -c
-                - |
-                  until curl -sf "http://chart-ci.topograph.svc.cluster.local:49021/healthz" ; do
-                    echo "Waiting for topograph to start ..."
-                    sleep 2
-                  done
-              command:
-                - sh
-              image: curlimages/curl:8.13.0
-              imagePullPolicy: IfNotPresent
-              name: wait
           securityContext: {}
           serviceAccountName: chart-ci-node-observer
           volumes:
@@ -2627,19 +2562,6 @@ renders values.slinky.block-example.yaml:
               volumeMounts:
                 - mountPath: /etc/topograph
                   name: config-volume
-          initContainers:
-            - args:
-                - -c
-                - |
-                  until curl -sf "http://chart-ci.topograph.svc.cluster.local:49021/healthz" ; do
-                    echo "Waiting for topograph to start ..."
-                    sleep 2
-                  done
-              command:
-                - sh
-              image: curlimages/curl:8.13.0
-              imagePullPolicy: IfNotPresent
-              name: wait
           nodeSelector:
             dedicated: user-workload
           securityContext: {}
@@ -3148,19 +3070,6 @@ renders values.slinky.partition-example.yaml:
               volumeMounts:
                 - mountPath: /etc/topograph
                   name: config-volume
-          initContainers:
-            - args:
-                - -c
-                - |
-                  until curl -sf "http://chart-ci.topograph.svc.cluster.local:49021/healthz" ; do
-                    echo "Waiting for topograph to start ..."
-                    sleep 2
-                  done
-              command:
-                - sh
-              image: curlimages/curl:8.13.0
-              imagePullPolicy: IfNotPresent
-              name: wait
           nodeSelector:
             dedicated: user-workload
           securityContext: {}
@@ -3644,19 +3553,6 @@ renders values.slinky.tree-example.yaml:
               volumeMounts:
                 - mountPath: /etc/topograph
                   name: config-volume
-          initContainers:
-            - args:
-                - -c
-                - |
-                  until curl -sf "http://chart-ci.topograph.svc.cluster.local:49021/healthz" ; do
-                    echo "Waiting for topograph to start ..."
-                    sleep 2
-                  done
-              command:
-                - sh
-              image: curlimages/curl:8.13.0
-              imagePullPolicy: IfNotPresent
-              name: wait
           nodeSelector:
             dedicated: user-workload
           securityContext: {}

--- a/charts/topograph/tests/subcharts_test.yaml
+++ b/charts/topograph/tests/subcharts_test.yaml
@@ -18,16 +18,17 @@ tests:
           path: spec.replicas
           value: 2
 
-  - it: node-observer wait init container polls the topograph healthz endpoint
+  - it: node-observer runs as a single container without a wait init container
     templates:
       - charts/node-observer/templates/deployment.yaml
     asserts:
+      # The former `wait` init container was replaced by an in-process health
+      # check, so no init container should be rendered.
+      - notExists:
+          path: spec.template.spec.initContainers
       - equal:
-          path: spec.template.spec.initContainers[0].name
-          value: wait
-      - matchRegex:
-          path: spec.template.spec.initContainers[0].args[1]
-          pattern: "http://chart-ci\\.topograph\\.svc\\.cluster\\.local:49021/healthz"
+          path: spec.template.spec.containers[0].command[0]
+          value: /usr/local/bin/node-observer
 
   - it: node-observer uses an existing service account when creation is disabled
     templates:

--- a/pkg/node_observer/controller.go
+++ b/pkg/node_observer/controller.go
@@ -33,6 +33,7 @@ type Controller struct {
 	ctx            context.Context
 	client         kubernetes.Interface
 	statusInformer *StatusInformer
+	healthURL      string
 }
 
 func NewController(ctx context.Context, client kubernetes.Interface, cfg *Config) (*Controller, error) {
@@ -41,6 +42,11 @@ func NewController(ctx context.Context, client kubernetes.Interface, cfg *Config
 	data, err := json.Marshal(payload)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal payload: %v", err)
+	}
+
+	healthURL, err := healthCheckURL(cfg.GenerateTopologyURL)
+	if err != nil {
+		return nil, err
 	}
 
 	f := httpreq.GetRequestFunc(ctx, http.MethodPost, headers, nil, data, cfg.GenerateTopologyURL)
@@ -52,10 +58,16 @@ func NewController(ctx context.Context, client kubernetes.Interface, cfg *Config
 		ctx:            ctx,
 		client:         client,
 		statusInformer: statusInformer,
+		healthURL:      healthURL,
 	}, nil
 }
 
 func (c *Controller) Start() error {
+	klog.Infof("Waiting for topograph API to become ready")
+	if err := waitForTopograph(c.ctx, c.healthURL, healthCheckInterval, healthCheckTimeout); err != nil {
+		return err
+	}
+
 	klog.Infof("Starting state observer")
 	return c.statusInformer.Start()
 }

--- a/pkg/node_observer/health.go
+++ b/pkg/node_observer/health.go
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package node_observer
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"k8s.io/klog/v2"
+
+	"github.com/NVIDIA/topograph/internal/httpreq"
+)
+
+// healthCheckInterval is how long to wait between topograph health probes
+// while the API is not yet ready.
+const healthCheckInterval = 2 * time.Second
+
+// healthCheckTimeout bounds how long to wait for the topograph API to become
+// ready before giving up. When exceeded, waitForTopograph returns an error so
+// the process exits non-zero and the pod restarts.
+const healthCheckTimeout = 1 * time.Minute
+
+// healthCheckURL derives the topograph health endpoint from the generate
+// topology URL by replacing its path with /healthz.
+func healthCheckURL(generateTopologyURL string) (string, error) {
+	u, err := url.Parse(generateTopologyURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse generateTopologyUrl %q: %w", generateTopologyURL, err)
+	}
+	u.Path = "/healthz"
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String(), nil
+}
+
+// waitForTopograph blocks until the topograph API health endpoint responds
+// successfully, the context is cancelled, or timeout elapses. It replaces the
+// chart's former `wait` init container. On timeout it returns an error so the
+// caller can exit non-zero.
+func waitForTopograph(ctx context.Context, healthURL string, interval, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	start := time.Now()
+	f := httpreq.GetRequestFunc(ctx, http.MethodGet, nil, nil, nil, healthURL)
+	for {
+		_, _, err := httpreq.DoRequest(f, false)
+		if err == nil {
+			klog.Infof("Topograph API is ready at %s", healthURL)
+			return nil
+		}
+		klog.Infof("Waiting for topograph to start at %s: %v", healthURL, err)
+
+		select {
+		case <-ctx.Done():
+			// Report the actual elapsed time rather than the nominal timeout:
+			// context.WithTimeout honours whichever deadline (this timeout or the
+			// parent context's) fires first, so the two can differ.
+			return fmt.Errorf("topograph API not ready at %s after %s: %w", healthURL, time.Since(start).Round(time.Second), ctx.Err())
+		case <-time.After(interval):
+		}
+	}
+}

--- a/pkg/node_observer/health_test.go
+++ b/pkg/node_observer/health_test.go
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package node_observer
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHealthCheckURL(t *testing.T) {
+	testCases := []struct {
+		name        string
+		generateURL string
+		expected    string
+		err         string
+	}{
+		{
+			name:        "in-cluster service URL",
+			generateURL: "http://topograph.topograph.svc.cluster.local:49021/v1/generate",
+			expected:    "http://topograph.topograph.svc.cluster.local:49021/healthz",
+		},
+		{
+			name:        "strips query and fragment",
+			generateURL: "https://host:8443/v1/generate?foo=bar#frag",
+			expected:    "https://host:8443/healthz",
+		},
+		{
+			name:        "no path",
+			generateURL: "http://host:49021",
+			expected:    "http://host:49021/healthz",
+		},
+		{
+			name:        "invalid URL",
+			generateURL: "http://[::1]:namedport/v1/generate",
+			err:         "failed to parse generateTopologyUrl",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := healthCheckURL(tc.generateURL)
+			if len(tc.err) != 0 {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, got)
+		})
+	}
+}
+
+func TestWaitForTopographReady(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Fail the first probe, then succeed, to exercise the retry loop.
+		if atomic.AddInt32(&hits, 1) < 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	err := waitForTopograph(context.Background(), srv.URL+"/healthz", time.Millisecond, time.Minute)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, atomic.LoadInt32(&hits), int32(2))
+}
+
+func TestWaitForTopographTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	err := waitForTopograph(context.Background(), srv.URL+"/healthz", time.Millisecond, 50*time.Millisecond)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestWaitForTopographContextCancelled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := waitForTopograph(ctx, srv.URL+"/healthz", time.Hour, time.Hour)
+	require.ErrorIs(t, err, context.Canceled)
+}


### PR DESCRIPTION
## Description

Replace the node-observer chart's curl-based `wait` init container with an in-process health wait in the `node-observer` binary, removing the dependency on the `curlimages/curl` image for this subchart.

- **node-observer** waits for the topograph API to become healthy before starting its watch loop. The controller polls `/healthz` (derived from `generateTopologyUrl`) every 2s and gives up after 1m, returning an error so the pod restarts if topograph never comes up. Timeout errors report the actual elapsed time rather than the nominal deadline.
- The `wait` init container, the `waitImage` value, and the `node-observer.waitImage` helper are removed.
- Helm-unittest coverage and snapshots updated for the slimmer Deployment.

Related follow-up (separate PR): node-data-broker main-container / health-endpoint changes.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).

## Test plan
- [x] `go test ./pkg/node_observer/...`
- [x] `make chart-test`