### PR TITLE
chore(docker): add OCI image labels and chart metadata

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,9 +62,6 @@ jobs:
           context: .
           file: ./Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
-          build-args: |
-            VERSION=${{ steps.meta.outputs.version }}
-            REVISION=${{ github.sha }}
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,9 +62,9 @@ jobs:
           context: .
           file: ./Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
-          #build-args: |
-          #  TARGETOS=linux
-          #  TARGETARCH=amd64
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
+            REVISION=${{ github.sha }}
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- OCI standard labels (`org.opencontainers.image.*`) on the Topograph container image; the docker workflow passes `VERSION` and `REVISION` build-args from release metadata ([#377](https://github.com/NVIDIA/topograph/pull/377)).
+- OCI labels missing from `docker/metadata-action` on the Topograph container image: `org.opencontainers.image.documentation`, `authors`, and `vendor` ([#377](https://github.com/NVIDIA/topograph/pull/377)).
 - Helm chart metadata: `home`, `icon`, `maintainers`, `keywords`, and Artifact Hub annotations ([#377](https://github.com/NVIDIA/topograph/pull/377)).
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- OCI standard labels (`org.opencontainers.image.*`) on the Topograph container image; the docker workflow passes `VERSION` and `REVISION` build-args from release metadata ([#377](https://github.com/NVIDIA/topograph/pull/377)).
+- Helm chart metadata: `home`, `icon`, `maintainers`, `keywords`, and Artifact Hub annotations ([#377](https://github.com/NVIDIA/topograph/pull/377)).
+
 ### Fixed
 
 - Helm node-observer now targets the rendered Topograph Service fullname in `generateTopologyUrl`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,20 +10,10 @@ RUN make build-${TARGETOS}-${TARGETARCH}
 
 FROM alpine:3
 
-ARG VERSION=dev
-ARG REVISION=unknown
-
 RUN apk add --no-cache rdma-core
 
 COPY --from=builder /go/src/github.com/NVIDIA/topograph/bin/* /usr/local/bin/
 
-LABEL org.opencontainers.image.title="Topograph" \
-    org.opencontainers.image.description="Discovers the physical network topology of a cluster and exposes it to schedulers." \
-    org.opencontainers.image.url="https://github.com/NVIDIA/topograph" \
-    org.opencontainers.image.source="https://github.com/NVIDIA/topograph" \
-    org.opencontainers.image.documentation="https://github.com/NVIDIA/topograph/blob/main/docs/overview.md" \
+LABEL org.opencontainers.image.documentation="https://github.com/NVIDIA/topograph/blob/main/docs/overview.md" \
     org.opencontainers.image.authors="NVIDIA CORPORATION" \
-    org.opencontainers.image.vendor="NVIDIA" \
-    org.opencontainers.image.licenses="Apache-2.0" \
-    org.opencontainers.image.version="${VERSION}" \
-    org.opencontainers.image.revision="${REVISION}"
+    org.opencontainers.image.vendor="NVIDIA"

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,4 @@ LABEL org.opencontainers.image.title="Topograph" \
     org.opencontainers.image.vendor="NVIDIA" \
     org.opencontainers.image.licenses="Apache-2.0" \
     org.opencontainers.image.version="${VERSION}" \
-    org.opencontainers.image.revision="${REVISION}" \
-    org.opencontainers.image.base.name="docker.io/library/alpine:3"
+    org.opencontainers.image.revision="${REVISION}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,21 @@ RUN make build-${TARGETOS}-${TARGETARCH}
 
 FROM alpine:3
 
+ARG VERSION=dev
+ARG REVISION=unknown
+
 RUN apk add --no-cache rdma-core
 
 COPY --from=builder /go/src/github.com/NVIDIA/topograph/bin/* /usr/local/bin/
+
+LABEL org.opencontainers.image.title="Topograph" \
+    org.opencontainers.image.description="Discovers the physical network topology of a cluster and exposes it to schedulers." \
+    org.opencontainers.image.url="https://github.com/NVIDIA/topograph" \
+    org.opencontainers.image.source="https://github.com/NVIDIA/topograph" \
+    org.opencontainers.image.documentation="https://github.com/NVIDIA/topograph/blob/main/docs/overview.md" \
+    org.opencontainers.image.authors="NVIDIA CORPORATION" \
+    org.opencontainers.image.vendor="NVIDIA" \
+    org.opencontainers.image.licenses="Apache-2.0" \
+    org.opencontainers.image.version="${VERSION}" \
+    org.opencontainers.image.revision="${REVISION}" \
+    org.opencontainers.image.base.name="docker.io/library/alpine:3"

--- a/charts/topograph/Chart.yaml
+++ b/charts/topograph/Chart.yaml
@@ -1,28 +1,40 @@
 apiVersion: v2
 name: topograph
-description: A Helm chart for Kubernetes
+description: Discovers the physical network topology of a cluster and exposes it to schedulers.
 kubeVersion: ">=1.27.0-0"
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.5.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
 appVersion: "v0.5.0"
+
+home: https://github.com/NVIDIA/topograph
+icon: https://raw.githubusercontent.com/NVIDIA/topograph/main/docs/assets/topograph-logo.png
+sources:
+  - https://github.com/NVIDIA/topograph
+maintainers:
+  - name: NVIDIA CORPORATION
+    url: https://www.nvidia.com
+keywords:
+  - topograph
+  - topology
+  - kubernetes
+  - slurm
+  - slinky
+  - infiniband
+  - gpu
+  - scheduling
+annotations:
+  org.opencontainers.image.title: Topograph
+  org.opencontainers.image.description: Discovers the physical network topology of a cluster and exposes it to schedulers.
+  org.opencontainers.image.vendor: NVIDIA
+  org.opencontainers.image.licenses: Apache-2.0
+  org.opencontainers.image.source: https://github.com/NVIDIA/topograph
+  org.opencontainers.image.documentation: https://github.com/NVIDIA/topograph/blob/main/docs/overview.md
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: Documentation
+      url: https://github.com/NVIDIA/topograph/blob/main/docs/overview.md
+    - name: Chart Source
+      url: https://github.com/NVIDIA/topograph/tree/main/charts/topograph
 
 dependencies:
   - name: node-data-broker


### PR DESCRIPTION
## Summary
- Add OCI standard labels to the Topograph container image (`Dockerfile`), with `VERSION` and `REVISION` build-args wired from the docker workflow
- Pass `VERSION` and `REVISION` from `docker/metadata-action` into image builds via `build-push-action`
- Enrich `charts/topograph/Chart.yaml` with chart metadata (description, home, icon, maintainers, keywords, Artifact Hub annotations)

## Test plan
- [x] `helm lint charts/topograph`
- [ ] Trigger `.github/workflows/docker.yml` and verify published image labels (`org.opencontainers.image.*`)
- [ ] Confirm `helm show chart` / Artifact Hub metadata render as expected after release