### PR TITLE
refactor(server): replace golang-lru with local cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.297.1
 	github.com/go-playground/validator/v10 v10.30.2
 	github.com/googleapis/gax-go/v2 v2.22.0
-	github.com/hashicorp/golang-lru v1.0.2
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/nebius/gosdk v0.2.29
 	github.com/oklog/run v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -132,8 +132,6 @@ github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5T
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3 h1:B+8ClL/kCQkRiU82d9xajRPKYMrB7E0MbtzWVi1K4ns=
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3/go.mod h1:NbCUVmiS4foBGBHOYlCT25+YmGpJ32dZPi75pGEUpj4=
-github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iPY6p1c=
-github.com/hashicorp/golang-lru v1.0.2/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=

--- a/pkg/server/lru.go
+++ b/pkg/server/lru.go
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package server
+
+import "container/list"
+
+type lruCache[K comparable, V any] struct {
+	capacity int
+	entries  map[K]*list.Element
+	items    *list.List
+}
+
+type lruEntry[K comparable, V any] struct {
+	key   K
+	value V
+}
+
+func newLRUCache[K comparable, V any](capacity int) *lruCache[K, V] {
+	if capacity <= 0 {
+		panic("lru cache capacity must be positive")
+	}
+
+	return &lruCache[K, V]{
+		capacity: capacity,
+		entries:  make(map[K]*list.Element),
+		items:    list.New(),
+	}
+}
+
+func (c *lruCache[K, V]) Add(key K, value V) bool {
+	if item, ok := c.entries[key]; ok {
+		item.Value.(*lruEntry[K, V]).value = value
+		c.items.MoveToFront(item)
+		return false
+	}
+
+	item := c.items.PushFront(&lruEntry[K, V]{
+		key:   key,
+		value: value,
+	})
+	c.entries[key] = item
+
+	if c.items.Len() <= c.capacity {
+		return false
+	}
+
+	c.removeOldest()
+	return true
+}
+
+func (c *lruCache[K, V]) Get(key K) (V, bool) {
+	item, ok := c.entries[key]
+	if !ok {
+		var zero V
+		return zero, false
+	}
+
+	c.items.MoveToFront(item)
+	return item.Value.(*lruEntry[K, V]).value, true
+}
+
+func (c *lruCache[K, V]) removeOldest() {
+	item := c.items.Back()
+	if item == nil {
+		return
+	}
+
+	c.items.Remove(item)
+	delete(c.entries, item.Value.(*lruEntry[K, V]).key)
+}

--- a/pkg/server/trailing_delay_queue.go
+++ b/pkg/server/trailing_delay_queue.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	lru "github.com/hashicorp/golang-lru"
 	"k8s.io/klog/v2"
 
 	"github.com/NVIDIA/topograph/internal/httperr"
@@ -37,7 +36,7 @@ type TrailingDelayQueue struct {
 	delay    time.Duration
 	shutdown chan struct{}
 	timers   map[string]*time.Timer // map hash:timer
-	store    *lru.Cache             // map hash:processing result
+	store    *lruCache[string, *Completion]
 }
 
 func NewTrailingDelayQueue(handle HandleFunc, delay time.Duration) *TrailingDelayQueue {
@@ -47,7 +46,7 @@ func NewTrailingDelayQueue(handle HandleFunc, delay time.Duration) *TrailingDela
 		shutdown: make(chan struct{}),
 		timers:   make(map[string]*time.Timer),
 	}
-	q.store, _ = lru.New(RequestHistorySize)
+	q.store = newLRUCache[string, *Completion](RequestHistorySize)
 
 	go q.run()
 
@@ -122,7 +121,7 @@ func (q *TrailingDelayQueue) Get(hash string) *Completion {
 	defer q.mutex.Unlock()
 
 	if res, ok := q.store.Get(hash); ok {
-		completion := *(res.(*Completion))
+		completion := *res
 		return &completion
 	}
 

--- a/pkg/server/trailing_delay_queue_test.go
+++ b/pkg/server/trailing_delay_queue_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	lru "github.com/hashicorp/golang-lru"
 	"github.com/stretchr/testify/require"
 
 	"github.com/NVIDIA/topograph/internal/httperr"
@@ -89,7 +88,7 @@ func TestVaryingPayload(t *testing.T) {
 }
 
 func TestLRU(t *testing.T) {
-	cache, _ := lru.New(3)
+	cache := newLRUCache[int, int](3)
 
 	_, ok := cache.Get(1)
 	require.False(t, ok) // not found


### PR DESCRIPTION
## Description
remove golang-lru dependency

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).
