### PR TITLE
fix(chart): drop unused RBAC verbs from API server and node-data-broker ClusterRoles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Helm node-observer now targets the rendered Topograph Service fullname in `generateTopologyUrl`.
 
+### Security
+
+- Removed unused RBAC verbs from the Topograph API server and node-data-broker ClusterRoles (least-privilege): API server `pods` rule dropped `get` (list-only), `daemonsets` rule dropped `list` (get-only), and the Slinky `configmaps` rule dropped `list`; node-data-broker `nodes` rule dropped `list` (get/update), and the InfiniBand `daemonsets`/`pods` rules dropped `list`/`get` respectively (get-only, list-only).
+
 ## [0.5.0] - 2026-06-30
 
 ### Added

--- a/charts/topograph/charts/node-data-broker/templates/rbac.yaml
+++ b/charts/topograph/charts/node-data-broker/templates/rbac.yaml
@@ -8,14 +8,14 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: [nodes]
-  verbs: [get,list,update]
+  verbs: [get,update]
 {{- if and (eq .Values.global.provider.name "infiniband-k8s") (not $useGpuCliqueLabel) }}
 - apiGroups: [apps]
   resources: [daemonsets]
-  verbs: [get,list]
+  verbs: [get]
 - apiGroups: [""]
   resources: [pods]
-  verbs: [get,list]
+  verbs: [list]
 - apiGroups: [""]
   resources: [pods/exec]
   verbs: [create]

--- a/charts/topograph/templates/rbac.yaml
+++ b/charts/topograph/templates/rbac.yaml
@@ -32,7 +32,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: [pods]
-  verbs: [get,list]
+  verbs: [list]
 {{- if $needsPodExec.value }}
 - apiGroups: [""]
   resources: [pods/exec]
@@ -43,11 +43,11 @@ rules:
   verbs: [get,list,update]
 - apiGroups: [apps]
   resources: [daemonsets]
-  verbs: [get,list]
+  verbs: [get]
 {{- if eq .Values.global.engine.name "slinky" }}
 - apiGroups: [""]
   resources: [configmaps]
-  verbs: [create,get,list,update]
+  verbs: [create,get,update]
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/topograph/tests/__snapshot__/render_snapshot_test.yaml.snap
+++ b/charts/topograph/tests/__snapshot__/render_snapshot_test.yaml.snap
@@ -81,7 +81,6 @@ renders default values.yaml:
           - nodes
         verbs:
           - get
-          - list
           - update
   3: |
     apiVersion: rbac.authorization.k8s.io/v1
@@ -354,7 +353,6 @@ renders default values.yaml:
         resources:
           - pods
         verbs:
-          - get
           - list
       - apiGroups:
           - ""
@@ -370,7 +368,6 @@ renders default values.yaml:
           - daemonsets
         verbs:
           - get
-          - list
   15: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
@@ -566,7 +563,6 @@ renders values.k8s.gateway-api-example.yaml:
           - nodes
         verbs:
           - get
-          - list
           - update
   3: |
     apiVersion: rbac.authorization.k8s.io/v1
@@ -861,7 +857,6 @@ renders values.k8s.gateway-api-example.yaml:
         resources:
           - pods
         verbs:
-          - get
           - list
       - apiGroups:
           - ""
@@ -877,7 +872,6 @@ renders values.k8s.gateway-api-example.yaml:
           - daemonsets
         verbs:
           - get
-          - list
   16: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
@@ -1075,7 +1069,6 @@ renders values.k8s.gcp-federated-workload-identity-example.yaml:
           - nodes
         verbs:
           - get
-          - list
           - update
   3: |
     apiVersion: rbac.authorization.k8s.io/v1
@@ -1371,7 +1364,6 @@ renders values.k8s.gcp-federated-workload-identity-example.yaml:
         resources:
           - pods
         verbs:
-          - get
           - list
       - apiGroups:
           - ""
@@ -1387,7 +1379,6 @@ renders values.k8s.gcp-federated-workload-identity-example.yaml:
           - daemonsets
         verbs:
           - get
-          - list
   15: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
@@ -1585,7 +1576,6 @@ renders values.k8s.gcp-service-account-example.yaml:
           - nodes
         verbs:
           - get
-          - list
           - update
   3: |
     apiVersion: rbac.authorization.k8s.io/v1
@@ -1869,7 +1859,6 @@ renders values.k8s.gcp-service-account-example.yaml:
         resources:
           - pods
         verbs:
-          - get
           - list
       - apiGroups:
           - ""
@@ -1885,7 +1874,6 @@ renders values.k8s.gcp-service-account-example.yaml:
           - daemonsets
         verbs:
           - get
-          - list
   15: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
@@ -2093,7 +2081,6 @@ renders values.k8s.ib-example.yaml:
           - nodes
         verbs:
           - get
-          - list
           - update
   3: |
     apiVersion: rbac.authorization.k8s.io/v1
@@ -2369,7 +2356,6 @@ renders values.k8s.ib-example.yaml:
         resources:
           - pods
         verbs:
-          - get
           - list
       - apiGroups:
           - ""
@@ -2391,7 +2377,6 @@ renders values.k8s.ib-example.yaml:
           - daemonsets
         verbs:
           - get
-          - list
   15: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
@@ -2587,7 +2572,6 @@ renders values.slinky.block-example.yaml:
           - nodes
         verbs:
           - get
-          - list
           - update
   3: |
     apiVersion: rbac.authorization.k8s.io/v1
@@ -2884,7 +2868,6 @@ renders values.slinky.block-example.yaml:
         resources:
           - pods
         verbs:
-          - get
           - list
       - apiGroups:
           - ""
@@ -2900,7 +2883,6 @@ renders values.slinky.block-example.yaml:
           - daemonsets
         verbs:
           - get
-          - list
       - apiGroups:
           - ""
         resources:
@@ -2908,7 +2890,6 @@ renders values.slinky.block-example.yaml:
         verbs:
           - create
           - get
-          - list
           - update
   15: |
     apiVersion: rbac.authorization.k8s.io/v1
@@ -3105,7 +3086,6 @@ renders values.slinky.partition-example.yaml:
           - nodes
         verbs:
           - get
-          - list
           - update
   3: |
     apiVersion: rbac.authorization.k8s.io/v1
@@ -3419,7 +3399,6 @@ renders values.slinky.partition-example.yaml:
         resources:
           - pods
         verbs:
-          - get
           - list
       - apiGroups:
           - ""
@@ -3435,7 +3414,6 @@ renders values.slinky.partition-example.yaml:
           - daemonsets
         verbs:
           - get
-          - list
       - apiGroups:
           - ""
         resources:
@@ -3443,7 +3421,6 @@ renders values.slinky.partition-example.yaml:
         verbs:
           - create
           - get
-          - list
           - update
   15: |
     apiVersion: rbac.authorization.k8s.io/v1
@@ -3640,7 +3617,6 @@ renders values.slinky.tree-example.yaml:
           - nodes
         verbs:
           - get
-          - list
           - update
   3: |
     apiVersion: rbac.authorization.k8s.io/v1
@@ -3929,7 +3905,6 @@ renders values.slinky.tree-example.yaml:
         resources:
           - pods
         verbs:
-          - get
           - list
       - apiGroups:
           - ""
@@ -3945,7 +3920,6 @@ renders values.slinky.tree-example.yaml:
           - daemonsets
         verbs:
           - get
-          - list
       - apiGroups:
           - ""
         resources:
@@ -3953,7 +3927,6 @@ renders values.slinky.tree-example.yaml:
         verbs:
           - create
           - get
-          - list
           - update
   15: |
     apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/topograph/tests/rbac_test.yaml
+++ b/charts/topograph/tests/rbac_test.yaml
@@ -57,7 +57,7 @@ tests:
           content:
             apiGroups: [""]
             resources: [pods]
-            verbs: [get, list]
+            verbs: [list]
       - contains:
           path: rules
           content:
@@ -69,7 +69,7 @@ tests:
           content:
             apiGroups: [apps]
             resources: [daemonsets]
-            verbs: [get, list]
+            verbs: [get]
 
   - it: does not grant pods/exec or configmaps with the default provider and engine
     documentIndex: 0
@@ -86,6 +86,18 @@ tests:
             apiGroups: [""]
             resources: [configmaps]
             verbs: [create, get, list, update]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [pods]
+            verbs: [get, list]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [apps]
+            resources: [daemonsets]
+            verbs: [get, list]
 
   - it: grants pods/exec for the infiniband-k8s provider
     set:
@@ -109,6 +121,12 @@ tests:
     documentIndex: 0
     asserts:
       - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [configmaps]
+            verbs: [create, get, update]
+      - notContains:
           path: rules
           content:
             apiGroups: [""]

--- a/charts/topograph/tests/subchart_rbac_test.yaml
+++ b/charts/topograph/tests/subchart_rbac_test.yaml
@@ -71,6 +71,12 @@ tests:
           content:
             apiGroups: [""]
             resources: [nodes]
+            verbs: [get, update]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
             verbs: [get, list, update]
       - notContains:
           path: rules
@@ -117,6 +123,12 @@ tests:
     documentIndex: 0
     asserts:
       - contains:
+          path: rules
+          content:
+            apiGroups: [apps]
+            resources: [daemonsets]
+            verbs: [get]
+      - notContains:
           path: rules
           content:
             apiGroups: [apps]

--- a/charts/topograph/tests/subchart_rbac_test.yaml
+++ b/charts/topograph/tests/subchart_rbac_test.yaml
@@ -138,6 +138,18 @@ tests:
           path: rules
           content:
             apiGroups: [""]
+            resources: [pods]
+            verbs: [list]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [pods]
+            verbs: [get, list]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
             resources: [pods/exec]
             verbs: [create]
 


### PR DESCRIPTION
## Description

Removes provably-unused RBAC verbs from the Topograph API server and node-data-broker `ClusterRole`s, tightening them toward least privilege. No runtime behavior changes — every dropped verb has zero call sites in the codebase.

Dropped verbs:
- **API server (`topograph`)**: `pods: get`, `daemonsets: list`, `configmaps: list` (slinky engine rule)
- **node-data-broker**: `nodes: list`, `daemonsets: list` (IB rule), `pods: get` (IB rule)

Each removal was cross-referenced against actual `client-go` usage: the observer/broker/engine code paths use `List`/`Watch`/`Get`/`Update`/`Create` only where retained, and never exercise the dropped verbs (e.g. no `Pods().Get`, no `DaemonSets().List`, no `ConfigMaps().List` anywhere; the broker uses no informers and never lists nodes). The retained verbs are unchanged, so no supported provider/engine combination loses a grant it uses.

Helm-unittest coverage was extended with discriminating `contains`/`notContains` assertions in `rbac_test.yaml` and `subchart_rbac_test.yaml` (each mutation-verified to fail if a dropped verb reappears), and the render snapshot was refreshed.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).
