### PR TITLE
feat(helm): add container customization hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `govulncheck` job in the Go CI workflow for symbol-level vulnerability scanning on pull requests.
 - OCI labels missing from `docker/metadata-action` on the Topograph container image: `org.opencontainers.image.documentation`, `authors`, and `vendor` ([#377](https://github.com/NVIDIA/topograph/pull/377)).
 - Helm chart metadata: `home`, `icon`, `maintainers`, `keywords`, and Artifact Hub annotations ([#377](https://github.com/NVIDIA/topograph/pull/377)).
+- Helm `env`, `initContainers`, and `lifecycle` overrides across the API server, node-observer, and node-data-broker containers.
 
 ### Changed
 

--- a/charts/topograph/README.md
+++ b/charts/topograph/README.md
@@ -104,6 +104,8 @@ The chart depends on two subcharts, both managed as local file dependencies:
 
 Both are installed together when you install this chart. Their values are accessible under the top-level keys `node-data-broker` and `node-observer` (enabled by default).
 
+The API server, node-observer, and node-data-broker containers all support `env`, `initContainers`, and `lifecycle` overrides for deployment-specific integration hooks.
+
 ## References
 
 - **Project documentation site**: <https://topograph.docs.buildwithfern.com/topograph>

--- a/charts/topograph/charts/node-data-broker/templates/daemonset.yaml
+++ b/charts/topograph/charts/node-data-broker/templates/daemonset.yaml
@@ -25,6 +25,10 @@ spec:
       serviceAccountName: {{ include "node-data-broker.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -49,6 +53,14 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- with .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.port }}

--- a/charts/topograph/charts/node-data-broker/values.yaml
+++ b/charts/topograph/charts/node-data-broker/values.yaml
@@ -58,6 +58,15 @@ rbac:
 
 verbosity: 3
 
+# Additional environment variables for the node-data-broker container.
+env: {}
+
+# Additional init containers for the node-data-broker Pod.
+initContainers: []
+
+# Optional lifecycle hooks for the node-data-broker container.
+lifecycle: {}
+
 podAnnotations: {}
 podLabels: {}
 

--- a/charts/topograph/charts/node-observer/templates/deployment.yaml
+++ b/charts/topograph/charts/node-observer/templates/deployment.yaml
@@ -30,6 +30,10 @@ spec:
       serviceAccountName: {{ include "node-observer.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -40,6 +44,17 @@ spec:
             - /usr/local/bin/node-observer
           args:
             - -v={{ .Values.verbosity }}
+          {{- with .Values.env }}
+          env:
+            {{- range $key, $value := . }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- end }}
+          {{- with .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/topograph/charts/node-observer/values.yaml
+++ b/charts/topograph/charts/node-observer/values.yaml
@@ -31,6 +31,15 @@ rbac:
 
 verbosity: 3
 
+# Additional environment variables for the node-observer container.
+env: {}
+
+# Additional init containers for the node-observer Pod.
+initContainers: []
+
+# Optional lifecycle hooks for the node-observer container.
+lifecycle: {}
+
 topograph:
   # Watches the Topograph API pod and triggers topology generation when the
   # API becomes Ready after startup or a container restart.

--- a/charts/topograph/templates/deployment.yaml
+++ b/charts/topograph/templates/deployment.yaml
@@ -34,6 +34,10 @@ spec:
       serviceAccountName: {{ include "topograph.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -65,6 +69,10 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
+          {{- with .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.global.service.port }}

--- a/charts/topograph/tests/deployment_test.yaml
+++ b/charts/topograph/tests/deployment_test.yaml
@@ -198,16 +198,38 @@ tests:
           content: -k8s-topology-key-accelerator=network.topology.nvidia.com/accelerator
         template: templates/deployment.yaml
 
-  - it: renders user-supplied environment variables
+  - it: renders user-supplied environment variables, initContainers, and lifecycle
     set:
       env:
         HTTP_PROXY: http://proxy.example.com:3128
+      initContainers:
+        - name: wait-for-proxy
+          image: busybox:latest
+          command:
+            - sh
+            - -c
+            - "true"
+      lifecycle:
+        preStop:
+          exec:
+            command:
+              - sh
+              - -c
+              - "true"
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: HTTP_PROXY
             value: "http://proxy.example.com:3128"
+        template: templates/deployment.yaml
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-proxy
+        template: templates/deployment.yaml
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          value: "true"
         template: templates/deployment.yaml
 
   - it: mounts a credentials secret volume when configured

--- a/charts/topograph/tests/deployment_test.yaml
+++ b/charts/topograph/tests/deployment_test.yaml
@@ -201,9 +201,9 @@ tests:
   - it: renders user-supplied environment variables, initContainers, and lifecycle
     set:
       env:
-        HTTP_PROXY: http://proxy.example.com:3128
+        FOO: BAR
       initContainers:
-        - name: wait-for-proxy
+        - name: wait-for-dummy
           image: busybox:latest
           command:
             - sh
@@ -220,12 +220,12 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: HTTP_PROXY
-            value: "http://proxy.example.com:3128"
+            name: FOO
+            value: BAR
         template: templates/deployment.yaml
       - equal:
           path: spec.template.spec.initContainers[0].name
-          value: wait-for-proxy
+          value: wait-for-dummy
         template: templates/deployment.yaml
       - equal:
           path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]

--- a/charts/topograph/tests/deployment_test.yaml
+++ b/charts/topograph/tests/deployment_test.yaml
@@ -203,7 +203,7 @@ tests:
       env:
         FOO: BAR
       initContainers:
-        - name: wait-for-dummy
+        - name: test-init
           image: busybox:latest
           command:
             - sh
@@ -225,7 +225,7 @@ tests:
         template: templates/deployment.yaml
       - equal:
           path: spec.template.spec.initContainers[0].name
-          value: wait-for-dummy
+          value: test-init
         template: templates/deployment.yaml
       - equal:
           path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]

--- a/charts/topograph/tests/subcharts_test.yaml
+++ b/charts/topograph/tests/subcharts_test.yaml
@@ -93,6 +93,40 @@ tests:
           path: spec.template.spec.containers[0].image
           pattern: "^ghcr.io/nvidia/topograph:v[0-9]+\\.[0-9]+\\.[0-9]+$"
 
+  - it: node-observer renders user-supplied environment variables, initContainers, and lifecycle
+    templates:
+      - charts/node-observer/templates/deployment.yaml
+    set:
+      node-observer:
+        env:
+          HTTP_PROXY: http://proxy.example.com:3128
+        initContainers:
+          - name: wait-for-api
+            image: busybox:latest
+            command:
+              - sh
+              - -c
+              - "true"
+        lifecycle:
+          preStop:
+            exec:
+              command:
+                - sh
+                - -c
+                - "true"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HTTP_PROXY
+            value: "http://proxy.example.com:3128"
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-api
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          value: "true"
+
   - it: node-data-broker renders the broker as the main container by default
     templates:
       - charts/node-data-broker/templates/daemonset.yaml
@@ -126,6 +160,23 @@ tests:
       global:
         provider:
           name: infiniband-k8s
+      node-data-broker:
+        env:
+          LD_LIBRARY_PATH: /var/lib/nvml-mock/driver/usr/lib64
+        initContainers:
+          - name: copy-tools
+            image: busybox:latest
+            command:
+              - sh
+              - -c
+              - cp /bin/true /tools/true
+        lifecycle:
+          postStart:
+            exec:
+              command:
+                - sh
+                - -c
+                - "true"
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
@@ -137,6 +188,17 @@ tests:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LD_LIBRARY_PATH
+            value: /var/lib/nvml-mock/driver/usr/lib64
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: copy-tools
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.postStart.exec.command[2]
+          value: "true"
 
   - it: node-data-broker container passes the refresh interval
     templates:

--- a/charts/topograph/tests/subcharts_test.yaml
+++ b/charts/topograph/tests/subcharts_test.yaml
@@ -99,7 +99,7 @@ tests:
     set:
       node-observer:
         env:
-          HTTP_PROXY: http://proxy.example.com:3128
+          FOO: BAR
         initContainers:
           - name: wait-for-api
             image: busybox:latest
@@ -118,8 +118,8 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: HTTP_PROXY
-            value: "http://proxy.example.com:3128"
+            name: FOO
+            value: BAR
       - equal:
           path: spec.template.spec.initContainers[0].name
           value: wait-for-api
@@ -162,7 +162,7 @@ tests:
           name: infiniband-k8s
       node-data-broker:
         env:
-          LD_LIBRARY_PATH: /var/lib/nvml-mock/driver/usr/lib64
+          FOO: BAR
         initContainers:
           - name: copy-tools
             image: busybox:latest
@@ -191,8 +191,8 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: LD_LIBRARY_PATH
-            value: /var/lib/nvml-mock/driver/usr/lib64
+            name: FOO
+            value: BAR
       - equal:
           path: spec.template.spec.initContainers[0].name
           value: copy-tools

--- a/charts/topograph/values.schema.json
+++ b/charts/topograph/values.schema.json
@@ -117,6 +117,8 @@
       "maximum": 10
     },
     "env": { "type": "object" },
+    "initContainers": { "type": "array" },
+    "lifecycle": { "type": "object" },
     "config": { "type": "object" },
     "topologyNodeLabels": { "type": "object" },
     "podAnnotations": { "type": "object" },

--- a/charts/topograph/values.yaml
+++ b/charts/topograph/values.yaml
@@ -54,6 +54,10 @@ verbosity: 3
 
 env: {}
 
+initContainers: []
+
+lifecycle: {}
+
 config:
   requestAggregationDelay: 15s
   # Optional secret with API credentials


### PR DESCRIPTION
## Description
Expose `env`, `initContainers`, and `lifecycle` values consistently across the Topograph API server, node-observer, and node-data-broker chart containers.

This also updates Helm unit coverage, the chart schema, the chart README, and the unreleased changelog entry for the new chart customization surface.

## Test plan
- [x] `make chart-test`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).