### PR TITLE
fix(node-observer): refresh topology after API restarts

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -9,7 +9,7 @@ This file provides guidance to Claude Code when working with code in this reposi
 Topograph discovers the physical network topology of a cluster (NVLink domains, InfiniBand/Ethernet switch fabric, cloud rack topology) and exposes it to workload schedulers — Slurm, Kubernetes, and Slurm-on-Kubernetes (Slinky). It has five runtime components:
 
 - **API Server** — receives `/v1/generate` requests, aggregates bursts, dispatches to a Provider
-- **Node Observer** — Kubernetes-only; watches node status changes and triggers regeneration
+- **Node Observer** — Kubernetes-only; watches configured node/pod changes and Topograph API readiness, then triggers regeneration
 - **Node Data Broker** — Kubernetes-only DaemonSet; collects per-node attributes (NVLink clique IDs, etc.) as node annotations
 - **Provider** — per-environment adapter that queries a topology source (CSP API, NetQ, `ibnetdiscover`, DRA labels) and returns a canonical representation
 - **Engine** — per-scheduler translator that writes the canonical representation out as `topology.conf`, Kubernetes node labels, or a Slinky ConfigMap

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ This file provides guidance to Codex, Cursor, Copilot, and other coding agents w
 Topograph discovers the physical network topology of a cluster (NVLink domains, InfiniBand/Ethernet switch fabric, cloud rack topology) and exposes it to workload schedulers — Slurm, Kubernetes, and Slurm-on-Kubernetes (Slinky). It has five runtime components:
 
 - **API Server** — receives `/v1/generate` requests, aggregates bursts, dispatches to a Provider
-- **Node Observer** — Kubernetes-only; watches node status changes and triggers regeneration
+- **Node Observer** — Kubernetes-only; watches configured node/pod changes and Topograph API readiness, then triggers regeneration
 - **Node Data Broker** — Kubernetes-only DaemonSet; collects per-node attributes (NVLink clique IDs, etc.) as node annotations
 - **Provider** — per-environment adapter that queries a topology source (CSP API, NetQ, `ibnetdiscover`, DRA labels) and returns a canonical representation
 - **Engine** — per-scheduler translator that writes the canonical representation out as `topology.conf`, Kubernetes node labels, or a Slinky ConfigMap

--- a/charts/topograph/README.md
+++ b/charts/topograph/README.md
@@ -100,7 +100,7 @@ If you run a topograph image variant without busybox `wget` (for example, the IB
 The chart depends on two subcharts, both managed as local file dependencies:
 
 - **`node-data-broker`** — DaemonSet that collects per-node attributes (NVLink clique IDs, etc.) as node annotations for the Kubernetes engine
-- **`node-observer`** — watches node status changes and triggers topology regeneration
+- **`node-observer`** — watches configured node/pod changes and Topograph API readiness, then triggers topology regeneration
 
 Both are installed together when you install this chart. Their values are accessible under the top-level keys `node-data-broker` and `node-observer` (enabled by default).
 

--- a/charts/topograph/charts/node-observer/templates/_helpers.tpl
+++ b/charts/topograph/charts/node-observer/templates/_helpers.tpl
@@ -38,13 +38,6 @@ Container image reference. The tag defaults to the chart appVersion when unset.
 {{- end }}
 
 {{/*
-Wait init container image reference.
-*/}}
-{{- define "node-observer.waitImage" -}}
-{{- printf "%s:%s" .Values.waitImage.repository .Values.waitImage.tag -}}
-{{- end }}
-
-{{/*
 Common labels
 */}}
 {{- define "node-observer.labels" -}}

--- a/charts/topograph/charts/node-observer/templates/configmap.yml
+++ b/charts/topograph/charts/node-observer/templates/configmap.yml
@@ -12,5 +12,18 @@ data:
       {{- toYaml .Values.global.provider | nindent 6 }}
     engine:
       {{- toYaml .Values.global.engine | nindent 6 }}
+    {{- if .Values.topograph.apiServer.enabled }}
+    apiServer:
+      namespace: {{ .Release.Namespace }}
+      containerName: {{ .Values.topograph.apiServer.containerName | default "topograph" }}
+      podSelector:
+        {{- if .Values.topograph.apiServer.podSelector }}
+        {{- toYaml .Values.topograph.apiServer.podSelector | nindent 8 }}
+        {{- else }}
+        matchLabels:
+          app.kubernetes.io/component: api-server
+          app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- end }}
+    {{- end }}
     trigger:
       {{- toYaml .Values.topograph.trigger | nindent 6 }}

--- a/charts/topograph/charts/node-observer/templates/deployment.yaml
+++ b/charts/topograph/charts/node-observer/templates/deployment.yaml
@@ -30,19 +30,6 @@ spec:
       serviceAccountName: {{ include "node-observer.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      initContainers:
-        - name: wait
-          image: {{ include "node-observer.waitImage" . | quote }}
-          imagePullPolicy: {{ .Values.waitImage.pullPolicy }}
-          command:
-            - sh
-          args:
-            - -c
-            - |
-              until curl -sf "{{ include "topograph.url" $ }}/healthz" ; do
-                echo "Waiting for topograph to start ..."
-                sleep 2
-              done
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/topograph/charts/node-observer/values.yaml
+++ b/charts/topograph/charts/node-observer/values.yaml
@@ -10,12 +10,6 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
-# Image for the init container that waits for the topograph API to be ready.
-waitImage:
-  repository: curlimages/curl
-  pullPolicy: IfNotPresent
-  tag: 8.13.0
-
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
@@ -38,6 +32,13 @@ rbac:
 verbosity: 3
 
 topograph:
+  # Watches the Topograph API pod and triggers topology generation when the
+  # API becomes Ready after startup or a container restart.
+  apiServer:
+    enabled: true
+    # Leave podSelector empty to use the chart's release-scoped API pod labels.
+    podSelector: {}
+    containerName: topograph
   # Initiate topology request based on changes in selected nodes and pods
   trigger:
 #    nodeSelector: {}

--- a/charts/topograph/templates/deployment.yaml
+++ b/charts/topograph/templates/deployment.yaml
@@ -22,9 +22,10 @@ spec:
         {{- end }}
       labels:
         {{- include "topograph.labels" . | nindent 8 }}
-        {{- with .Values.podLabels }}
+        {{- with omit .Values.podLabels "app.kubernetes.io/component" }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        app.kubernetes.io/component: api-server
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/topograph/tests/__snapshot__/render_snapshot_test.yaml.snap
+++ b/charts/topograph/tests/__snapshot__/render_snapshot_test.yaml.snap
@@ -110,6 +110,13 @@ renders default values.yaml:
           name: test
         engine:
           name: k8s
+        apiServer:
+          namespace: topograph
+          containerName: topograph
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: api-server
+              app.kubernetes.io/instance: chart-ci
         trigger:
           null
     kind: ConfigMap
@@ -143,7 +150,7 @@ renders default values.yaml:
       template:
         metadata:
           annotations:
-            checksum/config: 0d9b437577ab907b0706a7803d61099e00cfdc1aab7338b6fc65894d0f158cdb
+            checksum/config: 3cc425d3ec78f0db280e91b8b2472c5d5cf6aa2470ac10cb8cfb527c1baa8dcf
           labels:
             app.kubernetes.io/instance: chart-ci
             app.kubernetes.io/managed-by: Helm
@@ -170,19 +177,6 @@ renders default values.yaml:
               volumeMounts:
                 - mountPath: /etc/topograph
                   name: config-volume
-          initContainers:
-            - args:
-                - -c
-                - |
-                  until curl -sf "http://chart-ci.topograph.svc.cluster.local:49021/healthz" ; do
-                    echo "Waiting for topograph to start ..."
-                    sleep 2
-                  done
-              command:
-                - sh
-              image: curlimages/curl:8.13.0
-              imagePullPolicy: IfNotPresent
-              name: wait
           securityContext: {}
           serviceAccountName: chart-ci-node-observer
           volumes:
@@ -280,6 +274,7 @@ renders default values.yaml:
           annotations:
             checksum/config: 783f0643aeb7b18608d2eeb5fae26a211f3bddcc6e5c564da5c1f9f5fb03cf74
           labels:
+            app.kubernetes.io/component: api-server
             app.kubernetes.io/instance: chart-ci
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: topograph
@@ -581,6 +576,13 @@ renders values.k8s.gateway-api-example.yaml:
           name: test
         engine:
           name: k8s
+        apiServer:
+          namespace: topograph
+          containerName: topograph
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: api-server
+              app.kubernetes.io/instance: chart-ci
         trigger:
           null
     kind: ConfigMap
@@ -614,7 +616,7 @@ renders values.k8s.gateway-api-example.yaml:
       template:
         metadata:
           annotations:
-            checksum/config: 0d9b437577ab907b0706a7803d61099e00cfdc1aab7338b6fc65894d0f158cdb
+            checksum/config: 3cc425d3ec78f0db280e91b8b2472c5d5cf6aa2470ac10cb8cfb527c1baa8dcf
           labels:
             app.kubernetes.io/instance: chart-ci
             app.kubernetes.io/managed-by: Helm
@@ -641,19 +643,6 @@ renders values.k8s.gateway-api-example.yaml:
               volumeMounts:
                 - mountPath: /etc/topograph
                   name: config-volume
-          initContainers:
-            - args:
-                - -c
-                - |
-                  until curl -sf "http://chart-ci.topograph.svc.cluster.local:49021/healthz" ; do
-                    echo "Waiting for topograph to start ..."
-                    sleep 2
-                  done
-              command:
-                - sh
-              image: curlimages/curl:8.13.0
-              imagePullPolicy: IfNotPresent
-              name: wait
           securityContext: {}
           serviceAccountName: chart-ci-node-observer
           volumes:
@@ -751,6 +740,7 @@ renders values.k8s.gateway-api-example.yaml:
           annotations:
             checksum/config: 783f0643aeb7b18608d2eeb5fae26a211f3bddcc6e5c564da5c1f9f5fb03cf74
           labels:
+            app.kubernetes.io/component: api-server
             app.kubernetes.io/instance: chart-ci
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: topograph
@@ -1080,6 +1070,13 @@ renders values.k8s.gcp-federated-workload-identity-example.yaml:
               credentialsConfigmap: gcp-credentials-config
         engine:
           name: k8s
+        apiServer:
+          namespace: topograph
+          containerName: topograph
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: api-server
+              app.kubernetes.io/instance: chart-ci
         trigger:
           nodeSelector:
             brightcomputing.com/node-category: dgx
@@ -1114,7 +1111,7 @@ renders values.k8s.gcp-federated-workload-identity-example.yaml:
       template:
         metadata:
           annotations:
-            checksum/config: e1bc8c3475262722b4edf12e9157944cb4b3e4f3c380f251dee2aea0329d8d2e
+            checksum/config: 77ea06185a18a81c6857830fac1d6830a576db7e473a550fd8f4030ecf7a3fce
           labels:
             app.kubernetes.io/instance: chart-ci
             app.kubernetes.io/managed-by: Helm
@@ -1141,19 +1138,6 @@ renders values.k8s.gcp-federated-workload-identity-example.yaml:
               volumeMounts:
                 - mountPath: /etc/topograph
                   name: config-volume
-          initContainers:
-            - args:
-                - -c
-                - |
-                  until curl -sf "http://chart-ci.topograph.svc.cluster.local:49021/healthz" ; do
-                    echo "Waiting for topograph to start ..."
-                    sleep 2
-                  done
-              command:
-                - sh
-              image: curlimages/curl:8.13.0
-              imagePullPolicy: IfNotPresent
-              name: wait
           securityContext: {}
           serviceAccountName: chart-ci-node-observer
           volumes:
@@ -1251,6 +1235,7 @@ renders values.k8s.gcp-federated-workload-identity-example.yaml:
           annotations:
             checksum/config: 783f0643aeb7b18608d2eeb5fae26a211f3bddcc6e5c564da5c1f9f5fb03cf74
           labels:
+            app.kubernetes.io/component: api-server
             app.kubernetes.io/instance: chart-ci
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: topograph
@@ -1574,6 +1559,13 @@ renders values.k8s.gcp-service-account-example.yaml:
             serviceAccountKeysSecret: gcp-service-account-keys-secret
         engine:
           name: k8s
+        apiServer:
+          namespace: topograph
+          containerName: topograph
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: api-server
+              app.kubernetes.io/instance: chart-ci
         trigger:
           nodeSelector:
             brightcomputing.com/node-category: dgx
@@ -1608,7 +1600,7 @@ renders values.k8s.gcp-service-account-example.yaml:
       template:
         metadata:
           annotations:
-            checksum/config: b05f6e393e25894311104d42c6ac808f77eea4f7d9644623c21d068aca1c494c
+            checksum/config: a8a5af905e6577b68b55b8ad1cb91ad96869c87ffd6bb5039d418ffe199c23ce
           labels:
             app.kubernetes.io/instance: chart-ci
             app.kubernetes.io/managed-by: Helm
@@ -1635,19 +1627,6 @@ renders values.k8s.gcp-service-account-example.yaml:
               volumeMounts:
                 - mountPath: /etc/topograph
                   name: config-volume
-          initContainers:
-            - args:
-                - -c
-                - |
-                  until curl -sf "http://chart-ci.topograph.svc.cluster.local:49021/healthz" ; do
-                    echo "Waiting for topograph to start ..."
-                    sleep 2
-                  done
-              command:
-                - sh
-              image: curlimages/curl:8.13.0
-              imagePullPolicy: IfNotPresent
-              name: wait
           securityContext: {}
           serviceAccountName: chart-ci-node-observer
           volumes:
@@ -1745,6 +1724,7 @@ renders values.k8s.gcp-service-account-example.yaml:
           annotations:
             checksum/config: 783f0643aeb7b18608d2eeb5fae26a211f3bddcc6e5c564da5c1f9f5fb03cf74
           labels:
+            app.kubernetes.io/component: api-server
             app.kubernetes.io/instance: chart-ci
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: topograph
@@ -2071,6 +2051,13 @@ renders values.k8s.ib-example.yaml:
             useGpuCliqueLabel: true
         engine:
           name: k8s
+        apiServer:
+          namespace: topograph
+          containerName: topograph
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: api-server
+              app.kubernetes.io/instance: chart-ci
         trigger:
           nodeSelector:
             nvidia.com/gpu.present: "true"
@@ -2105,7 +2092,7 @@ renders values.k8s.ib-example.yaml:
       template:
         metadata:
           annotations:
-            checksum/config: e763816050b836f63ecd100d5c841fde3b7e26e15ddd4cfecdd07477a4bb3f33
+            checksum/config: b99a1da116af59a261b91df442dd04e4774c074d6b398c9f725ca63471fc40b9
           labels:
             app.kubernetes.io/instance: chart-ci
             app.kubernetes.io/managed-by: Helm
@@ -2132,19 +2119,6 @@ renders values.k8s.ib-example.yaml:
               volumeMounts:
                 - mountPath: /etc/topograph
                   name: config-volume
-          initContainers:
-            - args:
-                - -c
-                - |
-                  until curl -sf "http://chart-ci.topograph.svc.cluster.local:49021/healthz" ; do
-                    echo "Waiting for topograph to start ..."
-                    sleep 2
-                  done
-              command:
-                - sh
-              image: curlimages/curl:8.13.0
-              imagePullPolicy: IfNotPresent
-              name: wait
           securityContext: {}
           serviceAccountName: chart-ci-node-observer
           volumes:
@@ -2242,6 +2216,7 @@ renders values.k8s.ib-example.yaml:
           annotations:
             checksum/config: 783f0643aeb7b18608d2eeb5fae26a211f3bddcc6e5c564da5c1f9f5fb03cf74
           labels:
+            app.kubernetes.io/component: api-server
             app.kubernetes.io/instance: chart-ci
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: topograph
@@ -2565,6 +2540,13 @@ renders values.slinky.block-example.yaml:
             topologyConfigPath: topology.conf
             topologyConfigmapName: slurm-config
             useDynamicNodes: false
+        apiServer:
+          namespace: topograph
+          containerName: topograph
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: api-server
+              app.kubernetes.io/instance: chart-ci
         trigger:
           podSelector:
             matchLabels:
@@ -2600,7 +2582,7 @@ renders values.slinky.block-example.yaml:
       template:
         metadata:
           annotations:
-            checksum/config: 35cba7f729a95cb30bdc1a71b1c6665cabac5dd0abfc78c6231ce13883770efb
+            checksum/config: e7e5f1cd322eebcbfe743705122ae4d1e2197b6d857696a2f90af5ad24606060
           labels:
             app.kubernetes.io/instance: chart-ci
             app.kubernetes.io/managed-by: Helm
@@ -2627,19 +2609,6 @@ renders values.slinky.block-example.yaml:
               volumeMounts:
                 - mountPath: /etc/topograph
                   name: config-volume
-          initContainers:
-            - args:
-                - -c
-                - |
-                  until curl -sf "http://chart-ci.topograph.svc.cluster.local:49021/healthz" ; do
-                    echo "Waiting for topograph to start ..."
-                    sleep 2
-                  done
-              command:
-                - sh
-              image: curlimages/curl:8.13.0
-              imagePullPolicy: IfNotPresent
-              name: wait
           nodeSelector:
             dedicated: user-workload
           securityContext: {}
@@ -2739,6 +2708,7 @@ renders values.slinky.block-example.yaml:
           annotations:
             checksum/config: 783f0643aeb7b18608d2eeb5fae26a211f3bddcc6e5c564da5c1f9f5fb03cf74
           labels:
+            app.kubernetes.io/component: api-server
             app.kubernetes.io/instance: chart-ci
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: topograph
@@ -3086,6 +3056,13 @@ renders values.slinky.partition-example.yaml:
             topologyConfigPath: topology.conf
             topologyConfigmapName: slurm-config
             useDynamicNodes: true
+        apiServer:
+          namespace: topograph
+          containerName: topograph
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: api-server
+              app.kubernetes.io/instance: chart-ci
         trigger:
           podSelector:
             matchLabels:
@@ -3121,7 +3098,7 @@ renders values.slinky.partition-example.yaml:
       template:
         metadata:
           annotations:
-            checksum/config: d8595afcc4e98be3ff0ad4799b02bd84c7d8e68f5a2c1ae3bd7bd179457afaae
+            checksum/config: e5fd4045f0820044555721435ecef533b1e91cc6604f79a9cd85255926952d3c
           labels:
             app.kubernetes.io/instance: chart-ci
             app.kubernetes.io/managed-by: Helm
@@ -3148,19 +3125,6 @@ renders values.slinky.partition-example.yaml:
               volumeMounts:
                 - mountPath: /etc/topograph
                   name: config-volume
-          initContainers:
-            - args:
-                - -c
-                - |
-                  until curl -sf "http://chart-ci.topograph.svc.cluster.local:49021/healthz" ; do
-                    echo "Waiting for topograph to start ..."
-                    sleep 2
-                  done
-              command:
-                - sh
-              image: curlimages/curl:8.13.0
-              imagePullPolicy: IfNotPresent
-              name: wait
           nodeSelector:
             dedicated: user-workload
           securityContext: {}
@@ -3260,6 +3224,7 @@ renders values.slinky.partition-example.yaml:
           annotations:
             checksum/config: 783f0643aeb7b18608d2eeb5fae26a211f3bddcc6e5c564da5c1f9f5fb03cf74
           labels:
+            app.kubernetes.io/component: api-server
             app.kubernetes.io/instance: chart-ci
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: topograph
@@ -3582,6 +3547,13 @@ renders values.slinky.tree-example.yaml:
                 app.kubernetes.io/component: compute
             topologyConfigPath: topology.conf
             topologyConfigmapName: slurm-config
+        apiServer:
+          namespace: topograph
+          containerName: topograph
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: api-server
+              app.kubernetes.io/instance: chart-ci
         trigger:
           podSelector:
             matchLabels:
@@ -3617,7 +3589,7 @@ renders values.slinky.tree-example.yaml:
       template:
         metadata:
           annotations:
-            checksum/config: 9af8272a2f2ec2f5bbf7015b6058098343a8e526af1b0f4998b679bf40affe6c
+            checksum/config: e2be85c411ed46c5ddebc18623d914ceae909088087efadc070b18ed22e65df0
           labels:
             app.kubernetes.io/instance: chart-ci
             app.kubernetes.io/managed-by: Helm
@@ -3644,19 +3616,6 @@ renders values.slinky.tree-example.yaml:
               volumeMounts:
                 - mountPath: /etc/topograph
                   name: config-volume
-          initContainers:
-            - args:
-                - -c
-                - |
-                  until curl -sf "http://chart-ci.topograph.svc.cluster.local:49021/healthz" ; do
-                    echo "Waiting for topograph to start ..."
-                    sleep 2
-                  done
-              command:
-                - sh
-              image: curlimages/curl:8.13.0
-              imagePullPolicy: IfNotPresent
-              name: wait
           nodeSelector:
             dedicated: user-workload
           securityContext: {}
@@ -3756,6 +3715,7 @@ renders values.slinky.tree-example.yaml:
           annotations:
             checksum/config: 783f0643aeb7b18608d2eeb5fae26a211f3bddcc6e5c564da5c1f9f5fb03cf74
           labels:
+            app.kubernetes.io/component: api-server
             app.kubernetes.io/instance: chart-ci
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: topograph

--- a/charts/topograph/tests/deployment_test.yaml
+++ b/charts/topograph/tests/deployment_test.yaml
@@ -19,6 +19,13 @@ tests:
           value: 1
         template: templates/deployment.yaml
 
+  - it: labels the API server pod for node-observer monitoring
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: api-server
+        template: templates/deployment.yaml
+
   - it: image tag falls back to the chart appVersion when empty
     chart:
       appVersion: v1.2.3

--- a/charts/topograph/tests/subcharts_test.yaml
+++ b/charts/topograph/tests/subcharts_test.yaml
@@ -18,16 +18,26 @@ tests:
           path: spec.replicas
           value: 2
 
-  - it: node-observer wait init container polls the topograph healthz endpoint
+  - it: node-observer monitors the topograph API pod from the main container
     templates:
       - charts/node-observer/templates/deployment.yaml
+      - charts/node-observer/templates/configmap.yml
     asserts:
-      - equal:
-          path: spec.template.spec.initContainers[0].name
-          value: wait
+      - notExists:
+          path: spec.template.spec.initContainers
+        template: charts/node-observer/templates/deployment.yaml
       - matchRegex:
-          path: spec.template.spec.initContainers[0].args[1]
-          pattern: "http://chart-ci\\.topograph\\.svc\\.cluster\\.local:49021/healthz"
+          path: data["node-observer-config.yaml"]
+          pattern: "apiServer:"
+        template: charts/node-observer/templates/configmap.yml
+      - matchRegex:
+          path: data["node-observer-config.yaml"]
+          pattern: "containerName: topograph"
+        template: charts/node-observer/templates/configmap.yml
+      - matchRegex:
+          path: data["node-observer-config.yaml"]
+          pattern: "app.kubernetes.io/component: api-server"
+        template: charts/node-observer/templates/configmap.yml
 
   - it: node-observer uses an existing service account when creation is disabled
     templates:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,7 @@ The API Server receives topology generation requests and returns results asynchr
 
 ### 2. Node Observer
 
-The Node Observer is used in Kubernetes deployments. It monitors changes to cluster nodes. If a node goes down or comes online, the Node Observer sends a request to the API Server to generate a new topology configuration.
+The Node Observer is used in Kubernetes deployments. It monitors configured node and pod changes, and it also watches the Topograph API pod. If a selected node or pod changes, or if the API server becomes ready after startup or a container restart, the Node Observer sends a request to the API Server to generate a new topology configuration.
 
 ### 3. Node Data Broker
 
@@ -34,6 +34,6 @@ The Engine translates this internal representation into the format expected by t
 
 ## Workflow
 
-- The API Server listens on the port and notifies the Provider about incoming requests. In Kubernetes, the incoming requests are sent by the Node Observer, which watches changes in the node status.
+- The API Server listens on the port and notifies the Provider about incoming requests. In Kubernetes, the incoming requests are sent by the Node Observer, which watches selected node/pod status and API-server readiness.
 - The Provider receives notifications and invokes CSP API to retrieve topology-related information.
 - The Engine converts the topology information into the format expected by the user cluster (e.g., SLURM or Kubernetes).

--- a/docs/engines/slinky.md
+++ b/docs/engines/slinky.md
@@ -141,7 +141,7 @@ data:
 
 ## Usage Examples
 
-Topograph runs autonomously in Kubernetes environments, including Slinky. When the Node Observer detects that a node has been added or removed, it sends topology requests to the Topograph API server, which then triggers an update to the network topology information within the cluster. However, if you want to manually trigger network topology discovery, you can send HTTP requests to the API server, as shown below.
+Topograph runs autonomously in Kubernetes environments, including Slinky. When the Node Observer detects a selected node or pod change, or sees the Topograph API server become ready after startup or a container restart, it sends topology requests to the API server. The API server then triggers an update to the network topology information within the cluster. However, if you want to manually trigger network topology discovery, you can send HTTP requests to the API server, as shown below.
 
 ### Topology Configuration in the Tree Format
 

--- a/pkg/node_observer/config.go
+++ b/pkg/node_observer/config.go
@@ -27,11 +27,15 @@ import (
 	"github.com/NVIDIA/topograph/pkg/topology"
 )
 
-const defaultRetryDelay = 5 * time.Minute
+const (
+	defaultRetryDelay             = 5 * time.Minute
+	defaultAPIServerContainerName = "topograph"
+)
 
 type Config struct {
 	GenerateTopologyURL string            `yaml:"generateTopologyUrl"`
 	Trigger             Trigger           `yaml:"trigger"`
+	APIServer           APIServer         `yaml:"apiServer,omitempty"`
 	Provider            topology.Provider `yaml:"provider"`
 	Engine              topology.Engine   `yaml:"engine"`
 	RetryDelay          metav1.Duration   `yaml:"retryDelay"`
@@ -40,6 +44,12 @@ type Config struct {
 type Trigger struct {
 	NodeSelector map[string]string     `yaml:"nodeSelector,omitempty"`
 	PodSelector  *metav1.LabelSelector `yaml:"podSelector,omitempty"`
+}
+
+type APIServer struct {
+	Namespace     string                `yaml:"namespace,omitempty"`
+	PodSelector   *metav1.LabelSelector `yaml:"podSelector,omitempty"`
+	ContainerName string                `yaml:"containerName,omitempty"`
 }
 
 func NewConfigFromFile(fname string) (*Config, error) {
@@ -58,8 +68,12 @@ func NewConfigFromFile(fname string) (*Config, error) {
 		return nil, fmt.Errorf("must specify generateTopologyUrl")
 	}
 
-	if len(cfg.Trigger.NodeSelector) == 0 && cfg.Trigger.PodSelector == nil {
-		return nil, fmt.Errorf("must specify nodeSelector and/or podSelector in trigger")
+	if cfg.APIServer.PodSelector != nil && len(cfg.APIServer.ContainerName) == 0 {
+		cfg.APIServer.ContainerName = defaultAPIServerContainerName
+	}
+
+	if len(cfg.Trigger.NodeSelector) == 0 && cfg.Trigger.PodSelector == nil && cfg.APIServer.PodSelector == nil {
+		return nil, fmt.Errorf("must specify nodeSelector and/or podSelector in trigger, or apiServer.podSelector")
 	}
 
 	if cfg.RetryDelay.Duration == 0 {

--- a/pkg/node_observer/config_test.go
+++ b/pkg/node_observer/config_test.go
@@ -53,7 +53,7 @@ func TestNewConfigFromFile(t *testing.T) {
 			data: `
 generateTopologyUrl: "http://topograph.default.svc.cluster.local:49021/v1/generate"
 `,
-			err: "must specify nodeSelector and/or podSelector in trigger",
+			err: "must specify nodeSelector and/or podSelector in trigger, or apiServer.podSelector",
 		},
 		{
 			name: "Case 5: valid with default retry delay",
@@ -164,6 +164,38 @@ trigger:
 					},
 				},
 				RetryDelay: metav1.Duration{Duration: 10 * time.Minute},
+			},
+		},
+		{
+			name: "Case 7: valid with API server trigger and default container name",
+			data: `
+generateTopologyUrl: "http://topograph.default.svc.cluster.local:49021/v1/generate"
+provider:
+  name: test
+engine:
+  name: test
+apiServer:
+  namespace: topograph
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: api-server
+      app.kubernetes.io/instance: topograph
+`,
+			cfg: &Config{
+				GenerateTopologyURL: "http://topograph.default.svc.cluster.local:49021/v1/generate",
+				Provider:            topology.Provider{Name: "test"},
+				Engine:              topology.Engine{Name: "test"},
+				APIServer: APIServer{
+					Namespace:     "topograph",
+					ContainerName: defaultAPIServerContainerName,
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app.kubernetes.io/component": "api-server",
+							"app.kubernetes.io/instance":  "topograph",
+						},
+					},
+				},
+				RetryDelay: metav1.Duration{Duration: defaultRetryDelay},
 			},
 		},
 	}

--- a/pkg/node_observer/controller.go
+++ b/pkg/node_observer/controller.go
@@ -44,7 +44,7 @@ func NewController(ctx context.Context, client kubernetes.Interface, cfg *Config
 	}
 
 	f := httpreq.GetRequestFunc(ctx, http.MethodPost, headers, nil, data, cfg.GenerateTopologyURL)
-	statusInformer, err := NewStatusInformer(ctx, client, &cfg.Trigger, cfg.RetryDelay.Duration, f)
+	statusInformer, err := NewStatusInformer(ctx, client, &cfg.Trigger, &cfg.APIServer, cfg.RetryDelay.Duration, f)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/node_observer/controller_test.go
+++ b/pkg/node_observer/controller_test.go
@@ -24,9 +24,10 @@ func TestNewController(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name    string
-		trigger Trigger
-		err     string
+		name      string
+		trigger   Trigger
+		apiServer APIServer
+		err       string
 	}{
 		{
 			name: "Case 1: bad trigger",
@@ -40,7 +41,18 @@ func TestNewController(t *testing.T) {
 			err: `"BAD" is not a valid label selector operator`,
 		},
 		{
-			name: "Case 2: valid input",
+			name: "Case 2: bad API server selector",
+			apiServer: APIServer{
+				PodSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{Operator: "BAD"},
+					},
+				},
+			},
+			err: `"BAD" is not a valid label selector operator`,
+		},
+		{
+			name: "Case 3: valid input",
 			trigger: Trigger{
 				PodSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{"key": "val"},
@@ -55,6 +67,7 @@ func TestNewController(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg.Trigger = tc.trigger
+			cfg.APIServer = tc.apiServer
 			_, err := NewController(ctx, nil, cfg)
 			if len(tc.err) != 0 {
 				require.EqualError(t, err, tc.err)

--- a/pkg/node_observer/status_informer.go
+++ b/pkg/node_observer/status_informer.go
@@ -27,16 +27,19 @@ type StatusInformer struct {
 	client      kubernetes.Interface
 	nodeFactory informers.SharedInformerFactory
 	podFactory  informers.SharedInformerFactory
+	apiFactory  informers.SharedInformerFactory
 	reqFunc     httpreq.RequestFunc
 	reqExecFunc func(httpreq.RequestFunc, bool) ([]byte, *httperr.Error)
 	retryDelay  time.Duration
 	timer       *time.Timer
 	queue       chan struct{}
 	stopCh      chan struct{}
+
+	apiServerContainerName string
 }
 
-func NewStatusInformer(ctx context.Context, client kubernetes.Interface, trigger *Trigger, retryDelay time.Duration, reqFunc httpreq.RequestFunc) (*StatusInformer, error) {
-	klog.InfoS("Configuring status informer", "trigger", trigger)
+func NewStatusInformer(ctx context.Context, client kubernetes.Interface, trigger *Trigger, apiServer *APIServer, retryDelay time.Duration, reqFunc httpreq.RequestFunc) (*StatusInformer, error) {
+	klog.InfoS("Configuring status informer", "trigger", trigger, "apiServer", apiServer)
 
 	statusInformer := &StatusInformer{
 		ctx:         ctx,
@@ -48,7 +51,7 @@ func NewStatusInformer(ctx context.Context, client kubernetes.Interface, trigger
 		stopCh:      make(chan struct{}),
 	}
 
-	if len(trigger.NodeSelector) != 0 {
+	if trigger != nil && len(trigger.NodeSelector) != 0 {
 		listOptionsFunc := func(options *metav1.ListOptions) {
 			options.LabelSelector = labels.Set(trigger.NodeSelector).AsSelector().String()
 		}
@@ -56,20 +59,44 @@ func NewStatusInformer(ctx context.Context, client kubernetes.Interface, trigger
 			client, 0, informers.WithTweakListOptions(listOptionsFunc))
 	}
 
-	if trigger.PodSelector != nil {
-		selector, err := metav1.LabelSelectorAsSelector(trigger.PodSelector)
+	if trigger != nil && trigger.PodSelector != nil {
+		podFactory, err := newPodFactory(client, trigger.PodSelector, "")
 		if err != nil {
 			return nil, err
 		}
+		statusInformer.podFactory = podFactory
+	}
 
-		listOptionsFunc := func(options *metav1.ListOptions) {
-			options.LabelSelector = selector.String()
+	if apiServer != nil && apiServer.PodSelector != nil {
+		podFactory, err := newPodFactory(client, apiServer.PodSelector, apiServer.Namespace)
+		if err != nil {
+			return nil, err
 		}
-		statusInformer.podFactory = informers.NewSharedInformerFactoryWithOptions(
-			client, 0, informers.WithTweakListOptions(listOptionsFunc))
+		statusInformer.apiFactory = podFactory
+		statusInformer.apiServerContainerName = apiServer.ContainerName
 	}
 
 	return statusInformer, nil
+}
+
+func newPodFactory(client kubernetes.Interface, selector *metav1.LabelSelector, namespace string) (informers.SharedInformerFactory, error) {
+	s, err := metav1.LabelSelectorAsSelector(selector)
+	if err != nil {
+		return nil, err
+	}
+
+	listOptionsFunc := func(options *metav1.ListOptions) {
+		options.LabelSelector = s.String()
+	}
+
+	options := []informers.SharedInformerOption{
+		informers.WithTweakListOptions(listOptionsFunc),
+	}
+	if namespace != "" {
+		options = append(options, informers.WithNamespace(namespace))
+	}
+
+	return informers.NewSharedInformerFactoryWithOptions(client, 0, options...), nil
 }
 
 func (s *StatusInformer) Start() error {
@@ -80,6 +107,10 @@ func (s *StatusInformer) Start() error {
 	}
 
 	if err := s.startPodInformer(); err != nil {
+		return err
+	}
+
+	if err := s.startAPIServerInformer(); err != nil {
 		return err
 	}
 
@@ -95,6 +126,9 @@ func (s *StatusInformer) Stop(_ error) {
 	}
 	if s.podFactory != nil {
 		s.podFactory.Shutdown()
+	}
+	if s.apiFactory != nil {
+		s.apiFactory.Shutdown()
 	}
 	close(s.stopCh)
 }
@@ -128,6 +162,44 @@ func (s *StatusInformer) startNodeInformer() error {
 		}
 		s.nodeFactory.Start(s.ctx.Done())
 		s.nodeFactory.WaitForCacheSync(s.ctx.Done())
+	}
+	return nil
+}
+
+func (s *StatusInformer) startAPIServerInformer() error {
+	if s.apiFactory != nil {
+		informer := s.apiFactory.Core().V1().Pods().Informer()
+		_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj any) {
+				pod, ok := obj.(*corev1.Pod)
+				if !ok {
+					return
+				}
+				if isAPIServerPodReady(pod, s.apiServerContainerName) {
+					klog.V(4).Infof("Informer added ready API server pod %s/%s", pod.Namespace, pod.Name)
+					s.sendRequest()
+				}
+			},
+			UpdateFunc: func(oldObj, newObj any) {
+				oldPod, ok := oldObj.(*corev1.Pod)
+				if !ok {
+					return
+				}
+				newPod, ok := newObj.(*corev1.Pod)
+				if !ok {
+					return
+				}
+				if shouldRequestOnAPIServerUpdate(oldPod, newPod, s.apiServerContainerName) {
+					klog.V(4).Infof("Informer updated ready API server pod %s/%s", newPod.Namespace, newPod.Name)
+					s.sendRequest()
+				}
+			},
+		})
+		if err != nil {
+			return err
+		}
+		s.apiFactory.Start(s.ctx.Done())
+		s.apiFactory.WaitForCacheSync(s.ctx.Done())
 	}
 	return nil
 }
@@ -211,6 +283,56 @@ func (s *StatusInformer) run() {
 			s.process()
 		}
 	}
+}
+
+func shouldRequestOnAPIServerUpdate(oldPod, newPod *corev1.Pod, containerName string) bool {
+	if !isAPIServerPodReady(newPod, containerName) {
+		return false
+	}
+	if !isAPIServerPodReady(oldPod, containerName) {
+		return true
+	}
+
+	oldRestarts, oldFound := containerRestartCount(oldPod, containerName)
+	newRestarts, newFound := containerRestartCount(newPod, containerName)
+	return oldFound && newFound && newRestarts > oldRestarts
+}
+
+func isAPIServerPodReady(pod *corev1.Pod, containerName string) bool {
+	return k8s.IsPodReady(pod) && isContainerRunningAndReady(pod, containerName)
+}
+
+func isContainerRunningAndReady(pod *corev1.Pod, containerName string) bool {
+	found := false
+	for _, status := range pod.Status.ContainerStatuses {
+		if containerName != "" && status.Name != containerName {
+			continue
+		}
+		found = true
+		if status.Ready && status.State.Running != nil {
+			return true
+		}
+	}
+	return containerName == "" && !found
+}
+
+func containerRestartCount(pod *corev1.Pod, containerName string) (int32, bool) {
+	if containerName != "" {
+		for _, status := range pod.Status.ContainerStatuses {
+			if status.Name == containerName {
+				return status.RestartCount, true
+			}
+		}
+		return 0, false
+	}
+
+	var restarts int32
+	found := false
+	for _, status := range pod.Status.ContainerStatuses {
+		restarts += status.RestartCount
+		found = true
+	}
+	return restarts, found
 }
 
 func (s *StatusInformer) process() {

--- a/pkg/node_observer/status_informer_test.go
+++ b/pkg/node_observer/status_informer_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/NVIDIA/topograph/internal/httperr"
 	"github.com/NVIDIA/topograph/internal/httpreq"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -26,10 +27,86 @@ func TestNewStatusInformer(t *testing.T) {
 			MatchLabels: map[string]string{"key": "val"},
 		},
 	}
-	informer, err := NewStatusInformer(ctx, nil, trigger, 0, nil)
+	apiServer := &APIServer{
+		Namespace: "topograph",
+		PodSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{"app": "topograph"},
+		},
+		ContainerName: "topograph",
+	}
+	informer, err := NewStatusInformer(ctx, nil, trigger, apiServer, 0, nil)
 	require.NoError(t, err)
 	require.NotNil(t, informer.nodeFactory)
 	require.NotNil(t, informer.podFactory)
+	require.NotNil(t, informer.apiFactory)
+	require.Equal(t, "topograph", informer.apiServerContainerName)
+}
+
+func TestAPIServerPodUpdateTriggersOnReadyTransitionAndRestart(t *testing.T) {
+	testCases := []struct {
+		name      string
+		oldPod    *corev1.Pod
+		newPod    *corev1.Pod
+		triggered bool
+	}{
+		{
+			name:      "not ready after update",
+			oldPod:    makeAPIServerPod(false, makeContainerStatus("topograph", false, 0)),
+			newPod:    makeAPIServerPod(false, makeContainerStatus("topograph", false, 0)),
+			triggered: false,
+		},
+		{
+			name:      "becomes ready",
+			oldPod:    makeAPIServerPod(false, makeContainerStatus("topograph", false, 0)),
+			newPod:    makeAPIServerPod(true, makeContainerStatus("topograph", true, 0)),
+			triggered: true,
+		},
+		{
+			name:      "target container restart count increases while ready",
+			oldPod:    makeAPIServerPod(true, makeContainerStatus("topograph", true, 1)),
+			newPod:    makeAPIServerPod(true, makeContainerStatus("topograph", true, 2)),
+			triggered: true,
+		},
+		{
+			name:      "ready update without restart",
+			oldPod:    makeAPIServerPod(true, makeContainerStatus("topograph", true, 1)),
+			newPod:    makeAPIServerPod(true, makeContainerStatus("topograph", true, 1)),
+			triggered: false,
+		},
+		{
+			name: "sidecar restart does not trigger",
+			oldPod: makeAPIServerPod(true,
+				makeContainerStatus("topograph", true, 1),
+				makeContainerStatus("sidecar", true, 1),
+			),
+			newPod: makeAPIServerPod(true,
+				makeContainerStatus("topograph", true, 1),
+				makeContainerStatus("sidecar", true, 2),
+			),
+			triggered: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.triggered, shouldRequestOnAPIServerUpdate(tc.oldPod, tc.newPod, "topograph"))
+		})
+	}
+}
+
+func TestAPIServerPodReadinessRequiresTargetContainer(t *testing.T) {
+	require.True(t, isAPIServerPodReady(
+		makeAPIServerPod(true, makeContainerStatus("topograph", true, 0)),
+		"topograph",
+	))
+	require.False(t, isAPIServerPodReady(
+		makeAPIServerPod(true, makeContainerStatus("topograph", false, 0)),
+		"topograph",
+	))
+	require.False(t, isAPIServerPodReady(
+		makeAPIServerPod(true, makeContainerStatus("sidecar", true, 0)),
+		"topograph",
+	))
 }
 
 func reqExecFunc(f httpreq.RequestFunc, _ bool) ([]byte, *httperr.Error) {
@@ -136,4 +213,38 @@ func TestRetryCancelledByNewRequest(t *testing.T) {
 	// - initial
 	// - immediate second (not waiting full retryDelay)
 	require.Equal(t, int32(2), atomic.LoadInt32(&calls))
+}
+
+func makeAPIServerPod(ready bool, statuses ...corev1.ContainerStatus) *corev1.Pod {
+	conditionStatus := corev1.ConditionFalse
+	if ready {
+		conditionStatus = corev1.ConditionTrue
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "topograph-abc",
+			Namespace: "topograph",
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: conditionStatus,
+				},
+			},
+			ContainerStatuses: statuses,
+		},
+	}
+}
+
+func makeContainerStatus(name string, ready bool, restarts int32) corev1.ContainerStatus {
+	status := corev1.ContainerStatus{
+		Name:         name,
+		Ready:        ready,
+		RestartCount: restarts,
+	}
+	if ready {
+		status.State.Running = &corev1.ContainerStateRunning{}
+	}
+	return status
 }


### PR DESCRIPTION
## Description
This change makes node-observer trigger topology regeneration when the Topograph
API server becomes available again after startup or restart.

Previously, node-observer used an init container to wait for `/healthz` before
starting. That only handled initial startup. If the Topograph container restarted
later, node-observer stayed running but did not send a new topology request.

The readiness/restart logic now lives in the node-observer main process:

- adds `apiServer` observer config
- watches the Topograph API pod by label selector
- triggers generation when the API pod becomes Ready
- detects target container restart count increases while Ready
- removes the node-observer wait init container
- labels the Topograph API pod with `app.kubernetes.io/component: api-server`
- updates Helm tests, snapshots, docs, and agent guidance

closes #366

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).
