### PR TITLE
feat(provider/lambdai): Kubernetes node-data-broker support

### DIFF
--- a/charts/topograph/values.yaml
+++ b/charts/topograph/values.yaml
@@ -4,7 +4,7 @@
 
 global:
   provider:
-    # name: "aws", "oci", "gcp", "nebius", "nscale", "netq", "infiniband-k8s", "dra" or "test".
+    # name: "aws", "oci", "gcp", "nebius", "nscale", "lambdai", "netq", "infiniband-k8s", "dra" or "test".
     name: test
     # params:
     #   # For infiniband-k8s, use an existing Kubernetes node label as the

--- a/cmd/node-data-broker/main.go
+++ b/cmd/node-data-broker/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/NVIDIA/topograph/pkg/providers/dra"
 	"github.com/NVIDIA/topograph/pkg/providers/gcp"
 	"github.com/NVIDIA/topograph/pkg/providers/infiniband"
+	"github.com/NVIDIA/topograph/pkg/providers/lambdai"
 	"github.com/NVIDIA/topograph/pkg/providers/nebius"
 	"github.com/NVIDIA/topograph/pkg/providers/oci"
 )
@@ -257,6 +258,8 @@ func getAnnotations(ctx context.Context, client kubernetes.Interface, config *re
 		return dra.GetNodeAnnotations(ctx, nodeName)
 	case infiniband.NAME_K8S:
 		return infiniband.GetNodeAnnotations(ctx, client, config, nodeName, extras)
+	case lambdai.NAME:
+		return lambdai.GetNodeAnnotations(ctx, client, nodeName)
 	case "":
 		return nil, fmt.Errorf("must set provider")
 	default:

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -32,6 +32,8 @@ navigation:
         path: providers/nebius.md
       - page: Nscale
         path: providers/nscale.md
+      - page: Lambda
+        path: providers/lambdai.md
       - page: InfiniBand
         path: providers/infiniband.md
       - page: NetQ

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -38,6 +38,7 @@ Currently supported providers:
 - [GCP](./providers/gcp.md)
 - [Nebius](./providers/nebius.md)
 - [Nscale](./providers/nscale.md)
+- [Lambda](./providers/lambdai.md)
 - [NetQ](./providers/netq.md)
 - [DRA](./providers/dra.md) — reads `nvidia.com/gpu.clique` labels set by the NVIDIA GPU operator DRA driver
 - [InfiniBand (bare-metal)](./providers/infiniband.md#infiniband-bm-bare-metal)
@@ -55,7 +56,7 @@ Currently supported engines:
 
 | Scenario | Recommended provider |
 |---|---|
-| Cloud cluster (AWS, GCP, OCI, Nebius, Nscale) | Use the matching CSP provider |
+| Cloud cluster (AWS, GCP, OCI, Nebius, Nscale, Lambda) | Use the matching CSP provider |
 | Spectrum-X fabric | [NetQ](./providers/netq.md) |
 | Multi-Node NVLink (MNNVL), infrastructure visibility | [NetQ](./providers/netq.md) |
 | MNNVL on Kubernetes (scheduling) | [DRA](./providers/dra.md) |

--- a/docs/providers/lambdai.md
+++ b/docs/providers/lambdai.md
@@ -1,0 +1,205 @@
+# Lambda Topology Provider
+
+The `lambdai` topology provider reads topology data from the Lambda topology API and converts it into Topograph's canonical three-tier topology graph.
+
+The provider queries a single endpoint, `GET /api/v1/topology/instance`, which returns each instance's network switch path and (when available) its NVLink domain. From this it builds a switch tree (for Slurm `topology/tree` or Kubernetes labels) and, when NVLink data is present, an NVLink domain map (for `topology/block`).
+
+## When to Use This Provider
+
+Use this provider for Lambda Cloud clusters where the Lambda topology API is the topology source. It works with both the Slurm engine (generating `topology.conf`) and the Kubernetes engine (labeling nodes).
+
+With the **Slurm engine**, `lambdai` does **not** auto-discover nodes: the topology request must supply explicit `nodes` — a per-region map of provider instance IDs to hostnames (see [Configuration](#configuration)). With the **Kubernetes engine**, node discovery is automatic via the node-data-broker (see [Kubernetes engine](#kubernetes-engine)). Either way, each region triggers one paginated API call.
+
+## Prerequisites
+
+- A Lambda topology API endpoint reachable from the Topograph host
+- A Lambda workspace ID
+- An API token with permission to read instance topology
+- The region ID for each cluster you query
+
+## Credentials
+
+| Field | Required | Description |
+|---|---|---|
+| `workspaceId` | Yes | Lambda workspace ID; sent as the `workspace_id` query parameter |
+| `token` | Yes | Bearer token used for topology API requests |
+
+Store credentials in a YAML file:
+
+```yaml
+workspaceId: <WORKSPACE_ID>
+token: <API_TOKEN>
+```
+
+Reference that file from the Topograph config:
+
+```yaml
+credentialsPath: /etc/topograph/lambdai-credentials.yaml
+```
+
+Credentials can also be supplied directly in the topology request payload under `provider.creds`.
+
+## Parameters
+
+| Field | Required | Description |
+|---|---|---|
+| `url` | Yes | Base URL for the Lambda topology API, for example `https://cloud.example.com` |
+| `trimTiers` | No | Number of highest topology tiers to trim from output. Defaults to `0` |
+
+The region is **not** a parameter — it is taken from each entry in the request's `nodes` list and forwarded to the API as the `region` query parameter (the API requires it). The top-level Topograph `pageSize` setting controls the page size for paginated topology requests.
+
+## Configuration
+
+Example Topograph config for Slurm:
+
+```yaml
+http:
+  port: 49021
+  ssl: false
+
+provider: lambdai
+engine: slurm
+
+requestAggregationDelay: 15s
+pageSize: 200
+credentialsPath: /etc/topograph/lambdai-credentials.yaml
+
+providerParams:
+  url: https://cloud.example.com
+
+engineParams:
+  plugin: topology/tree
+  topologyConfigPath: /etc/slurm/topology.conf
+```
+
+Example request payload. The `nodes` list is required: each region maps provider instance IDs to the hostnames Topograph should emit.
+
+```json
+{
+  "provider": {
+    "name": "lambdai",
+    "creds": {
+      "workspaceId": "<WORKSPACE_ID>",
+      "token": "<API_TOKEN>"
+    },
+    "params": {
+      "url": "https://cloud.example.com"
+    }
+  },
+  "engine": {
+    "name": "slurm",
+    "params": {
+      "plugin": "topology/tree"
+    }
+  },
+  "nodes": [
+    {
+      "region": "<REGION>",
+      "instances": {
+        "<INSTANCE_ID_1>": "node001",
+        "<INSTANCE_ID_2>": "node002"
+      }
+    }
+  ]
+}
+```
+
+## How It Works
+
+For each region in the request's `nodes` list, the provider pages through the topology endpoint:
+
+```text
+GET <url>/api/v1/topology/instance?workspace_id=<workspaceId>&region=<region>&page_size=<pageSize>
+Authorization: Bearer <token>
+```
+
+The response is an envelope containing a `data` array and a pagination cursor:
+
+```json
+{
+  "data": [
+    { "id": "<instance-id>", "networkPath": [{ "id": "<switch>" }, { "id": "<switch>" }], "nvlink": null }
+  ],
+  "page_token": null
+}
+```
+
+When `page_token` is non-null, the provider requests the next page with `&page_token=<token>` and repeats until it is null.
+
+Each returned instance is translated as follows:
+
+| API field | Topograph field |
+|---|---|
+| `id` | Instance ID (matched against the request's instance-to-hostname map) |
+| `networkPath[0].id` | Leaf tier |
+| `networkPath[1].id` | Spine tier |
+| `networkPath[2].id` | Core tier |
+| `nvlink.domain_id` + `nvlink.clique_id` | Accelerator / NVLink domain (`<domain_id>.<clique_id>`) |
+
+`networkPath` is ordered from the leaf tier upward; paths shorter than three hops simply omit the higher tiers, and longer paths are logged and ignored.
+
+NVLink domain data is best-effort. When the API returns `nvlink` for an instance, the provider derives its accelerator/NVLink domain, which enables `topology/block` output. When `nvlink` is null or absent, the provider emits the switch tree only. The exact shape of populated `nvlink` data may evolve; verify `topology/block` output once the API returns NVLink domains for your fleet.
+
+## Kubernetes engine
+
+With the `k8s` engine you do not pass `nodes` explicitly. Instead, the node-data-broker init container stamps each node with the two annotations the engine groups by, derived from fields the `lambda-cloud-controller` already sets on the Node object:
+
+| Node field (set by `lambda-cloud-controller`) | Topograph annotation (set by node-data-broker) |
+|---|---|
+| `.spec.providerID` — `lambda://<instance-id>` | `topograph.nvidia.com/instance` — `<instance-id>` (matches the API `id` 1:1) |
+| `topology.kubernetes.io/region` label — e.g. `stg-sjc01-cl03` | `topograph.nvidia.com/region` |
+
+The Kubernetes engine then discovers nodes from these annotations, the provider queries the Lambda API once per region, and the engine writes `network.topology.nvidia.com/*` labels. The Node Observer re-triggers generation when nodes change.
+
+Requirements:
+
+- The `lambda-cloud-controller` must populate `.spec.providerID` and the `topology.kubernetes.io/region` label. The node-data-broker's init container errors and is retried by Kubernetes until both are present, so a node that is still initializing is simply labeled once its controller has finished.
+- Keep the node-data-broker enabled (the chart default) — it is what translates the Node fields into the canonical annotations.
+- **Node Observer trigger** — the Node Observer needs a watch selector or it crash-loops with `must specify nodeSelector and/or podSelector in trigger`. Set `node-observer.topograph.trigger.nodeSelector` (or `podSelector`) — e.g. `kubernetes.io/os: linux` to watch all nodes.
+- **Tainted (GPU) nodes** — the node-data-broker is a DaemonSet and needs a matching toleration to run on tainted nodes (Lambda GPU instances carry `nvidia.com/gpu=true:NoSchedule`); without it those nodes are never annotated or labeled. `node-data-broker.tolerations[0].operator=Exists` lets it run on every node.
+- **Image architecture** — the image must match the node architecture. Lambda GPU instances such as GH200 are `arm64`, so use a multi-arch or arm64 image.
+- **Registry pull** — if the cluster cannot pull the image anonymously, create a pull secret and set `imagePullSecrets`, `node-observer.imagePullSecrets`, and `node-data-broker.imagePullSecrets`.
+
+Install with Helm (see the [Kubernetes quickstart](../get-started/quickstart-k8s.md) for the full flow):
+
+```bash
+# creds.yaml contains: workspaceId: <...>  /  token: <...>
+kubectl create secret generic lambdai-creds \
+  --from-file=credentials.yaml=creds.yaml -n topograph
+
+helm install topograph oci://ghcr.io/nvidia/topograph/topograph \
+  --version <chart-version> -n topograph --create-namespace \
+  --set global.provider.name=lambdai \
+  --set global.provider.params.url=https://cloud.example.com \
+  --set global.engine.name=k8s \
+  --set config.credentialsSecret=lambdai-creds \
+  --set "node-observer.topograph.trigger.nodeSelector.kubernetes\.io/os=linux" \
+  --set "node-data-broker.tolerations[0].operator=Exists"
+
+# After a few seconds, topology labels appear on nodes:
+kubectl get nodes --show-labels | grep network.topology.nvidia
+```
+
+Only `leaf`/`spine`/`core` labels appear until the API returns `nvlink` data (see the note above); the `accelerator` label follows once it does.
+
+## Verifying the Output
+
+First sanity-check the API directly:
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "$URL/api/v1/topology/instance?workspace_id=$WORKSPACE_ID&region=$REGION" | jq .
+```
+
+Then trigger topology generation and read the result:
+
+```bash
+id=$(curl -s -X POST -H "Content-Type: application/json" -d @payload.json http://localhost:49021/v1/generate)
+curl -s "http://localhost:49021/v1/topology?uid=$id"
+```
+
+For the Slurm engine, verify the generated `topology.conf` reflects the expected switch hierarchy for your Lambda instances. See the [Slurm engine documentation](../engines/slurm.md) for details.
+
+## Simulation
+
+A `lambdai-sim` provider variant is registered for testing without a live API. Instead of calling the topology API, it reads a YAML simulation model and serves it through the same translation path. Select it with `provider: lambdai-sim` and point it at a model file via the `modelFileName` parameter; see [Test Mode and Test Provider](./test.md) for the model-file format and simulation parameters.

--- a/pkg/providers/lambdai/k8s.go
+++ b/pkg/providers/lambdai/k8s.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 LAMBDA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package lambdai
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/NVIDIA/topograph/pkg/topology"
+)
+
+const (
+	// providerIDPrefix is the scheme the lambda-cloud-controller uses in
+	// Node.spec.providerID, e.g. "lambda://<instance-id>".
+	providerIDPrefix = "lambda://"
+	// regionLabelKey is the well-known Kubernetes label the lambda-cloud-controller
+	// sets to the Lambda region, e.g. "stg-sjc01-cl03".
+	regionLabelKey = "topology.kubernetes.io/region"
+)
+
+// GetNodeAnnotations derives Topograph's instance and region annotations for a
+// Lambda node from fields the lambda-cloud-controller sets on the Node object:
+// the instance ID from .spec.providerID ("lambda://<id>") and the region from
+// the "topology.kubernetes.io/region" label. The instance ID matches the
+// topology API's `id` field 1:1.
+//
+// It runs in the node-data-broker init container, so returning an error when
+// providerID or the region label is not yet populated causes the init container
+// to retry until the controller has initialized the node.
+func GetNodeAnnotations(ctx context.Context, client kubernetes.Interface, nodeName string) (map[string]string, error) {
+	node, err := client.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get node %q: %w", nodeName, err)
+	}
+
+	instance, ok := strings.CutPrefix(node.Spec.ProviderID, providerIDPrefix)
+	if !ok || len(instance) == 0 {
+		return nil, fmt.Errorf("node %q providerID %q is not %q-prefixed; is lambda-cloud-controller initialized?",
+			nodeName, node.Spec.ProviderID, providerIDPrefix)
+	}
+
+	region := node.Labels[regionLabelKey]
+	if len(region) == 0 {
+		return nil, fmt.Errorf("node %q is missing the %q label", nodeName, regionLabelKey)
+	}
+
+	return map[string]string{
+		topology.KeyNodeInstance: instance,
+		topology.KeyNodeRegion:   region,
+	}, nil
+}

--- a/pkg/providers/lambdai/k8s_test.go
+++ b/pkg/providers/lambdai/k8s_test.go
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 LAMBDA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package lambdai
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/NVIDIA/topograph/pkg/topology"
+)
+
+func TestGetNodeAnnotations(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		node     *corev1.Node
+		nodeName string
+		want     map[string]string
+		err      string
+	}{
+		{
+			name: "Case 1: success",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "node1",
+					Labels: map[string]string{regionLabelKey: "stg-sjc01-cl03"},
+				},
+				Spec: corev1.NodeSpec{ProviderID: "lambda://e56f5f8557db44c1b162872c94deed6d"},
+			},
+			nodeName: "node1",
+			want: map[string]string{
+				topology.KeyNodeInstance: "e56f5f8557db44c1b162872c94deed6d",
+				topology.KeyNodeRegion:   "stg-sjc01-cl03",
+			},
+		},
+		{
+			name:     "Case 2: node not found",
+			node:     &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "other"}},
+			nodeName: "node1",
+			err:      `failed to get node "node1"`,
+		},
+		{
+			name: "Case 3: providerID missing prefix",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "node1",
+					Labels: map[string]string{regionLabelKey: "stg-sjc01-cl03"},
+				},
+				Spec: corev1.NodeSpec{ProviderID: "e56f5f8557db44c1b162872c94deed6d"},
+			},
+			nodeName: "node1",
+			err:      `is not "lambda://"-prefixed`,
+		},
+		{
+			name: "Case 4: providerID empty",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "node1",
+					Labels: map[string]string{regionLabelKey: "stg-sjc01-cl03"},
+				},
+			},
+			nodeName: "node1",
+			err:      `is not "lambda://"-prefixed`,
+		},
+		{
+			name: "Case 5: missing region label",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+				Spec:       corev1.NodeSpec{ProviderID: "lambda://e56f5f8557db44c1b162872c94deed6d"},
+			},
+			nodeName: "node1",
+			err:      `missing the "topology.kubernetes.io/region" label`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := fake.NewSimpleClientset(tt.node)
+			got, err := GetNodeAnnotations(ctx, client, tt.nodeName)
+			if len(tt.err) != 0 {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.err)
+				require.Nil(t, got)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
Add lambdai.GetNodeAnnotations, which derives Topograph's instance and region node annotations from a node's .spec.providerID (lambda://<id>) and its topology.kubernetes.io/region label, and dispatch to it from the node-data-broker so the k8s engine can discover and label Lambda nodes. Register lambdai in the provider overview and docs nav.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).
