### PR TITLE
fix(provider/lambdai): align client with the Lambda topology API

### DIFF
--- a/pkg/providers/lambdai/instance_topology.go
+++ b/pkg/providers/lambdai/instance_topology.go
@@ -39,7 +39,7 @@ func (p *baseProvider) generateRegionInstanceTopology(ctx context.Context, clien
 	}
 	klog.InfoS("Getting instance topology", "region", ci.Region)
 
-	req := &InstanceListRequest{PageSize: client.PageSize()}
+	req := &InstanceListRequest{Region: ci.Region, PageSize: client.PageSize()}
 
 	for {
 		resp, err := client.InstanceList(ctx, req)
@@ -55,11 +55,11 @@ func (p *baseProvider) generateRegionInstanceTopology(ctx context.Context, clien
 			for indx := range len(inst.NetworkPath) {
 				switch indx {
 				case 0:
-					t.LeafID = inst.NetworkPath[indx]
+					t.LeafID = inst.NetworkPath[indx].ID
 				case 1:
-					t.SpineID = inst.NetworkPath[indx]
+					t.SpineID = inst.NetworkPath[indx].ID
 				case 2:
-					t.CoreID = inst.NetworkPath[indx]
+					t.CoreID = inst.NetworkPath[indx].ID
 				default:
 					klog.Warningf("unsupported size %d of topology path for instance %q", len(inst.NetworkPath), inst.ID)
 				}

--- a/pkg/providers/lambdai/provider.go
+++ b/pkg/providers/lambdai/provider.go
@@ -27,6 +27,9 @@ const (
 	authToken       = "token"
 	apiBaseURL      = "url"
 
+	// apiPath is the Lambda topology API endpoint for listing instance topology.
+	apiPath = "/api/v1/topology/instance"
+
 	defaultPageSize = 200
 )
 
@@ -60,14 +63,28 @@ type lambdaiClient struct {
 	pageSize    int
 }
 
+// apiResponse is the envelope returned by the topology API: a "data" array of
+// instances plus a pagination cursor ("page_token", null on the last page).
+type apiResponse struct {
+	Data      []InstanceTopology `json:"data"`
+	PageToken string             `json:"page_token"`
+}
+
 // InstanceTopology represents the topology of a single instance.
 type InstanceTopology struct {
-	ID          string      `json:"id"`
-	NetworkPath []string    `json:"networkPath"`
-	NVLink      *NVLinkInfo `json:"nvlink,omitempty"`
+	ID          string       `json:"id"`
+	NetworkPath []NetworkHop `json:"networkPath"`
+	NVLink      *NVLinkInfo  `json:"nvlink,omitempty"`
+}
+
+// NetworkHop is a single switch in an instance's network path, ordered from the
+// leaf tier upward.
+type NetworkHop struct {
+	ID string `json:"id"`
 }
 
 type InstanceListRequest struct {
+	Region    string
 	PageSize  int
 	PageToken string
 }
@@ -78,6 +95,8 @@ type InstanceListResponse struct {
 }
 
 // NVLinkInfo represents NVLink domain information.
+// NOTE: the populated shape is unverified — sampled staging instances all
+// returned "nvlink": null. Revisit these tags once real NVLink data is available.
 type NVLinkInfo struct {
 	DomainID string `json:"domain_id,omitempty"`
 	CliqueID string `json:"clique_id,omitempty"`
@@ -93,30 +112,33 @@ func (c *lambdaiClient) PageSize() int {
 
 func (c *lambdaiClient) InstanceList(ctx context.Context, req *InstanceListRequest) (*InstanceListResponse, error) {
 	headers := map[string]string{"Authorization": "Bearer " + c.bearerToken}
-	query := map[string]string{"workspace_id": c.workspaceID}
-	// TODO: follow up on correct pagination
+	query := map[string]string{
+		"workspace_id": c.workspaceID,
+		"region":       req.Region,
+	}
+	// page_size is a best-effort hint; the API paginates via page_token.
 	if req.PageSize > 0 {
 		query["page_size"] = strconv.Itoa(req.PageSize)
 	}
 	if req.PageToken != "" {
 		query["page_token"] = req.PageToken
 	}
-	f := httpreq.GetRequestFunc(ctx, http.MethodGet, headers, query, nil, c.baseURL, "/api/v1/instance-topology")
+	f := httpreq.GetRequestFunc(ctx, http.MethodGet, headers, query, nil, c.baseURL, apiPath)
 
 	body, httpErr := httpreq.DoRequestWithRetries(f, false)
 	if httpErr != nil {
 		return nil, httpErr
 	}
 
-	resp := &InstanceListResponse{Items: []InstanceTopology{}}
-	if err := json.Unmarshal(body, &resp.Items); err != nil {
+	var apiResp apiResponse
+	if err := json.Unmarshal(body, &apiResp); err != nil {
 		return nil, httperr.NewError(http.StatusBadGateway, err.Error())
 	}
 
-	// TODO: follow up on correct page token
-	resp.NextPageToken = ""
-
-	return resp, nil
+	return &InstanceListResponse{
+		Items:         apiResp.Data,
+		NextPageToken: apiResp.PageToken,
+	}, nil
 }
 
 func NamedLoader() (string, providers.Loader) {

--- a/pkg/providers/lambdai/provider_sim.go
+++ b/pkg/providers/lambdai/provider_sim.go
@@ -56,9 +56,13 @@ func (c *simClient) InstanceList(ctx context.Context, req *InstanceListRequest) 
 		if !exists {
 			continue
 		}
+		netPath := make([]NetworkHop, len(node.NetLayers))
+		for i, layer := range node.NetLayers {
+			netPath[i] = NetworkHop{ID: layer}
+		}
 		instance := InstanceTopology{
 			ID:          node.ID,
-			NetworkPath: node.NetLayers,
+			NetworkPath: netPath,
 			//TODO: check whether the below mapping is correct
 			NVLink: &NVLinkInfo{
 				DomainID: node.Attributes.NVLink,

--- a/pkg/providers/lambdai/provider_test.go
+++ b/pkg/providers/lambdai/provider_test.go
@@ -7,10 +7,12 @@ package lambdai
 import (
 	"context"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/NVIDIA/topograph/pkg/engines/slurm"
 	"github.com/NVIDIA/topograph/pkg/providers"
 	"github.com/NVIDIA/topograph/pkg/topology"
 )
@@ -112,4 +114,72 @@ func TestLoader(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestGenerateTopologyConfig drives the real client against a mock of the Lambda
+// topology API, asserting the verified request contract (path, region +
+// workspace_id query, Bearer auth), the {data, page_token} response envelope,
+// page_token pagination, and the networkPath -> leaf/spine/core mapping.
+func TestGenerateTopologyConfig(t *testing.T) {
+	ctx := context.Background()
+
+	const page1 = `{"data":[
+		{"id":"i-1","networkPath":[{"id":"leaf1"},{"id":"spine1"},{"id":"core1"}],"nvlink":null},
+		{"id":"i-2","networkPath":[{"id":"leaf1"},{"id":"spine1"},{"id":"core1"}],"nvlink":null}
+	],"page_token":"page2"}`
+	const page2 = `{"data":[
+		{"id":"i-3","networkPath":[{"id":"leaf2"},{"id":"spine1"},{"id":"core1"}],"nvlink":null}
+	],"page_token":null}`
+
+	var paths, regions, workspaces, auths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		paths = append(paths, r.URL.Path)
+		regions = append(regions, r.URL.Query().Get("region"))
+		workspaces = append(workspaces, r.URL.Query().Get("workspace_id"))
+		auths = append(auths, r.Header.Get("Authorization"))
+
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("page_token") == "" {
+			_, _ = w.Write([]byte(page1))
+		} else {
+			_, _ = w.Write([]byte(page2))
+		}
+	}))
+	defer server.Close()
+
+	provider, httpErr := Loader(ctx, providers.Config{
+		Creds: map[string]any{
+			authWorkspaceID: "ws-1",
+			authToken:       "tok-1",
+		},
+		Params: map[string]any{
+			apiBaseURL: server.URL,
+		},
+	})
+	require.Nil(t, httpErr)
+
+	graph, httpErr := provider.GenerateTopologyConfig(ctx, nil, []topology.ComputeInstances{
+		{
+			Region:    "stg-sjc01-cl03",
+			Instances: map[string]string{"i-1": "node1", "i-2": "node2", "i-3": "node3"},
+		},
+	})
+	require.Nil(t, httpErr)
+	require.NotNil(t, graph)
+
+	// Two calls: the second is driven by the page_token returned on page 1.
+	require.Equal(t, []string{apiPath, apiPath}, paths)
+	require.Equal(t, []string{"stg-sjc01-cl03", "stg-sjc01-cl03"}, regions)
+	require.Equal(t, []string{"ws-1", "ws-1"}, workspaces)
+	require.Equal(t, []string{"Bearer tok-1", "Bearer tok-1"}, auths)
+
+	// Both pages merged; networkPath objects mapped into the switch hierarchy.
+	out, httpErr := slurm.GenerateOutput(ctx, graph, nil)
+	require.Nil(t, httpErr)
+	require.Equal(t, `SwitchName=core1 Switches=spine1
+SwitchName=spine1 Switches=leaf[1-2]
+SwitchName=leaf1 Nodes=node[1-2]
+SwitchName=leaf2 Nodes=node3
+`, string(out))
 }


### PR DESCRIPTION
## Description
Match the deployed API: query GET /api/v1/topology/instance with the required region parameter, parse the {data, page_token} envelope and paginate via page_token, and model networkPath as {id} objects mapped to leaf/spine/core. Update the simulator and add an httptest covering the request contract, envelope, pagination, and mapping.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).
