### PR TITLE
fix(slinky): consolidate and guard pod-to-SLURM node name resolution

### DIFF
--- a/pkg/engines/slinky/engine.go
+++ b/pkg/engines/slinky/engine.go
@@ -222,6 +222,10 @@ func (eng *SlinkyEngine) getClusterNodes(ctx context.Context) (*clusterNodes, *h
 			continue
 		}
 		host := resolveSlurmNodeName(&pod)
+		if host == "" {
+			klog.Warningf("Cannot resolve SLURM node name for pod %s/%s, skipping", pod.Namespace, pod.Name)
+			continue
+		}
 		klog.V(4).Infof("Mapping k8s node %s to SLURM node %s", pod.Spec.NodeName, host)
 		nodeMap[pod.Spec.NodeName] = host
 	}

--- a/pkg/engines/slinky/engine.go
+++ b/pkg/engines/slinky/engine.go
@@ -188,6 +188,15 @@ func (eng *SlinkyEngine) GetComputeInstances(ctx context.Context, _ any) ([]topo
 	return getComputeInstances(clusterNodes.nodes, clusterNodes.nodeMap)
 }
 
+// resolveSlurmNodeName resolves a slurmd pod's SLURM node name, preferring the
+// KeySlurmNodeName label and falling back to the pod's hostname.
+func resolveSlurmNodeName(pod *corev1.Pod) string {
+	if name, ok := pod.Labels[topology.KeySlurmNodeName]; ok {
+		return name
+	}
+	return pod.Spec.Hostname
+}
+
 // getClusterNodes returns the Kubernetes nodes selected for topology generation
 // and a map from Kubernetes node name to Slurm node name. The mapping is built
 // from Ready slurmd pods in the configured namespace and pod selector, using the
@@ -212,10 +221,7 @@ func (eng *SlinkyEngine) getClusterNodes(ctx context.Context) (*clusterNodes, *h
 		if !k8s.IsPodReady(&pod) {
 			continue
 		}
-		host, ok := pod.Labels[topology.KeySlurmNodeName]
-		if !ok {
-			host = pod.Spec.Hostname
-		}
+		host := resolveSlurmNodeName(&pod)
 		klog.V(4).Infof("Mapping k8s node %s to SLURM node %s", pod.Spec.NodeName, host)
 		nodeMap[pod.Spec.NodeName] = host
 	}
@@ -513,10 +519,7 @@ func (eng *SlinkyEngine) listPartitionNodes(ctx context.Context, sel *metav1.Lab
 			klog.Warningf("topology: skipped not Ready pod %s/%s (selector %s)", pod.Namespace, pod.Name, s.String())
 			continue
 		}
-		host, ok := pod.Labels[topology.KeySlurmNodeName]
-		if !ok {
-			host = pod.Spec.Hostname
-		}
+		host := resolveSlurmNodeName(&pod)
 		if host == "" {
 			klog.Warningf("topology: cannot find Slurm hostname for pod %s/%s (selector %s)", pod.Namespace, pod.Name, s.String())
 			continue

--- a/pkg/engines/slinky/engine_test.go
+++ b/pkg/engines/slinky/engine_test.go
@@ -557,6 +557,56 @@ func TestResolveSlurmNodeName(t *testing.T) {
 	}
 }
 
+func TestGetClusterNodes(t *testing.T) {
+	namespace := "test-ns"
+	podSel := metav1.LabelSelector{MatchLabels: map[string]string{"app": "slinky"}}
+	sel, err := metav1.LabelSelectorAsSelector(&podSel)
+	require.NoError(t, err)
+
+	readyCond := []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}
+	pod := func(name, nodeName, slurmLabel, hostname string, ready bool) *corev1.Pod {
+		labels := map[string]string{"app": "slinky"}
+		if slurmLabel != "" {
+			labels[topology.KeySlurmNodeName] = slurmLabel
+		}
+		status := corev1.PodStatus{Phase: corev1.PodRunning}
+		if ready {
+			status.Conditions = readyCond
+		}
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: labels},
+			Spec:       corev1.PodSpec{NodeName: nodeName, Hostname: hostname},
+			Status:     status,
+		}
+	}
+
+	// pod-empty-label carries the slurm.node.name label with an empty value (distinct
+	// from the label being absent): resolveSlurmNodeName must not fall back to the
+	// hostname, so the guard still skips it.
+	emptyLabelPod := pod("pod-empty-label", "k8s-5", "", "host-5", true)
+	emptyLabelPod.Labels[topology.KeySlurmNodeName] = ""
+
+	client := fake.NewSimpleClientset(
+		pod("pod-label", "k8s-1", "slurm-1", "", true),     // mapped via label
+		pod("pod-hostname", "k8s-2", "", "slurm-2", true),  // mapped via hostname fallback
+		pod("pod-empty", "k8s-3", "", "", true),            // skipped: ready but no SLURM name (the guard)
+		pod("pod-notready", "k8s-4", "slurm-4", "", false), // skipped: not Ready
+		emptyLabelPod, // skipped: label present but empty (no hostname fallback)
+	)
+	eng := &SlinkyEngine{
+		client: client,
+		params: &Params{
+			Namespace:   namespace,
+			podListOpt:  &metav1.ListOptions{LabelSelector: sel.String()},
+			nodeListOpt: &metav1.ListOptions{},
+		},
+	}
+
+	clusterNodes, httpErr := eng.getClusterNodes(context.Background())
+	require.Nil(t, httpErr)
+	require.Equal(t, map[string]string{"k8s-1": "slurm-1", "k8s-2": "slurm-2"}, clusterNodes.nodeMap)
+}
+
 // Helper for annotation checks
 func requireAnnotation(t *testing.T, annotations map[string]string, key, expected string) {
 	val, ok := annotations[key]

--- a/pkg/engines/slinky/engine_test.go
+++ b/pkg/engines/slinky/engine_test.go
@@ -516,6 +516,47 @@ func makeReadySlurmdPod(name, nodeName, slurmName string) *corev1.Pod {
 	}
 }
 
+func TestResolveSlurmNodeName(t *testing.T) {
+	testCases := []struct {
+		name string
+		pod  *corev1.Pod
+		want string
+	}{
+		{
+			name: "label takes precedence over hostname",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{topology.KeySlurmNodeName: "slurm-node-1"}},
+				Spec:       corev1.PodSpec{Hostname: "host-1"},
+			},
+			want: "slurm-node-1",
+		},
+		{
+			name: "present but empty label yields empty, no hostname fallback",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{topology.KeySlurmNodeName: ""}},
+				Spec:       corev1.PodSpec{Hostname: "host-1"},
+			},
+			want: "",
+		},
+		{
+			name: "falls back to hostname when label absent",
+			pod:  &corev1.Pod{Spec: corev1.PodSpec{Hostname: "host-1"}},
+			want: "host-1",
+		},
+		{
+			name: "empty when neither label nor hostname set",
+			pod:  &corev1.Pod{},
+			want: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, resolveSlurmNodeName(tc.pod))
+		})
+	}
+}
+
 // Helper for annotation checks
 func requireAnnotation(t *testing.T, annotations map[string]string, key, expected string) {
 	val, ok := annotations[key]


### PR DESCRIPTION
## Description

Cleans up and hardens how the Slinky engine maps a slurmd pod to its SLURM node name.

The label-then-hostname resolution (the `slurm.node.name` label, falling back to `pod.Spec.Hostname`) was duplicated inline in both `getClusterNodes` and `listPartitionNodes`. This PR consolidates it into a single `resolveSlurmNodeName` helper and fixes a latent bug the duplication hid.

**Refactor (behavior-preserving):** extract `resolveSlurmNodeName(pod)` as the single source of truth for the label/hostname resolution; both call sites now use it. Each caller keeps its own surrounding logic, so behavior is unchanged.

**Fix:** `getClusterNodes` previously mapped a Ready pod's Kubernetes node to an empty SLURM node name when the pod had neither the `slurm.node.name` label nor a hostname, leaving a `node -> ""` entry in the node map (which surfaced downstream as a bogus `instance -> ""` in the compute-instance mapping). It now skips such pods with a warning, mirroring the existing guard in `listPartitionNodes`. Keeping empty values out of the map at the source means all downstream consumers (compute-instance mapping, GPU-clique domains, node reconciliation) can rely on every mapped node having a real SLURM name.

**Tests:**
- `TestResolveSlurmNodeName`: label precedence, present-but-empty label (returns `""`, no hostname fallback), hostname fallback, and the empty case.
- `TestGetClusterNodes`: label mapping, hostname fallback, the empty-name skip (regression guard for the fix), and the not-Ready skip.

No user-facing behavior or configuration changes; `scontrol`-based discovery is unchanged.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).