### PR TITLE
fix: bump Go toolchain to 1.25.12 for GO-2026-5856 (crypto/tls)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -62,7 +62,7 @@ These structures propagate across every provider and engine. Changing them in a 
 
 ### Prerequisites
 
-- **Go 1.25.11** (see `go.mod`) — newer minor versions are fine; older will not build
+- **Go 1.25.12** (see `go.mod`) — newer minor versions are fine; older will not build
 - **make**
 - **golangci-lint** — `brew install golangci-lint` or via `go install`
 - **helm 3.10+ or 4.x** — required for `make chart-test`; the `helm-unittest` plugin is installed automatically by the target (`brew install helm`). CI pins helm `v4.1.1` in `.github/workflows/chart-test.yaml`.

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.11'
+        go-version: '1.25.12'
 
     - name: Lint
       uses: golangci/golangci-lint-action@v9
@@ -42,7 +42,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.11'
+        go-version: '1.25.12'
 
     - name: Test
       run: go test -v -coverpkg=./... -coverprofile=coverage.out -covermode=atomic ./...
@@ -63,7 +63,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.11'
+        go-version: '1.25.12'
 
     - name: Build
       run: |
@@ -78,7 +78,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.11'
+        go-version: '1.25.12'
         cache: true
 
     - name: Run govulncheck

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ These structures propagate across every provider and engine. Changing them in a 
 
 ### Prerequisites
 
-- **Go 1.25.11** (see `go.mod`) — newer minor versions are fine; older will not build
+- **Go 1.25.12** (see `go.mod`) — newer minor versions are fine; older will not build
 - **make**
 - **golangci-lint** — `brew install golangci-lint` or via `go install`
 - **helm 3.10+ or 4.x** — required for `make chart-test`; the `helm-unittest` plugin is installed automatically by the target (`brew install helm`). CI pins helm `v4.1.1` in `.github/workflows/chart-test.yaml`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- Go toolchain bumped to **1.25.11** (`go.mod`, `Dockerfile`, CI) to address reachable stdlib vulnerabilities reported by `govulncheck`.
+- Go toolchain bumped to **1.25.12** (`go.mod`, `Dockerfile`, CI) to address reachable stdlib vulnerabilities reported by `govulncheck`, most recently [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856) (Encrypted Client Hello privacy leak in `crypto/tls`).
 - Slinky engine `useGpuCliqueLabel` now emits an actionable diagnostic when no block domains can be built: the error reports how many nodes were scanned and why each was skipped (no Slurm mapping, missing `nvidia.com/gpu.clique` label, or missing the node-data-broker-written `topograph.nvidia.com/instance` annotation), and lists the offending node names. When no Kubernetes nodes are selected at all, it reports a distinct error pointing at the engine `nodeSelector`.
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.11 AS builder
+FROM golang:1.25.12 AS builder
 
 WORKDIR /go/src/github.com/NVIDIA/topograph
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/NVIDIA/topograph
 
-go 1.25.11
+go 1.25.12
 
 require (
 	cloud.google.com/go/compute v1.60.0


### PR DESCRIPTION
## Description

`govulncheck` in CI is failing on `main` and on every open PR because of a newly-published Go standard-library advisory, **[GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856)** — an Encrypted Client Hello privacy leak in `crypto/tls`. It is reachable from `internal/httpreq`, `pkg/server/http_server.go`, and `pkg/engines/slurm`, so `govulncheck` exits non-zero. It is **fixed in the Go standard library at 1.25.12**.

This bumps the pinned toolchain `1.25.11 → 1.25.12` in the four places it appears (`go.mod` `go` directive, `Dockerfile` builder image, and the four `setup-go` pins in `.github/workflows/go.yml`), and refreshes the version reference in `AGENTS.md`, `.claude/CLAUDE.md`, and the existing `CHANGELOG.md` `[Unreleased]` entry.

No source changes; the same maintenance step as the previous `1.25.x` bumps.

### Verification

```
$ govulncheck ./...
No vulnerabilities found.
Your code is affected by 0 vulnerabilities.
```
`make qualify` passes (fmt, vet, lint, test).

This unblocks CI on `main` and on the open RBAC-hardening PRs (#384, #385).

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).
