### PR TITLE
fix(chart): support existing service accounts with managed RBAC

### DIFF
--- a/charts/topograph/README.md
+++ b/charts/topograph/README.md
@@ -56,9 +56,21 @@ For the full list of values and their defaults, see [`values.yaml`](./values.yam
 - [`values.k8s.gateway-api-example.yaml`](./values.k8s.gateway-api-example.yaml) — exposing the Topograph API via Gateway API (`HTTPRoute`) instead of `Ingress`
 - [`values.slinky.tree-example.yaml`](./values.slinky.tree-example.yaml), [`values.slinky.block-example.yaml`](./values.slinky.block-example.yaml), [`values.slinky.partition-example.yaml`](./values.slinky.partition-example.yaml) — Slinky engine variants
 
+To use an existing Kubernetes ServiceAccount while still letting the chart create the required RBAC, disable only ServiceAccount creation and provide the existing account name:
+
+```yaml
+serviceAccount:
+  create: false
+  name: existing-topograph-sa
+rbac:
+  create: true
+```
+
+Set `rbac.create=false` only when ClusterRoles and ClusterRoleBindings are managed outside the chart.
+
 ### Values validation
 
-The chart ships a [`values.schema.json`](./values.schema.json) that validates the most error-prone fields at install time — the `global.provider.name` and `global.engine.name` enums, type and range constraints on `replicaCount`, `image.pullPolicy`, `service.type`, `service.port`, and `verbosity`, and the expected shapes of `ingress`, `serviceMonitor`, and related nested objects. Invalid values are rejected by `helm install` and `helm template` with a clear schema-validation error.
+The chart ships a [`values.schema.json`](./values.schema.json) that validates the most error-prone fields at install time — the `global.provider.name` and `global.engine.name` enums, type and range constraints on `replicaCount`, `image.pullPolicy`, `service.type`, `service.port`, and `verbosity`, and the expected shapes of `serviceAccount`, `rbac`, `ingress`, `serviceMonitor`, and related nested objects. Invalid values are rejected by `helm install` and `helm template` with a clear schema-validation error.
 
 The schema is deliberately narrow: per-provider credential requirements (which fields a given provider needs in its credentials map) are documented in prose in `docs/providers/<name>.md` rather than enforced in the schema, because the credential field sets evolve with upstream provider changes and are hard to keep accurate in a schema.
 

--- a/charts/topograph/charts/node-data-broker/templates/_helpers.tpl
+++ b/charts/topograph/charts/node-data-broker/templates/_helpers.tpl
@@ -76,6 +76,13 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Create the name of the RBAC resources.
+*/}}
+{{- define "node-data-broker.rbacName" -}}
+{{- include "node-data-broker.fullname" . }}
+{{- end }}
+
+{{/*
 Create the name of a generated ConfigMap mount.
 */}}
 {{- define "node-data-broker.configMapMountName" -}}

--- a/charts/topograph/charts/node-data-broker/templates/rbac.yaml
+++ b/charts/topograph/charts/node-data-broker/templates/rbac.yaml
@@ -1,10 +1,10 @@
-{{- if .Values.enabled }}
+{{- if and .Values.enabled .Values.rbac.create }}
 {{- $providerParams := default dict .Values.global.provider.params }}
 {{- $useGpuCliqueLabel := and (eq .Values.global.provider.name "infiniband-k8s") (eq (lower (toString (get $providerParams "useGpuCliqueLabel"))) "true") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "node-data-broker.serviceAccountName" . }}
+  name: {{ include "node-data-broker.rbacName" . }}
 rules:
 - apiGroups: [""]
   resources: [nodes]
@@ -24,7 +24,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "node-data-broker.serviceAccountName" . }}
+  name: {{ include "node-data-broker.rbacName" . }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "node-data-broker.serviceAccountName" . }}
@@ -32,6 +32,6 @@ subjects:
   apiGroup: ""
 roleRef:
   kind: ClusterRole
-  name: {{ include "node-data-broker.serviceAccountName" . }}
+  name: {{ include "node-data-broker.rbacName" . }}
   apiGroup: ""
 {{- end }}

--- a/charts/topograph/charts/node-data-broker/values.yaml
+++ b/charts/topograph/charts/node-data-broker/values.yaml
@@ -39,6 +39,10 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+rbac:
+  # Specifies whether RBAC resources should be created for the service account
+  create: true
+
 verbosity: 3
 
 podAnnotations: {}

--- a/charts/topograph/charts/node-observer/templates/_helpers.tpl
+++ b/charts/topograph/charts/node-observer/templates/_helpers.tpl
@@ -74,3 +74,10 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create the name of the RBAC resources.
+*/}}
+{{- define "node-observer.rbacName" -}}
+{{- include "node-observer.fullname" . }}
+{{- end }}

--- a/charts/topograph/charts/node-observer/templates/rbac.yaml
+++ b/charts/topograph/charts/node-observer/templates/rbac.yaml
@@ -1,7 +1,8 @@
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "node-observer.serviceAccountName" . }}
+  name: {{ include "node-observer.rbacName" . }}
 rules:
 - apiGroups: [""]
   resources: [nodes,pods]
@@ -10,7 +11,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "node-observer.serviceAccountName" . }}
+  name: {{ include "node-observer.rbacName" . }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "node-observer.serviceAccountName" . }}
@@ -18,5 +19,6 @@ subjects:
   apiGroup: ""
 roleRef:
   kind: ClusterRole
-  name: {{ include "node-observer.serviceAccountName" . }}
+  name: {{ include "node-observer.rbacName" . }}
   apiGroup: ""
+{{- end }}

--- a/charts/topograph/charts/node-observer/values.yaml
+++ b/charts/topograph/charts/node-observer/values.yaml
@@ -31,6 +31,10 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+rbac:
+  # Specifies whether RBAC resources should be created for the service account
+  create: true
+
 verbosity: 3
 
 topograph:

--- a/charts/topograph/templates/NOTES.txt
+++ b/charts/topograph/templates/NOTES.txt
@@ -35,3 +35,12 @@
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
 {{- end }}
+{{- if not .Values.serviceAccount.create }}
+
+2. Topograph is configured to use the existing ServiceAccount "{{ include "topograph.serviceAccountName" . }}".
+{{- if .Values.rbac.create }}
+   RBAC resources were rendered and bound to that ServiceAccount.
+{{- else }}
+   RBAC rendering is disabled; make sure the ServiceAccount already has the required permissions.
+{{- end }}
+{{- end }}

--- a/charts/topograph/templates/_helpers.tpl
+++ b/charts/topograph/templates/_helpers.tpl
@@ -69,6 +69,13 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Create the name of the RBAC resources.
+*/}}
+{{- define "topograph.rbacName" -}}
+{{- include "topograph.fullname" . }}
+{{- end }}
+
+{{/*
 Create topograph service URL
 */}}
 {{- define "topograph.url" -}}

--- a/charts/topograph/templates/rbac.yaml
+++ b/charts/topograph/templates/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.rbac.create -}}
 {{- /*
 pods/exec is needed by providers that exec inside pods, and by Slinky only for
 legacy partition discovery through `scontrol show partition` in a login pod.
@@ -27,7 +27,7 @@ already supplies nodes, a pod selector, or the default flat topology.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "topograph.serviceAccountName" . }}
+  name: {{ include "topograph.rbacName" . }}
 rules:
 - apiGroups: [""]
   resources: [pods]
@@ -52,7 +52,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "topograph.serviceAccountName" . }}
+  name: {{ include "topograph.rbacName" . }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "topograph.serviceAccountName" . }}
@@ -60,6 +60,6 @@ subjects:
   apiGroup: ""
 roleRef:
   kind: ClusterRole
-  name: {{ include "topograph.serviceAccountName" . }}
+  name: {{ include "topograph.rbacName" . }}
   apiGroup: ""
 {{- end }}

--- a/charts/topograph/tests/deployment_test.yaml
+++ b/charts/topograph/tests/deployment_test.yaml
@@ -135,6 +135,17 @@ tests:
           path: spec.template.metadata.annotations["checksum/config"]
         template: templates/deployment.yaml
 
+  - it: uses an existing service account when creation is disabled
+    set:
+      serviceAccount:
+        create: false
+        name: existing-topograph-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: existing-topograph-sa
+        template: templates/deployment.yaml
+
   - it: exposes the container port from the global service port
     set:
       global:

--- a/charts/topograph/tests/rbac_test.yaml
+++ b/charts/topograph/tests/rbac_test.yaml
@@ -16,9 +16,34 @@ tests:
           of: ClusterRoleBinding
         documentIndex: 1
 
-  - it: is omitted entirely when serviceAccount.create is false
+  - it: still renders for an existing service account
     set:
       serviceAccount:
+        create: false
+        name: existing-topograph-sa
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: chart-ci-topograph
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: chart-ci-topograph
+        documentIndex: 1
+      - equal:
+          path: roleRef.name
+          value: chart-ci-topograph
+        documentIndex: 1
+      - equal:
+          path: subjects[0].name
+          value: existing-topograph-sa
+        documentIndex: 1
+
+  - it: is omitted entirely when rbac.create is false
+    set:
+      rbac:
         create: false
     asserts:
       - hasDocuments:

--- a/charts/topograph/tests/subchart_rbac_test.yaml
+++ b/charts/topograph/tests/subchart_rbac_test.yaml
@@ -33,6 +33,34 @@ tests:
           path: subjects[0].name
           value: chart-ci-node-observer
 
+  - it: node-observer binds RBAC to an existing service account
+    templates:
+      - charts/node-observer/templates/rbac.yaml
+    set:
+      node-observer:
+        serviceAccount:
+          create: false
+          name: existing-node-observer-sa
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: roleRef.name
+          value: chart-ci-node-observer
+      - equal:
+          path: subjects[0].name
+          value: existing-node-observer-sa
+
+  - it: node-observer RBAC is omitted when rbac.create is false
+    templates:
+      - charts/node-observer/templates/rbac.yaml
+    set:
+      node-observer:
+        rbac:
+          create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: node-data-broker grants only node access with the default provider
     templates:
       - charts/node-data-broker/templates/rbac.yaml
@@ -50,6 +78,34 @@ tests:
             apiGroups: [""]
             resources: [pods/exec]
             verbs: [create]
+
+  - it: node-data-broker binds RBAC to an existing service account
+    templates:
+      - charts/node-data-broker/templates/rbac.yaml
+    set:
+      node-data-broker:
+        serviceAccount:
+          create: false
+          name: existing-node-data-broker-sa
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: roleRef.name
+          value: chart-ci-node-data-broker
+      - equal:
+          path: subjects[0].name
+          value: existing-node-data-broker-sa
+
+  - it: node-data-broker RBAC is omitted when rbac.create is false
+    templates:
+      - charts/node-data-broker/templates/rbac.yaml
+    set:
+      node-data-broker:
+        rbac:
+          create: false
+    asserts:
+      - hasDocuments:
+          count: 0
 
   - it: node-data-broker grants pods/exec for infiniband-k8s nvidia-smi discovery
     templates:

--- a/charts/topograph/tests/subcharts_test.yaml
+++ b/charts/topograph/tests/subcharts_test.yaml
@@ -29,6 +29,19 @@ tests:
           path: spec.template.spec.initContainers[0].args[1]
           pattern: "http://chart-ci\\.topograph\\.svc\\.cluster\\.local:49021/healthz"
 
+  - it: node-observer uses an existing service account when creation is disabled
+    templates:
+      - charts/node-observer/templates/deployment.yaml
+    set:
+      node-observer:
+        serviceAccount:
+          create: false
+          name: existing-node-observer-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: existing-node-observer-sa
+
   - it: node-observer image tag falls back to the chart appVersion when empty
     templates:
       - charts/node-observer/templates/deployment.yaml
@@ -50,6 +63,19 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[0].name
           value: init-node-labels
+
+  - it: node-data-broker uses an existing service account when creation is disabled
+    templates:
+      - charts/node-data-broker/templates/daemonset.yaml
+    set:
+      node-data-broker:
+        serviceAccount:
+          create: false
+          name: existing-node-data-broker-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: existing-node-data-broker-sa
 
   - it: node-data-broker init container passes the provider and NODE_NAME
     templates:

--- a/charts/topograph/values.schema.json
+++ b/charts/topograph/values.schema.json
@@ -98,6 +98,15 @@
         "name": { "type": "string" }
       }
     },
+    "rbac": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "description": "Create RBAC resources for the selected service account. Leave enabled when serviceAccount.create=false unless RBAC is managed outside the chart."
+        }
+      }
+    },
     "verbosity": {
       "type": "integer",
       "minimum": 0,

--- a/charts/topograph/values.yaml
+++ b/charts/topograph/values.yaml
@@ -42,6 +42,10 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+rbac:
+  # Specifies whether RBAC resources should be created for the service account
+  create: true
+
 verbosity: 3
 
 env: {}


### PR DESCRIPTION
## Description
Support existing service accounts with managed RBAC.
Add rbac.create so ServiceAccount creation can be disabled while the chart
still renders ClusterRoles and ClusterRoleBindings for the selected account.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).
