### PR TITLE
feat(kwok): generate KWOK nodes from topology models

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -23,7 +23,7 @@ This separation is load-bearing. If you find yourself reading the fabric in an e
 ### Repository map
 
 ```
-cmd/                  # Four entry points: topograph, node-observer, node-data-broker
+cmd/                  # Entry points: topograph, node-observer, node-data-broker, kwok-nodes
 pkg/
   providers/          # One directory per provider: aws, gcp, oci, nebius, netq, dra, infiniband, lambdai, cw, test
   engines/            # One directory per engine: k8s, slinky, slurm
@@ -73,7 +73,7 @@ These structures propagate across every provider and engine. Changing them in a 
 ```bash
 git clone https://github.com/NVIDIA/topograph.git
 cd topograph
-make build   # produces bin/topograph, bin/node-observer, bin/node-data-broker
+make build   # produces bin/topograph, bin/node-observer, bin/node-data-broker, bin/kwok-nodes
 ```
 
 Cross-compile with `make build-linux-amd64`, `make build-darwin-arm64`, etc.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ This separation is load-bearing. If you find yourself reading the fabric in an e
 ### Repository map
 
 ```
-cmd/                  # Four entry points: topograph, node-observer, node-data-broker
+cmd/                  # Entry points: topograph, node-observer, node-data-broker, kwok-nodes
 pkg/
   providers/          # One directory per provider: aws, gcp, oci, nebius, netq, dra, infiniband, lambdai, cw, test
   engines/            # One directory per engine: k8s, slinky, slurm
@@ -73,7 +73,7 @@ These structures propagate across every provider and engine. Changing them in a 
 ```bash
 git clone https://github.com/NVIDIA/topograph.git
 cd topograph
-make build   # produces bin/topograph, bin/node-observer, bin/node-data-broker
+make build   # produces bin/topograph, bin/node-observer, bin/node-data-broker, bin/kwok-nodes
 ```
 
 Cross-compile with `make build-linux-amd64`, `make build-darwin-arm64`, etc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Helm chart metadata: `home`, `icon`, `maintainers`, `keywords`, and Artifact Hub annotations ([#377](https://github.com/NVIDIA/topograph/pull/377)).
 - Helm `env`, `initContainers`, and `lifecycle` overrides across the API server, node-observer, and node-data-broker containers.
 - Lambda provider Kubernetes node-data-broker support: Topograph instance and region annotations are derived from Lambda node `.spec.providerID` and `topology.kubernetes.io/region`, enabling automatic node discovery with the Kubernetes engine ([#375](https://github.com/NVIDIA/topograph/pull/375)).
+- `kwok-nodes` utility and helper script for rendering model-derived KWOK node manifests, creating local kind clusters, and installing KWOK.
 
 ### Changed
 
@@ -26,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `kwok-nodes` now maps generated instance IDs back to model hostnames when naming Kubernetes nodes and writing the Topograph instance annotation.
 - The node-observer now discovers the optional node-data-broker through `NODE_DATA_BROKER_NAME` and `NODE_DATA_BROKER_NAMESPACE` and gates topology generation on the broker DaemonSet's desired and ready replica counts. Helm injects the variables only when `nodeDataBroker.enabled=true`, so disabling the broker cannot leave the observer waiting for nonexistent pods.
 - The node-observer reports an actionable error and defers topology generation when an enabled node-data-broker DaemonSet has zero desired replicas.
 - Helm node-observer now targets the rendered Topograph Service fullname in `generateTopologyUrl`.

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ DOCKER_BIN ?= docker
 GOOS ?= $(shell uname | tr '[:upper:]' '[:lower:]')
 GOARCH ?= $(shell arch | sed 's/x86_64/amd64/')
 PLATFORMS ?= linux/arm64,linux/amd64
-TARGETS := topograph node-observer node-data-broker
+TARGETS := topograph node-observer node-data-broker kwok-nodes
 CMD_DIR := ./cmd
 OUTPUT_DIR := ./bin
 

--- a/charts/topograph/values.k8s.kind-kwok.yaml
+++ b/charts/topograph/values.k8s.kind-kwok.yaml
@@ -1,36 +1,22 @@
 provider:
   name: test
+  params:
+    modelFileName: medium.yaml
+    generateResponseCode: 202
+    topologyResponseCode: 200
 engine:
   name: k8s
-service:
-  type: ClusterIP
-  port: 49021
-
-nodeDataBroker:
-  enabled: false
-
-replicaCount: 1
-
-image:
-  repository: ghcr.io/nvidia/topograph
-  tag: ce8db4f
-  pullPolicy: IfNotPresent
-
-verbosity: 4
 
 nodeSelector:
   node-role.kubernetes.io/control-plane: ""
-
-tolerations: []
-
-affinity: {}
 
 nodeObserver:
   nodeSelector:
     node-role.kubernetes.io/control-plane: ""
   topograph:
-    nodeDataBroker:
-      enabled: false
     trigger:
       nodeSelector:
         kwok.x-k8s.io/node: "fake"
+
+nodeDataBroker:
+  enabled: false

--- a/cmd/kwok-nodes/main.go
+++ b/cmd/kwok-nodes/main.go
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/NVIDIA/topograph/internal/kwok"
+	"github.com/NVIDIA/topograph/internal/version"
+	"github.com/NVIDIA/topograph/pkg/models"
+)
+
+type options struct {
+	modelFile  string
+	outputFile string
+	version    bool
+	capacity   kwok.Capacity
+}
+
+func main() {
+	opts := parseFlags()
+	if opts.version {
+		fmt.Println("Version:", version.Version)
+		os.Exit(0)
+	}
+
+	if err := mainInternal(opts); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func parseFlags() options {
+	opts := options{
+		capacity: kwok.DefaultCapacity(),
+	}
+
+	flag.StringVar(&opts.modelFile, "model", "", "model file to load; basenames resolve from tests/models")
+	flag.StringVar(&opts.outputFile, "output", "-", "output manifest path; use - for stdout")
+	flag.StringVar(&opts.capacity.CPU, "cpu", opts.capacity.CPU, "node CPU capacity")
+	flag.StringVar(&opts.capacity.Memory, "memory", opts.capacity.Memory, "node memory capacity")
+	flag.StringVar(&opts.capacity.Pods, "pods", opts.capacity.Pods, "node pod capacity")
+	flag.StringVar(&opts.capacity.EphemeralStorage, "ephemeral-storage", opts.capacity.EphemeralStorage, "node ephemeral-storage capacity")
+	flag.IntVar(&opts.capacity.GPUs, "gpus", opts.capacity.GPUs, "GPU capacity per node; 0 omits GPU capacity")
+	flag.StringVar(&opts.capacity.GPUResourceName, "gpu-resource-name", opts.capacity.GPUResourceName, "extended resource name for GPU capacity")
+	flag.BoolVar(&opts.version, "version", false, "show the version")
+	flag.Parse()
+
+	return opts
+}
+
+func mainInternal(opts options) error {
+	if opts.modelFile == "" {
+		return fmt.Errorf("missing required -model")
+	}
+
+	model, err := models.NewModelFromFile(opts.modelFile)
+	if err != nil {
+		return err
+	}
+
+	nodes, err := kwok.NodesFromModel(model, opts.capacity)
+	if err != nil {
+		return err
+	}
+
+	data, err := kwok.MarshalNodeManifest(nodes)
+	if err != nil {
+		return err
+	}
+
+	if opts.outputFile == "" || opts.outputFile == "-" {
+		_, err = os.Stdout.Write(data)
+		return err
+	}
+
+	return os.WriteFile(opts.outputFile, data, 0o644)
+}

--- a/cmd/kwok-nodes/main_test.go
+++ b/cmd/kwok-nodes/main_test.go
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/topograph/internal/kwok"
+)
+
+func TestMainInternalWritesManifest(t *testing.T) {
+	output := filepath.Join(t.TempDir(), "nodes.yaml")
+
+	err := mainInternal(options{
+		modelFile:  "../../tests/models/small-tree.yaml",
+		outputFile: output,
+		capacity:   kwok.DefaultCapacity(),
+	})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(output)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "kind: List")
+	require.Contains(t, string(data), "name: i21")
+}

--- a/docs/modeling.md
+++ b/docs/modeling.md
@@ -12,7 +12,59 @@ Model loading lives in `pkg/models`. Model fixtures live under `tests/models/`.
 
 ## Where Models Are Used
 
-Models are consumed in two different simulation flows.
+Models are consumed in several simulation and local-development flows.
+
+### KWOK Clusters
+
+`kwok-nodes` renders virtual Kubernetes `Node` objects from a model file as a plain YAML manifest. The helper script `scripts/create-test-cluster.sh` then creates or reuses a local kind cluster, installs KWOK into it, and applies that manifest. This is useful when you want to run Topograph against a Kubernetes API without provisioning real nodes.
+
+Prerequisites:
+
+- `kind` installed and available on `PATH`
+- `kubectl` installed and available on `PATH`
+- A Docker-compatible runtime supported by kind
+- Network access to GitHub releases when installing KWOK manifests
+
+Build the manifest renderer:
+
+```bash
+make build
+```
+
+Render a KWOK node manifest from one of the embedded model fixtures:
+
+```bash
+bin/kwok-nodes -model medium.yaml -output /tmp/kwok-nodes.yaml
+```
+
+Create or reuse a kind cluster named `topograph`, install KWOK, and apply the generated nodes:
+
+```bash
+scripts/create-test-cluster.sh -m medium.yaml
+```
+
+Create or reuse a named kind cluster from an explicit model path, and keep the generated manifest:
+
+```bash
+scripts/create-test-cluster.sh \
+  --cluster topo-demo \
+  --model tests/models/nvl72.yaml \
+  --output /tmp/nvl72-kwok-nodes.yaml \
+  --gpus 8
+```
+
+To pass a kind cluster configuration file, add `--kind-config path/to/kind.yaml`. To pin KWOK installation to a release, add `--kwok-release vX.Y.Z`; otherwise the script uses GitHub's latest KWOK release download URL.
+
+The utility uses the model-derived instance-to-hostname mapping, so model hostname `1101` becomes Kubernetes node `1101` with:
+
+- `topograph.nvidia.com/instance: i-1101`
+- `topograph.nvidia.com/region: <derived-region-or-none>`
+- `kwok.x-k8s.io/node=fake` as both a label and annotation
+- Model-derived labels such as `topology.kubernetes.io/region`, `topology.kubernetes.io/zone`, and `network.topology.nvidia.com/accelerator`
+
+Generated Kubernetes node names come from model hostnames and are normalized to valid lowercase DNS names. For example, model hostname `I21` becomes Kubernetes node `i21`, while its generated instance ID `i-I21` is stored in `topograph.nvidia.com/instance`.
+
+The script applies the manifest with kubeconfig context `kind-<cluster>`, matching the context name created by `kind create cluster --name=<cluster>`.
 
 ### Test Provider
 

--- a/internal/kwok/nodes.go
+++ b/internal/kwok/nodes.go
@@ -1,0 +1,278 @@
+/*
+ * Copyright 2026 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package kwok
+
+import (
+	"fmt"
+	"hash/fnv"
+	"maps"
+	"sort"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	"github.com/NVIDIA/topograph/pkg/models"
+	"github.com/NVIDIA/topograph/pkg/topology"
+)
+
+const (
+	NodeSelectorKey   = "kwok.x-k8s.io/node"
+	NodeSelectorValue = "fake"
+
+	defaultCPU              = "96"
+	defaultMemory           = "1024Gi"
+	defaultPods             = "110"
+	defaultEphemeralStorage = "10Gi"
+	defaultGPUResourceName  = "nvidia.com/gpu"
+)
+
+type Capacity struct {
+	CPU              string
+	Memory           string
+	Pods             string
+	EphemeralStorage string
+	GPUs             int
+	GPUResourceName  string
+}
+
+func DefaultCapacity() Capacity {
+	return Capacity{
+		CPU:              defaultCPU,
+		Memory:           defaultMemory,
+		Pods:             defaultPods,
+		EphemeralStorage: defaultEphemeralStorage,
+		GPUResourceName:  defaultGPUResourceName,
+	}
+}
+
+func NodesFromModel(model *models.Model, capacity Capacity) ([]*corev1.Node, error) {
+	resources, err := capacity.ResourceList()
+	if err != nil {
+		return nil, err
+	}
+
+	instanceInfo := newInstanceInfo(model.Instances)
+	hostNames := make([]string, 0, len(model.Nodes))
+	for hostName := range model.Nodes {
+		hostNames = append(hostNames, hostName)
+	}
+	sort.Strings(hostNames)
+
+	nodes := make([]*corev1.Node, 0, len(hostNames))
+	seenNodeNames := make(map[string]string, len(hostNames))
+	for _, hostName := range hostNames {
+		instance := model.Nodes[hostName]
+		info := instanceInfo[hostName]
+		if info.instanceID == "" {
+			return nil, fmt.Errorf("model hostname %q has no instance ID mapping", hostName)
+		}
+		nodeName := kubernetesNodeName(hostName)
+		if seenHostName, ok := seenNodeNames[nodeName]; ok {
+			return nil, fmt.Errorf("model hostnames %q and %q resolve to duplicate Kubernetes node name %q", seenHostName, hostName, nodeName)
+		}
+		seenNodeNames[nodeName] = hostName
+		if info.region == "" {
+			info.region = "none"
+		}
+
+		labels := map[string]string{
+			NodeSelectorKey: NodeSelectorValue,
+		}
+		maps.Copy(labels, instance.Labels)
+
+		annotations := map[string]string{
+			NodeSelectorKey:          NodeSelectorValue,
+			topology.KeyNodeInstance: info.instanceID,
+			topology.KeyNodeRegion:   info.region,
+		}
+
+		nodes = append(nodes, &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        nodeName,
+				Labels:      labels,
+				Annotations: annotations,
+			},
+			Spec: corev1.NodeSpec{
+				ProviderID: "kwok://" + nodeName,
+			},
+			Status: corev1.NodeStatus{
+				Capacity:    resources.DeepCopy(),
+				Allocatable: resources.DeepCopy(),
+			},
+		})
+	}
+
+	return nodes, nil
+}
+
+func MarshalNodeManifest(nodes []*corev1.Node) ([]byte, error) {
+	items := make([]nodeManifestItem, 0, len(nodes))
+	for _, node := range nodes {
+		items = append(items, nodeManifestItem{
+			APIVersion: "v1",
+			Kind:       "Node",
+			Metadata: nodeManifestMetadata{
+				Name:        node.Name,
+				Labels:      node.Labels,
+				Annotations: node.Annotations,
+			},
+			Spec: nodeManifestSpec{
+				ProviderID: node.Spec.ProviderID,
+			},
+			Status: nodeManifestStatus{
+				Capacity:    resourceStrings(node.Status.Capacity),
+				Allocatable: resourceStrings(node.Status.Allocatable),
+			},
+		})
+	}
+
+	return yaml.Marshal(nodeManifest{
+		APIVersion: "v1",
+		Kind:       "List",
+		Items:      items,
+	})
+}
+
+func (c Capacity) ResourceList() (corev1.ResourceList, error) {
+	c = c.withDefaults()
+	resources := corev1.ResourceList{}
+
+	if err := setResource(resources, corev1.ResourceCPU, c.CPU); err != nil {
+		return nil, err
+	}
+	if err := setResource(resources, corev1.ResourceMemory, c.Memory); err != nil {
+		return nil, err
+	}
+	if err := setResource(resources, corev1.ResourcePods, c.Pods); err != nil {
+		return nil, err
+	}
+	if err := setResource(resources, corev1.ResourceEphemeralStorage, c.EphemeralStorage); err != nil {
+		return nil, err
+	}
+	if c.GPUs > 0 {
+		resources[corev1.ResourceName(c.GPUResourceName)] = resource.MustParse(strconv.Itoa(c.GPUs))
+	}
+
+	return resources, nil
+}
+
+func (c Capacity) withDefaults() Capacity {
+	defaults := DefaultCapacity()
+	if c.CPU == "" {
+		c.CPU = defaults.CPU
+	}
+	if c.Memory == "" {
+		c.Memory = defaults.Memory
+	}
+	if c.Pods == "" {
+		c.Pods = defaults.Pods
+	}
+	if c.EphemeralStorage == "" {
+		c.EphemeralStorage = defaults.EphemeralStorage
+	}
+	if c.GPUResourceName == "" {
+		c.GPUResourceName = defaults.GPUResourceName
+	}
+	return c
+}
+
+func setResource(resources corev1.ResourceList, name corev1.ResourceName, value string) error {
+	quantity, err := resource.ParseQuantity(value)
+	if err != nil {
+		return fmt.Errorf("invalid %s quantity %q: %v", name, value, err)
+	}
+	resources[name] = quantity
+	return nil
+}
+
+type nodeInfo struct {
+	instanceID string
+	region     string
+}
+
+func newInstanceInfo(instances []topology.ComputeInstances) map[string]nodeInfo {
+	info := make(map[string]nodeInfo)
+	for _, ci := range instances {
+		for instanceID, hostName := range ci.Instances {
+			info[hostName] = nodeInfo{
+				instanceID: instanceID,
+				region:     ci.Region,
+			}
+		}
+	}
+	return info
+}
+
+func kubernetesNodeName(name string) string {
+	name = strings.ToLower(name)
+	var b strings.Builder
+	b.Grow(len(name))
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '.' {
+			b.WriteRune(r)
+			continue
+		}
+		b.WriteByte('-')
+	}
+
+	normalized := strings.Trim(b.String(), "-.")
+	if normalized == "" {
+		normalized = "node"
+	}
+	if len(normalized) <= 253 {
+		return normalized
+	}
+
+	hash := fnv.New64a()
+	_, _ = hash.Write([]byte(normalized))
+	suffix := fmt.Sprintf("-%x", hash.Sum64())
+	normalized = strings.TrimRight(normalized[:253-len(suffix)], "-.") + suffix
+	return normalized
+}
+
+type nodeManifest struct {
+	APIVersion string             `json:"apiVersion"`
+	Kind       string             `json:"kind"`
+	Items      []nodeManifestItem `json:"items"`
+}
+
+type nodeManifestItem struct {
+	APIVersion string               `json:"apiVersion"`
+	Kind       string               `json:"kind"`
+	Metadata   nodeManifestMetadata `json:"metadata"`
+	Spec       nodeManifestSpec     `json:"spec"`
+	Status     nodeManifestStatus   `json:"status"`
+}
+
+type nodeManifestMetadata struct {
+	Name        string            `json:"name"`
+	Labels      map[string]string `json:"labels,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+type nodeManifestSpec struct {
+	ProviderID string `json:"providerID,omitempty"`
+}
+
+type nodeManifestStatus struct {
+	Capacity    map[string]string `json:"capacity,omitempty"`
+	Allocatable map[string]string `json:"allocatable,omitempty"`
+}
+
+func resourceStrings(resources corev1.ResourceList) map[string]string {
+	if len(resources) == 0 {
+		return nil
+	}
+	values := make(map[string]string, len(resources))
+	for name, quantity := range resources {
+		values[string(name)] = quantity.String()
+	}
+	return values
+}

--- a/internal/kwok/nodes_test.go
+++ b/internal/kwok/nodes_test.go
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package kwok
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/NVIDIA/topograph/pkg/models"
+	"github.com/NVIDIA/topograph/pkg/topology"
+)
+
+func TestNodesFromModel(t *testing.T) {
+	model, err := models.NewModelFromFile("../../tests/models/small-tree.yaml")
+	require.NoError(t, err)
+
+	nodes, err := NodesFromModel(model, Capacity{
+		CPU:              "8",
+		Memory:           "64Gi",
+		Pods:             "42",
+		EphemeralStorage: "1Ti",
+		GPUs:             8,
+	})
+	require.NoError(t, err)
+	require.Len(t, nodes, 6)
+
+	node := nodes[0]
+	require.Equal(t, "i21", node.Name)
+	require.Equal(t, map[string]string{
+		NodeSelectorKey:         NodeSelectorValue,
+		models.LabelAccelerator: "nvl2",
+	}, node.Labels)
+	require.Equal(t, map[string]string{
+		NodeSelectorKey:          NodeSelectorValue,
+		topology.KeyNodeInstance: "i-I21",
+		topology.KeyNodeRegion:   "none",
+	}, node.Annotations)
+	require.Equal(t, "kwok://i21", node.Spec.ProviderID)
+	require.Equal(t, resource.MustParse("8"), node.Status.Capacity[corev1.ResourceCPU])
+	require.Equal(t, resource.MustParse("64Gi"), node.Status.Capacity[corev1.ResourceMemory])
+	require.Equal(t, resource.MustParse("42"), node.Status.Capacity[corev1.ResourcePods])
+	require.Equal(t, resource.MustParse("1Ti"), node.Status.Capacity[corev1.ResourceEphemeralStorage])
+	require.Equal(t, resource.MustParse("8"), node.Status.Capacity[corev1.ResourceName(defaultGPUResourceName)])
+	require.Equal(t, node.Status.Capacity, node.Status.Allocatable)
+}
+
+func TestNodesFromModelUsesDerivedRegionAndLabels(t *testing.T) {
+	model, err := models.NewModelFromFile("../../tests/models/medium.yaml")
+	require.NoError(t, err)
+
+	nodes, err := NodesFromModel(model, DefaultCapacity())
+	require.NoError(t, err)
+
+	var node *corev1.Node
+	for _, candidate := range nodes {
+		if candidate.Name == "1301" {
+			node = candidate
+			break
+		}
+	}
+	require.NotNil(t, node)
+	require.Equal(t, "i-1301", node.Annotations[topology.KeyNodeInstance])
+	require.Equal(t, "us-west", node.Annotations[topology.KeyNodeRegion])
+	require.Equal(t, "us-west", node.Labels[models.LabelTopologyRegion])
+	require.Equal(t, "zone2", node.Labels[models.LabelTopologyZone])
+	require.Equal(t, "nvl3", node.Labels[models.LabelAccelerator])
+}
+
+func TestMarshalNodeManifest(t *testing.T) {
+	model, err := models.NewModelFromFile("../../tests/models/small-tree.yaml")
+	require.NoError(t, err)
+	nodes, err := NodesFromModel(model, DefaultCapacity())
+	require.NoError(t, err)
+
+	data, err := MarshalNodeManifest(nodes)
+	require.NoError(t, err)
+
+	manifest := string(data)
+	require.Contains(t, manifest, "apiVersion: v1")
+	require.Contains(t, manifest, "kind: List")
+	require.Contains(t, manifest, "name: i21")
+	require.Contains(t, manifest, "topograph.nvidia.com/instance: i-I21")
+}
+
+func TestCapacityRejectsInvalidQuantities(t *testing.T) {
+	_, err := (Capacity{CPU: "not-a-quantity"}).ResourceList()
+	require.ErrorContains(t, err, `invalid cpu quantity "not-a-quantity"`)
+}
+
+func TestKubernetesNodeName(t *testing.T) {
+	require.Equal(t, "n-i21", kubernetesNodeName("n-I21"))
+	require.Equal(t, "node-name", kubernetesNodeName(".Node_Name."))
+	require.Equal(t, "node", kubernetesNodeName("___"))
+}

--- a/scripts/create-test-cluster.sh
+++ b/scripts/create-test-cluster.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+CLUSTER="topograph"
+KIND_CONFIG=""
+MODEL=""
+OUTPUT=""
+CPU="96"
+MEMORY="1024Gi"
+PODS="110"
+EPHEMERAL_STORAGE="10Gi"
+GPUS="0"
+GPU_RESOURCE_NAME="nvidia.com/gpu"
+KWOK_RELEASE="latest"
+WAIT="120s"
+
+usage() {
+  cat <<EOF
+Usage: $0 -m <model-file> [options]
+
+Create or reuse a kind cluster, install KWOK in it, and populate it with
+virtual nodes rendered from a Topograph model file.
+
+Options:
+  -m, --model <file>              Model file. Basenames resolve from tests/models.
+  -c, --cluster <name>            kind cluster name. Default: ${CLUSTER}
+      --kind-config <file>        Optional kind cluster config for cluster creation.
+  -o, --output <file>             Keep the generated Node manifest at this path.
+      --kwok-release <tag>        KWOK release tag to install, or latest. Default: ${KWOK_RELEASE}
+      --wait <duration>           kind cluster readiness wait timeout. Default: ${WAIT}
+      --cpu <quantity>            Node CPU capacity. Default: ${CPU}
+      --memory <quantity>         Node memory capacity. Default: ${MEMORY}
+      --pods <quantity>           Node pod capacity. Default: ${PODS}
+      --ephemeral-storage <qty>   Node ephemeral-storage capacity. Default: ${EPHEMERAL_STORAGE}
+      --gpus <count>              GPU capacity per node. Default: ${GPUS}
+      --gpu-resource-name <name>  GPU extended resource name. Default: ${GPU_RESOURCE_NAME}
+  -h, --help                      Show this help.
+
+Environment:
+  KIND                            kind binary. Default: kind
+  KUBECTL                         kubectl binary. Default: kubectl
+  KWOK_NODES_BIN                  kwok-nodes binary. Default: bin/kwok-nodes
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -m|--model)
+      MODEL="$2"
+      shift 2
+      ;;
+    -c|--cluster)
+      CLUSTER="$2"
+      shift 2
+      ;;
+    --kind-config)
+      KIND_CONFIG="$2"
+      shift 2
+      ;;
+    -o|--output)
+      OUTPUT="$2"
+      shift 2
+      ;;
+    --kwok-release)
+      KWOK_RELEASE="$2"
+      shift 2
+      ;;
+    --wait)
+      WAIT="$2"
+      shift 2
+      ;;
+    --cpu)
+      CPU="$2"
+      shift 2
+      ;;
+    --memory)
+      MEMORY="$2"
+      shift 2
+      ;;
+    --pods)
+      PODS="$2"
+      shift 2
+      ;;
+    --ephemeral-storage)
+      EPHEMERAL_STORAGE="$2"
+      shift 2
+      ;;
+    --gpus)
+      GPUS="$2"
+      shift 2
+      ;;
+    --gpu-resource-name)
+      GPU_RESOURCE_NAME="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${MODEL}" ]]; then
+  echo "missing required --model" >&2
+  usage >&2
+  exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+KIND="${KIND:-kind}"
+KUBECTL="${KUBECTL:-kubectl}"
+KWOK_NODES_BIN="${KWOK_NODES_BIN:-${REPO_ROOT}/bin/kwok-nodes}"
+CONTEXT="kind-${CLUSTER}"
+
+kwok_release_url() {
+  local file="$1"
+  if [[ "${KWOK_RELEASE}" == "latest" ]]; then
+    echo "https://github.com/kubernetes-sigs/kwok/releases/latest/download/${file}"
+  else
+    echo "https://github.com/kubernetes-sigs/kwok/releases/download/${KWOK_RELEASE}/${file}"
+  fi
+}
+
+apply_with_retry() {
+  local description="$1"
+  local manifest="$2"
+
+  for attempt in 1 2 3 4 5; do
+    if "${KUBECTL}" --context "${CONTEXT}" apply -f "${manifest}"; then
+      return 0
+    fi
+    echo "Retrying ${description} install (${attempt}/5)" >&2
+    sleep 2
+  done
+
+  echo "failed to apply ${description}: ${manifest}" >&2
+  return 1
+}
+
+if [[ ! -x "${KWOK_NODES_BIN}" ]]; then
+  echo "Building ${KWOK_NODES_BIN}"
+  (cd "${REPO_ROOT}" && go build -o "${KWOK_NODES_BIN}" ./cmd/kwok-nodes)
+fi
+
+TMP_DIR=""
+if [[ -n "${OUTPUT}" ]]; then
+  mkdir -p "$(dirname "${OUTPUT}")"
+  MANIFEST="${OUTPUT}"
+else
+  TMP_DIR="$(mktemp -d)"
+  trap 'rm -rf "${TMP_DIR}"' EXIT
+  MANIFEST="${TMP_DIR}/kwok-nodes.yaml"
+fi
+
+"${KWOK_NODES_BIN}" \
+  -model "${MODEL}" \
+  -output "${MANIFEST}" \
+  -cpu "${CPU}" \
+  -memory "${MEMORY}" \
+  -pods "${PODS}" \
+  -ephemeral-storage "${EPHEMERAL_STORAGE}" \
+  -gpus "${GPUS}" \
+  -gpu-resource-name "${GPU_RESOURCE_NAME}"
+
+if "${KIND}" get clusters 2>/dev/null | grep -Fxq "${CLUSTER}"; then
+  echo "Reusing kind cluster ${CLUSTER}"
+else
+  create_args=(create cluster --name "${CLUSTER}" --wait "${WAIT}")
+  if [[ -n "${KIND_CONFIG}" ]]; then
+    create_args+=(--config "${KIND_CONFIG}")
+  fi
+  "${KIND}" "${create_args[@]}"
+fi
+
+KWOK_MANIFEST_URL="$(kwok_release_url kwok.yaml)"
+KWOK_STAGE_URL="$(kwok_release_url stage-fast.yaml)"
+
+"${KUBECTL}" --context "${CONTEXT}" apply -f "${KWOK_MANIFEST_URL}"
+apply_with_retry "KWOK stage configuration" "${KWOK_STAGE_URL}"
+"${KUBECTL}" --context "${CONTEXT}" apply -f "${MANIFEST}"
+
+echo "kind cluster ${CONTEXT} is ready with KWOK nodes from ${MODEL}"
+if [[ -n "${OUTPUT}" ]]; then
+  echo "Node manifest written to ${OUTPUT}"
+fi


### PR DESCRIPTION
Add kwok-nodes to render model-derived Kubernetes Node manifests and a helper script to create or reuse a KWOK cluster and apply them.