### PR TITLE
docs(dra): attribute gpu.clique label to GPU Feature Discovery, not the DRA driver

### DIFF
--- a/docs/providers/dra.md
+++ b/docs/providers/dra.md
@@ -1,6 +1,6 @@
 # DRA Topology Provider
 
-The DRA provider discovers NVLink domain membership by reading `nvidia.com/gpu.clique` node labels set by the [NVIDIA GPU Operator](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/index.html)'s Dynamic Resource Allocation (DRA) driver. It is a Kubernetes-only provider that uses in-cluster service account auth — no credentials are required.
+The DRA provider discovers NVLink domain membership by reading `nvidia.com/gpu.clique` node labels set by the [NVIDIA GPU Operator](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/index.html)'s [GPU Feature Discovery (GFD)](https://github.com/NVIDIA/k8s-device-plugin/blob/main/docs/gpu-feature-discovery/README.md). It is a Kubernetes-only provider that uses in-cluster service account auth — no credentials are required.
 
 **Important**: The DRA provider produces **block topology only** (`topology/block` — NVLink domain membership). It does not discover switch tree topology. If you need both switch tree and NVLink domain topology, use the [InfiniBand](./infiniband.md) or [NetQ](./netq.md) provider instead.
 
@@ -8,7 +8,7 @@ The DRA provider discovers NVLink domain membership by reading `nvidia.com/gpu.c
 
 On GB200 NVL72 and similar Multi-Node NVLink (MNNVL) hardware, groups of nodes share a high-bandwidth NVLink fabric (1.8 TB/s chip-to-chip). Workloads that span these nodes — distributed training, disaggregated inference — benefit significantly from being placed within the same NVLink domain.
 
-Kubernetes exposes this through **ComputeDomains**, a DRA-based abstraction that represents a set of nodes sharing an NVLink/MNNVL domain as a first-class scheduling object. The GPU Operator's DRA driver labels each node with `nvidia.com/gpu.clique` to encode its NVLink clique membership. Schedulers like [KAI Scheduler](https://github.com/NVIDIA/KAI-Scheduler) consume these labels — via Topograph — to make topology-aware placement decisions.
+Kubernetes exposes this through **ComputeDomains**, a DRA-based abstraction that represents a set of nodes sharing an NVLink/MNNVL domain as a first-class scheduling object. The GPU Operator's GPU Feature Discovery (GFD) labels each node with `nvidia.com/gpu.clique` to encode its NVLink clique membership. Schedulers like [KAI Scheduler](https://github.com/NVIDIA/KAI-Scheduler) consume these labels — via Topograph — to make topology-aware placement decisions.
 
 The DRA provider is Topograph's integration point for this ecosystem. For more background, see:
 - [Enabling Multi-Node NVLink on Kubernetes for GB200 and Beyond](https://developer.nvidia.com/blog/enabling-multi-node-nvlink-on-kubernetes-for-gb200-and-beyond/)
@@ -27,7 +27,7 @@ If you also need switch tree topology — for example to express the full fabric
 
 ## How It Works
 
-The `nvidia.com/gpu.clique` labels are applied automatically by the GPU Operator's DRA driver — these are not manually configured by users.
+The `nvidia.com/gpu.clique` labels are applied automatically by the GPU Operator's GPU Feature Discovery (GFD) — these are not manually configured by users.
 
 Topograph reads these labels from the Kubernetes API:
 
@@ -40,7 +40,7 @@ If no nodes with matching labels are found, Topograph returns a `502` error with
 ## Prerequisites
 
 - Kubernetes cluster with the NVIDIA GPU Operator deployed and DRA support enabled
-- Nodes must have `nvidia.com/gpu.clique` labels — applied automatically by the DRA driver
+- Nodes must have `nvidia.com/gpu.clique` labels — applied automatically by GPU Feature Discovery (GFD)
 
 ## Parameters
 


### PR DESCRIPTION
## Description

`docs/providers/dra.md` attributes the `nvidia.com/gpu.clique` node label to "the GPU Operator's Dynamic Resource Allocation (DRA) driver" in four places (intro, Background, How It Works, Prerequisites). The label is actually written by **GPU Feature Discovery (GFD)** — specifically the IMEX labeler in NVIDIA/k8s-device-plugin ([`internal/lm/imex.go`](https://github.com/NVIDIA/k8s-device-plugin/blob/main/internal/lm/imex.go), `newImexLabeler`). The DRA driver (NVIDIA/k8s-dra-driver-gpu) does not set node labels.

This repo's own `docs/reference/node-labels.md` already attributes the label correctly ("The GPU Operator device plugin sets `nvidia.com/gpu.clique`…", "The GPU Operator's IMEX labeler writes `nvidia.com/gpu.clique`…"), so this change brings `dra.md` in line with it.

The distinction matters operationally: GFD applies the label regardless of whether DRA is enabled, so the current wording can lead readers to assume enabling DRA is a prerequisite for the label (and for this provider) when it is not.

Note for maintainers: the Prerequisites section still lists "NVIDIA GPU Operator deployed and DRA support enabled" — left unchanged here since it may be intentional guidance about the provider's target ecosystem (ComputeDomains), but strictly speaking the provider only requires the GFD-applied label.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/topograph/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes. (docs-only change)
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).

Generated with [Claude Code](https://claude.com/claude-code)

Supersedes #389 (closed by mistake while working around a PR-head sync delay after a force-push; GitHub does not allow reopening in that state).
