### PR TITLE
fix(node-observer): gate topology generation on broker readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- The node-observer now discovers the optional node-data-broker through `NODE_DATA_BROKER_NAME` and `NODE_DATA_BROKER_NAMESPACE` and gates topology generation on the broker DaemonSet's desired and ready replica counts. Helm injects the variables only when `nodeDataBroker.enabled=true`, so disabling the broker cannot leave the observer waiting for nonexistent pods.
+- The node-observer reports an actionable error and defers topology generation when an enabled node-data-broker DaemonSet has zero desired replicas.
 - Helm node-observer now targets the rendered Topograph Service fullname in `generateTopologyUrl`.
 - Lambda provider client now matches the Lambda topology API request and response contract: required `region` query parameter, `{data, page_token}` envelope, `page_token` pagination, and `networkPath` object mapping ([#374](https://github.com/NVIDIA/topograph/pull/374)).
 - Slinky engine now skips pods without a resolvable Slurm node name instead of adding an empty instance-to-node mapping ([#380](https://github.com/NVIDIA/topograph/pull/380)).
+
+### Removed
+
+- Periodic node annotation refreshes, including the `--refresh-interval` broker flag and `nodeDataBroker.refreshInterval` Helm value. The broker now applies annotations once at startup.
 
 ### Security
 

--- a/charts/topograph/README.md
+++ b/charts/topograph/README.md
@@ -100,7 +100,7 @@ The main chart directly manages all three runtime workloads:
 
 - **Topograph API server** — serves topology generation and retrieval requests
 - **`node-data-broker`** — DaemonSet that collects per-node attributes (NVLink clique IDs, etc.) as node annotations for the Kubernetes engine
-- **`node-observer`** — watches configured node/pod changes and Topograph API readiness, then triggers topology regeneration
+- **`node-observer`** — watches configured node/pod changes and Topograph API readiness, waits for desired node-data-broker replicas when the broker is enabled, then triggers topology regeneration
 
 The component templates live under `templates/nodeDataBroker` and `templates/nodeObserver`. Their settings use the top-level `nodeDataBroker` and `nodeObserver` values keys; the broker is enabled by default.
 

--- a/charts/topograph/templates/NOTES.txt
+++ b/charts/topograph/templates/NOTES.txt
@@ -35,6 +35,13 @@
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
 {{- end }}
+{{- if not .Values.nodeDataBroker.enabled }}
+
+  NOTE: node-data-broker is disabled; the node-observer broker readiness gate is also disabled.
+{{- else }}
+
+  NOTE: node-data-broker applies node annotations once when each broker pod starts.
+{{- end }}
 {{- if not .Values.serviceAccount.create }}
 
 2. Topograph is configured to use the existing ServiceAccount "{{ include "topograph.serviceAccountName" . }}".

--- a/charts/topograph/templates/nodeDataBroker/daemonset.yaml
+++ b/charts/topograph/templates/nodeDataBroker/daemonset.yaml
@@ -41,7 +41,6 @@ spec:
             - --provider={{ .Values.provider.name }}
             - -v={{ .Values.verbosity }}
             - --port={{ .Values.nodeDataBroker.port }}
-            - --refresh-interval={{ .Values.nodeDataBroker.refreshInterval }}
             {{- if $useGpuCliqueLabel }}
             - --set=useGpuCliqueLabel=true
             {{- end }}

--- a/charts/topograph/templates/nodeObserver/configmap.yml
+++ b/charts/topograph/templates/nodeObserver/configmap.yml
@@ -25,18 +25,5 @@ data:
           app.kubernetes.io/instance: {{ .Release.Name }}
         {{- end }}
     {{- end }}
-    {{- if .Values.nodeObserver.topograph.nodeDataBroker.enabled }}
-    nodeDataBroker:
-      namespace: {{ .Release.Namespace }}
-      containerName: {{ .Values.nodeObserver.topograph.nodeDataBroker.containerName | default "node-data-broker" }}
-      podSelector:
-        {{- if .Values.nodeObserver.topograph.nodeDataBroker.podSelector }}
-        {{- toYaml .Values.nodeObserver.topograph.nodeDataBroker.podSelector | nindent 8 }}
-        {{- else }}
-        matchLabels:
-          app.kubernetes.io/name: node-data-broker
-          app.kubernetes.io/instance: {{ .Release.Name }}
-        {{- end }}
-    {{- end }}
     trigger:
       {{- toYaml .Values.nodeObserver.topograph.trigger | nindent 6 }}

--- a/charts/topograph/templates/nodeObserver/deployment.yaml
+++ b/charts/topograph/templates/nodeObserver/deployment.yaml
@@ -44,9 +44,15 @@ spec:
             - /usr/local/bin/node-observer
           args:
             - -v={{ .Values.verbosity }}
-          {{- with .Values.nodeObserver.env }}
+          {{- if or .Values.nodeDataBroker.enabled .Values.nodeObserver.env }}
           env:
-            {{- range $key, $value := . }}
+            {{- if .Values.nodeDataBroker.enabled }}
+            - name: NODE_DATA_BROKER_NAME
+              value: {{ include "nodeDataBroker.fullname" . }}
+            - name: NODE_DATA_BROKER_NAMESPACE
+              value: {{ .Release.Namespace }}
+            {{- end }}
+            {{- range $key, $value := .Values.nodeObserver.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}

--- a/charts/topograph/templates/nodeObserver/rbac.yaml
+++ b/charts/topograph/templates/nodeObserver/rbac.yaml
@@ -7,6 +7,11 @@ rules:
 - apiGroups: [""]
   resources: [pods]
   verbs: [list,watch]
+{{- if .Values.nodeDataBroker.enabled }}
+- apiGroups: [apps]
+  resources: [daemonsets]
+  verbs: [list,watch]
+{{- end }}
 {{- if (default dict .Values.nodeObserver.topograph.trigger).nodeSelector }}
 - apiGroups: [""]
   resources: [nodes]

--- a/charts/topograph/tests/__snapshot__/render_snapshot_test.yaml.snap
+++ b/charts/topograph/tests/__snapshot__/render_snapshot_test.yaml.snap
@@ -6,6 +6,8 @@ renders default values.yaml:
         export CONTAINER_PORT=$(kubectl get pod --namespace topograph $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
         echo "Visit http://127.0.0.1:8080 to use your application"
         kubectl --namespace topograph port-forward $POD_NAME 8080:$CONTAINER_PORT
+
+        NOTE: node-data-broker applies node annotations once when each broker pod starts.
   2: |
     apiVersion: v1
     data:
@@ -140,7 +142,6 @@ renders default values.yaml:
                 - --provider=test
                 - -v=3
                 - --port=8080
-                - --refresh-interval=5m
               command:
                 - /usr/local/bin/node-data-broker
               env:
@@ -247,13 +248,6 @@ renders default values.yaml:
             matchLabels:
               app.kubernetes.io/component: api-server
               app.kubernetes.io/instance: chart-ci
-        nodeDataBroker:
-          namespace: topograph
-          containerName: node-data-broker
-          podSelector:
-            matchLabels:
-              app.kubernetes.io/name: node-data-broker
-              app.kubernetes.io/instance: chart-ci
         trigger:
           null
     kind: ConfigMap
@@ -287,7 +281,7 @@ renders default values.yaml:
       template:
         metadata:
           annotations:
-            checksum/config: 7d8475cee3f6752c24cf2b4d1d87840c496740d409300139edd00fb8dbcc5490
+            checksum/config: ce1893e4c0757528265ccc6126f8267f7dcfab70208b237990c5fc187c3bc453
           labels:
             app.kubernetes.io/instance: chart-ci
             app.kubernetes.io/managed-by: Helm
@@ -300,6 +294,11 @@ renders default values.yaml:
                 - -v=3
               command:
                 - /usr/local/bin/node-observer
+              env:
+                - name: NODE_DATA_BROKER_NAME
+                  value: chart-ci-topograph-node-data-broker
+                - name: NODE_DATA_BROKER_NAMESPACE
+                  value: topograph
               image: ghcr.io/nvidia/topograph:v0.0.0
               imagePullPolicy: IfNotPresent
               name: node-observer
@@ -343,6 +342,13 @@ renders default values.yaml:
           - ""
         resources:
           - pods
+        verbs:
+          - list
+          - watch
+      - apiGroups:
+          - apps
+        resources:
+          - daemonsets
         verbs:
           - list
           - watch
@@ -543,6 +549,8 @@ renders values.k8s.gateway-api-example.yaml:
         NOTE: The above URL(s) resolve to the Gateway referenced by parentRefs.
               The Gateway is platform-owned; confirm the operator has provisioned
               it and (if needed) published its listener address in DNS.
+
+        NOTE: node-data-broker applies node annotations once when each broker pod starts.
   2: |
     apiVersion: v1
     data:
@@ -699,7 +707,6 @@ renders values.k8s.gateway-api-example.yaml:
                 - --provider=test
                 - -v=3
                 - --port=8080
-                - --refresh-interval=5m
               command:
                 - /usr/local/bin/node-data-broker
               env:
@@ -806,13 +813,6 @@ renders values.k8s.gateway-api-example.yaml:
             matchLabels:
               app.kubernetes.io/component: api-server
               app.kubernetes.io/instance: chart-ci
-        nodeDataBroker:
-          namespace: topograph
-          containerName: node-data-broker
-          podSelector:
-            matchLabels:
-              app.kubernetes.io/name: node-data-broker
-              app.kubernetes.io/instance: chart-ci
         trigger:
           null
     kind: ConfigMap
@@ -846,7 +846,7 @@ renders values.k8s.gateway-api-example.yaml:
       template:
         metadata:
           annotations:
-            checksum/config: 7d8475cee3f6752c24cf2b4d1d87840c496740d409300139edd00fb8dbcc5490
+            checksum/config: ce1893e4c0757528265ccc6126f8267f7dcfab70208b237990c5fc187c3bc453
           labels:
             app.kubernetes.io/instance: chart-ci
             app.kubernetes.io/managed-by: Helm
@@ -859,6 +859,11 @@ renders values.k8s.gateway-api-example.yaml:
                 - -v=3
               command:
                 - /usr/local/bin/node-observer
+              env:
+                - name: NODE_DATA_BROKER_NAME
+                  value: chart-ci-topograph-node-data-broker
+                - name: NODE_DATA_BROKER_NAMESPACE
+                  value: topograph
               image: ghcr.io/nvidia/topograph:v0.0.0
               imagePullPolicy: IfNotPresent
               name: node-observer
@@ -902,6 +907,13 @@ renders values.k8s.gateway-api-example.yaml:
           - ""
         resources:
           - pods
+        verbs:
+          - list
+          - watch
+      - apiGroups:
+          - apps
+        resources:
+          - daemonsets
         verbs:
           - list
           - watch
@@ -1102,6 +1114,8 @@ renders values.k8s.gcp-federated-workload-identity-example.yaml:
         export CONTAINER_PORT=$(kubectl get pod --namespace topograph $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
         echo "Visit http://127.0.0.1:8080 to use your application"
         kubectl --namespace topograph port-forward $POD_NAME 8080:$CONTAINER_PORT
+
+        NOTE: node-data-broker applies node annotations once when each broker pod starts.
   2: |
     apiVersion: v1
     data:
@@ -1254,7 +1268,6 @@ renders values.k8s.gcp-federated-workload-identity-example.yaml:
                 - --provider=gcp
                 - -v=3
                 - --port=8080
-                - --refresh-interval=5m
               command:
                 - /usr/local/bin/node-data-broker
               env:
@@ -1367,13 +1380,6 @@ renders values.k8s.gcp-federated-workload-identity-example.yaml:
             matchLabels:
               app.kubernetes.io/component: api-server
               app.kubernetes.io/instance: chart-ci
-        nodeDataBroker:
-          namespace: topograph
-          containerName: node-data-broker
-          podSelector:
-            matchLabels:
-              app.kubernetes.io/name: node-data-broker
-              app.kubernetes.io/instance: chart-ci
         trigger:
           nodeSelector:
             brightcomputing.com/node-category: dgx
@@ -1408,7 +1414,7 @@ renders values.k8s.gcp-federated-workload-identity-example.yaml:
       template:
         metadata:
           annotations:
-            checksum/config: 7407a18309c1e35c6e8870fe67e1b78d96c8e46ac06421320eb47221631d49bb
+            checksum/config: ab9e684e4fe6d8559973e231b610449f5fcb157903352e7d217b7624a7f7f4a1
           labels:
             app.kubernetes.io/instance: chart-ci
             app.kubernetes.io/managed-by: Helm
@@ -1421,6 +1427,11 @@ renders values.k8s.gcp-federated-workload-identity-example.yaml:
                 - -v=3
               command:
                 - /usr/local/bin/node-observer
+              env:
+                - name: NODE_DATA_BROKER_NAME
+                  value: chart-ci-topograph-node-data-broker
+                - name: NODE_DATA_BROKER_NAMESPACE
+                  value: topograph
               image: ghcr.io/nvidia/topograph:v0.0.0
               imagePullPolicy: IfNotPresent
               name: node-observer
@@ -1464,6 +1475,13 @@ renders values.k8s.gcp-federated-workload-identity-example.yaml:
           - ""
         resources:
           - pods
+        verbs:
+          - list
+          - watch
+      - apiGroups:
+          - apps
+        resources:
+          - daemonsets
         verbs:
           - list
           - watch
@@ -1671,6 +1689,8 @@ renders values.k8s.gcp-service-account-example.yaml:
         export CONTAINER_PORT=$(kubectl get pod --namespace topograph $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
         echo "Visit http://127.0.0.1:8080 to use your application"
         kubectl --namespace topograph port-forward $POD_NAME 8080:$CONTAINER_PORT
+
+        NOTE: node-data-broker applies node annotations once when each broker pod starts.
   2: |
     apiVersion: v1
     data:
@@ -1813,7 +1833,6 @@ renders values.k8s.gcp-service-account-example.yaml:
                 - --provider=gcp
                 - -v=3
                 - --port=8080
-                - --refresh-interval=5m
               command:
                 - /usr/local/bin/node-data-broker
               env:
@@ -1924,13 +1943,6 @@ renders values.k8s.gcp-service-account-example.yaml:
             matchLabels:
               app.kubernetes.io/component: api-server
               app.kubernetes.io/instance: chart-ci
-        nodeDataBroker:
-          namespace: topograph
-          containerName: node-data-broker
-          podSelector:
-            matchLabels:
-              app.kubernetes.io/name: node-data-broker
-              app.kubernetes.io/instance: chart-ci
         trigger:
           nodeSelector:
             brightcomputing.com/node-category: dgx
@@ -1965,7 +1977,7 @@ renders values.k8s.gcp-service-account-example.yaml:
       template:
         metadata:
           annotations:
-            checksum/config: 44107666a7433d03a89a48b034157cf3439c76af0e5b824a3d0141e37469af58
+            checksum/config: 34b5154f7f45009200945b31fc5a82f2c81e895c842cb7263f22fb0510e24dd0
           labels:
             app.kubernetes.io/instance: chart-ci
             app.kubernetes.io/managed-by: Helm
@@ -1978,6 +1990,11 @@ renders values.k8s.gcp-service-account-example.yaml:
                 - -v=3
               command:
                 - /usr/local/bin/node-observer
+              env:
+                - name: NODE_DATA_BROKER_NAME
+                  value: chart-ci-topograph-node-data-broker
+                - name: NODE_DATA_BROKER_NAMESPACE
+                  value: topograph
               image: ghcr.io/nvidia/topograph:v0.0.0
               imagePullPolicy: IfNotPresent
               name: node-observer
@@ -2021,6 +2038,13 @@ renders values.k8s.gcp-service-account-example.yaml:
           - ""
         resources:
           - pods
+        verbs:
+          - list
+          - watch
+      - apiGroups:
+          - apps
+        resources:
+          - daemonsets
         verbs:
           - list
           - watch
@@ -2228,6 +2252,8 @@ renders values.k8s.ib-example.yaml:
         export CONTAINER_PORT=$(kubectl get pod --namespace topograph $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
         echo "Visit http://127.0.0.1:8080 to use your application"
         kubectl --namespace topograph port-forward $POD_NAME 8080:$CONTAINER_PORT
+
+        NOTE: node-data-broker applies node annotations once when each broker pod starts.
   2: |
     apiVersion: v1
     data:
@@ -2362,7 +2388,6 @@ renders values.k8s.ib-example.yaml:
                 - --provider=infiniband-k8s
                 - -v=3
                 - --port=8080
-                - --refresh-interval=5m
                 - --set=useGpuCliqueLabel=true
               command:
                 - /usr/local/bin/node-data-broker
@@ -2483,13 +2508,6 @@ renders values.k8s.ib-example.yaml:
             matchLabels:
               app.kubernetes.io/component: api-server
               app.kubernetes.io/instance: chart-ci
-        nodeDataBroker:
-          namespace: topograph
-          containerName: node-data-broker
-          podSelector:
-            matchLabels:
-              app.kubernetes.io/name: node-data-broker
-              app.kubernetes.io/instance: chart-ci
         trigger:
           nodeSelector:
             nvidia.com/gpu.present: "true"
@@ -2524,7 +2542,7 @@ renders values.k8s.ib-example.yaml:
       template:
         metadata:
           annotations:
-            checksum/config: 85bfd491e2dcc1e6f6aab6cb79b26897046009796bcf8c017037ff932e1e0022
+            checksum/config: 12ded19ccdc256a879be87750e73e8df0458ba73f2df1995312e94f790dedfd5
           labels:
             app.kubernetes.io/instance: chart-ci
             app.kubernetes.io/managed-by: Helm
@@ -2537,6 +2555,11 @@ renders values.k8s.ib-example.yaml:
                 - -v=3
               command:
                 - /usr/local/bin/node-observer
+              env:
+                - name: NODE_DATA_BROKER_NAME
+                  value: chart-ci-topograph-node-data-broker
+                - name: NODE_DATA_BROKER_NAMESPACE
+                  value: topograph
               image: ghcr.io/nvidia/topograph:v0.0.0
               imagePullPolicy: IfNotPresent
               name: node-observer
@@ -2580,6 +2603,13 @@ renders values.k8s.ib-example.yaml:
           - ""
         resources:
           - pods
+        verbs:
+          - list
+          - watch
+      - apiGroups:
+          - apps
+        resources:
+          - daemonsets
         verbs:
           - list
           - watch
@@ -2793,6 +2823,8 @@ renders values.slinky.block-example.yaml:
         export CONTAINER_PORT=$(kubectl get pod --namespace topograph $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
         echo "Visit http://127.0.0.1:8080 to use your application"
         kubectl --namespace topograph port-forward $POD_NAME 8080:$CONTAINER_PORT
+
+        NOTE: node-data-broker applies node annotations once when each broker pod starts.
   2: |
     apiVersion: v1
     data:
@@ -2931,7 +2963,6 @@ renders values.slinky.block-example.yaml:
                 - --provider=aws
                 - -v=3
                 - --port=8080
-                - --refresh-interval=5m
               command:
                 - /usr/local/bin/node-data-broker
               env:
@@ -3054,13 +3085,6 @@ renders values.slinky.block-example.yaml:
             matchLabels:
               app.kubernetes.io/component: api-server
               app.kubernetes.io/instance: chart-ci
-        nodeDataBroker:
-          namespace: topograph
-          containerName: node-data-broker
-          podSelector:
-            matchLabels:
-              app.kubernetes.io/name: node-data-broker
-              app.kubernetes.io/instance: chart-ci
         trigger:
           podSelector:
             matchLabels:
@@ -3096,7 +3120,7 @@ renders values.slinky.block-example.yaml:
       template:
         metadata:
           annotations:
-            checksum/config: 5b16d5cb5c819d172baad4e00dc6298503dfd4f2f7558b77c9789e088d0df380
+            checksum/config: 7e2d3da5fcebb1ad73540cdeea400e6b5b3580c427dae006587cc40c46c31b01
           labels:
             app.kubernetes.io/instance: chart-ci
             app.kubernetes.io/managed-by: Helm
@@ -3109,6 +3133,11 @@ renders values.slinky.block-example.yaml:
                 - -v=3
               command:
                 - /usr/local/bin/node-observer
+              env:
+                - name: NODE_DATA_BROKER_NAME
+                  value: chart-ci-topograph-node-data-broker
+                - name: NODE_DATA_BROKER_NAMESPACE
+                  value: topograph
               image: ghcr.io/nvidia/topograph:v0.0.0
               imagePullPolicy: IfNotPresent
               name: node-observer
@@ -3154,6 +3183,13 @@ renders values.slinky.block-example.yaml:
           - ""
         resources:
           - pods
+        verbs:
+          - list
+          - watch
+      - apiGroups:
+          - apps
+        resources:
+          - daemonsets
         verbs:
           - list
           - watch
@@ -3362,6 +3398,8 @@ renders values.slinky.partition-example.yaml:
         export CONTAINER_PORT=$(kubectl get pod --namespace topograph $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
         echo "Visit http://127.0.0.1:8080 to use your application"
         kubectl --namespace topograph port-forward $POD_NAME 8080:$CONTAINER_PORT
+
+        NOTE: node-data-broker applies node annotations once when each broker pod starts.
   2: |
     apiVersion: v1
     data:
@@ -3500,7 +3538,6 @@ renders values.slinky.partition-example.yaml:
                 - --provider=aws
                 - -v=3
                 - --port=8080
-                - --refresh-interval=5m
               command:
                 - /usr/local/bin/node-data-broker
               env:
@@ -3640,13 +3677,6 @@ renders values.slinky.partition-example.yaml:
             matchLabels:
               app.kubernetes.io/component: api-server
               app.kubernetes.io/instance: chart-ci
-        nodeDataBroker:
-          namespace: topograph
-          containerName: node-data-broker
-          podSelector:
-            matchLabels:
-              app.kubernetes.io/name: node-data-broker
-              app.kubernetes.io/instance: chart-ci
         trigger:
           podSelector:
             matchLabels:
@@ -3682,7 +3712,7 @@ renders values.slinky.partition-example.yaml:
       template:
         metadata:
           annotations:
-            checksum/config: 8b2202603b5be5a08a6d08e5c23931db646dd362860d63bcc59ead39a6f865e3
+            checksum/config: 665f27c8c6095b211f8df2f68171dbe62731459459aaf3f4e5170c49ea98ab25
           labels:
             app.kubernetes.io/instance: chart-ci
             app.kubernetes.io/managed-by: Helm
@@ -3695,6 +3725,11 @@ renders values.slinky.partition-example.yaml:
                 - -v=3
               command:
                 - /usr/local/bin/node-observer
+              env:
+                - name: NODE_DATA_BROKER_NAME
+                  value: chart-ci-topograph-node-data-broker
+                - name: NODE_DATA_BROKER_NAMESPACE
+                  value: topograph
               image: ghcr.io/nvidia/topograph:v0.0.0
               imagePullPolicy: IfNotPresent
               name: node-observer
@@ -3740,6 +3775,13 @@ renders values.slinky.partition-example.yaml:
           - ""
         resources:
           - pods
+        verbs:
+          - list
+          - watch
+      - apiGroups:
+          - apps
+        resources:
+          - daemonsets
         verbs:
           - list
           - watch
@@ -3948,6 +3990,8 @@ renders values.slinky.tree-example.yaml:
         export CONTAINER_PORT=$(kubectl get pod --namespace topograph $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
         echo "Visit http://127.0.0.1:8080 to use your application"
         kubectl --namespace topograph port-forward $POD_NAME 8080:$CONTAINER_PORT
+
+        NOTE: node-data-broker applies node annotations once when each broker pod starts.
   2: |
     apiVersion: v1
     data:
@@ -4086,7 +4130,6 @@ renders values.slinky.tree-example.yaml:
                 - --provider=aws
                 - -v=3
                 - --port=8080
-                - --refresh-interval=5m
               command:
                 - /usr/local/bin/node-data-broker
               env:
@@ -4201,13 +4244,6 @@ renders values.slinky.tree-example.yaml:
             matchLabels:
               app.kubernetes.io/component: api-server
               app.kubernetes.io/instance: chart-ci
-        nodeDataBroker:
-          namespace: topograph
-          containerName: node-data-broker
-          podSelector:
-            matchLabels:
-              app.kubernetes.io/name: node-data-broker
-              app.kubernetes.io/instance: chart-ci
         trigger:
           podSelector:
             matchLabels:
@@ -4243,7 +4279,7 @@ renders values.slinky.tree-example.yaml:
       template:
         metadata:
           annotations:
-            checksum/config: 0e38b109134651287d29e212243f3db8a5265f3bd04190121b5f8754f1e767c1
+            checksum/config: 5828aa0fcd7ba3f91e124680c8825c4fa19617f126dd4a459666249ef947ec85
           labels:
             app.kubernetes.io/instance: chart-ci
             app.kubernetes.io/managed-by: Helm
@@ -4256,6 +4292,11 @@ renders values.slinky.tree-example.yaml:
                 - -v=3
               command:
                 - /usr/local/bin/node-observer
+              env:
+                - name: NODE_DATA_BROKER_NAME
+                  value: chart-ci-topograph-node-data-broker
+                - name: NODE_DATA_BROKER_NAMESPACE
+                  value: topograph
               image: ghcr.io/nvidia/topograph:v0.0.0
               imagePullPolicy: IfNotPresent
               name: node-observer
@@ -4301,6 +4342,13 @@ renders values.slinky.tree-example.yaml:
           - ""
         resources:
           - pods
+        verbs:
+          - list
+          - watch
+      - apiGroups:
+          - apps
+        resources:
+          - daemonsets
         verbs:
           - list
           - watch

--- a/charts/topograph/tests/node-data-broker_test.yaml
+++ b/charts/topograph/tests/node-data-broker_test.yaml
@@ -123,17 +123,6 @@ tests:
           path: spec.template.spec.containers[0].lifecycle.postStart.exec.command[2]
           value: "true"
 
-  - it: passes the refresh interval to the container
-    templates:
-      - templates/nodeDataBroker/daemonset.yaml
-    set:
-      nodeDataBroker:
-        refreshInterval: 10m
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].args
-          content: --refresh-interval=10m
-
   - it: gates liveness behind a startup probe
     templates:
       - templates/nodeDataBroker/daemonset.yaml

--- a/charts/topograph/tests/node-observer_rbac_test.yaml
+++ b/charts/topograph/tests/node-observer_rbac_test.yaml
@@ -3,7 +3,7 @@ release:
   name: chart-ci
   namespace: topograph
 tests:
-  - it: grants pod watch only when trigger.nodeSelector is unset
+  - it: grants pod and broker DaemonSet watch when enabled
     templates:
       - templates/nodeObserver/rbac.yaml
     documentIndex: 0
@@ -15,6 +15,9 @@ tests:
           value:
             - apiGroups: [""]
               resources: [pods]
+              verbs: [list, watch]
+            - apiGroups: [apps]
+              resources: [daemonsets]
               verbs: [list, watch]
 
   - it: grants node watch when trigger.nodeSelector is set
@@ -36,8 +39,26 @@ tests:
             - apiGroups: [""]
               resources: [pods]
               verbs: [list, watch]
+            - apiGroups: [apps]
+              resources: [daemonsets]
+              verbs: [list, watch]
             - apiGroups: [""]
               resources: [nodes]
+              verbs: [list, watch]
+
+  - it: omits DaemonSet watch when the broker is disabled
+    templates:
+      - templates/nodeObserver/rbac.yaml
+    set:
+      nodeDataBroker:
+        enabled: false
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: rules
+          value:
+            - apiGroups: [""]
+              resources: [pods]
               verbs: [list, watch]
 
   - it: binds the role to its own service account

--- a/charts/topograph/tests/node-observer_test.yaml
+++ b/charts/topograph/tests/node-observer_test.yaml
@@ -66,27 +66,42 @@ tests:
           path: data["node-observer-config.yaml"]
           pattern: "app.kubernetes.io/component: api-server"
         template: templates/nodeObserver/configmap.yml
-      - matchRegex:
-          path: data["node-observer-config.yaml"]
-          pattern: "nodeDataBroker:"
-        template: templates/nodeObserver/configmap.yml
-      - matchRegex:
-          path: data["node-observer-config.yaml"]
-          pattern: "app.kubernetes.io/name: node-data-broker"
-        template: templates/nodeObserver/configmap.yml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NODE_DATA_BROKER_NAME
+            value: chart-ci-topograph-node-data-broker
+        template: templates/nodeObserver/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NODE_DATA_BROKER_NAMESPACE
+            value: topograph
+        template: templates/nodeObserver/deployment.yaml
 
-  - it: omits the node-data-broker gate when disabled
+  - it: omits the node-data-broker coordinates when disabled
     templates:
-      - templates/nodeObserver/configmap.yml
+      - templates/nodeObserver/deployment.yaml
     set:
+      nodeDataBroker:
+        enabled: false
       nodeObserver:
-        topograph:
-          nodeDataBroker:
-            enabled: false
+        env:
+          FOO: BAR
     asserts:
-      - notMatchRegex:
-          path: data["node-observer-config.yaml"]
-          pattern: "nodeDataBroker:"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FOO
+            value: BAR
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NODE_DATA_BROKER_NAME
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NODE_DATA_BROKER_NAMESPACE
 
   - it: uses an existing service account when creation is disabled
     templates:

--- a/charts/topograph/values.schema.json
+++ b/charts/topograph/values.schema.json
@@ -224,7 +224,6 @@
       "properties": {
         "enabled": { "type": "boolean" },
         "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
-        "refreshInterval": { "type": ["string", "integer"] },
         "extraArgs": { "type": "array", "items": { "type": "string" } },
         "startupProbe": { "type": "object" },
         "serviceAccount": { "type": "object" },

--- a/charts/topograph/values.yaml
+++ b/charts/topograph/values.yaml
@@ -240,6 +240,8 @@ nodeObserver:
   rbac:
     create: true
 
+  # NODE_DATA_BROKER_NAME and NODE_DATA_BROKER_NAMESPACE are injected when
+  # nodeDataBroker.enabled=true.
   env: {}
   initContainers: []
   lifecycle: {}
@@ -252,13 +254,6 @@ nodeObserver:
       # Leave empty to use the release-scoped API pod labels.
       podSelector: {}
       containerName: topograph
-    # Wait for node-data-broker pods to become Ready before the first topology
-    # request. Disable this when nodeDataBroker.enabled is false.
-    nodeDataBroker:
-      enabled: true
-      # Leave empty to use the release-scoped broker pod labels.
-      podSelector: {}
-      containerName: node-data-broker
     trigger:
       # nodeSelector: {}
       # podSelector: {}
@@ -300,11 +295,7 @@ nodeDataBroker:
 
   # Port serving the /healthz endpoint after node annotations are applied.
   port: 8080
-  # Re-apply annotations at this interval. Set to 0 to disable refresh.
-  refreshInterval: 5m
 
-  # When disabling the broker, also set
-  # nodeObserver.topograph.nodeDataBroker.enabled=false.
   extraArgs: []
   # - key=val
 

--- a/cmd/node-data-broker/main.go
+++ b/cmd/node-data-broker/main.go
@@ -1,17 +1,6 @@
 /*
- * Copyright (c) 2024-2026, NVIDIA CORPORATION.  All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright 2024-2026 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package main
@@ -47,10 +36,9 @@ import (
 )
 
 const (
-	defaultPort            = 8080
-	defaultRefreshInterval = 5 * time.Minute
-	readHeaderTimeout      = 5 * time.Second
-	shutdownTimeout        = 5 * time.Second
+	defaultPort       = 8080
+	readHeaderTimeout = 5 * time.Second
+	shutdownTimeout   = 5 * time.Second
 )
 
 type nodeBroker struct {
@@ -66,12 +54,10 @@ func main() {
 	var ver bool
 	var sets []string
 	var port int
-	var refreshInterval time.Duration
 	pflag.StringVar(&provider, "provider", "", "API provider")
 	pflag.BoolVar(&ver, "version", false, "show the version")
 	pflag.StringArrayVar(&sets, "set", []string{}, "extra key=value parameters")
 	pflag.IntVar(&port, "port", defaultPort, "port for the health HTTP server")
-	pflag.DurationVar(&refreshInterval, "refresh-interval", defaultRefreshInterval, "interval between node annotation refreshes after startup (0 disables periodic refresh)")
 
 	klog.InitFlags(nil)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
@@ -83,13 +69,13 @@ func main() {
 		os.Exit(0)
 	}
 
-	if err := mainInternal(provider, sets, port, refreshInterval); err != nil {
+	if err := mainInternal(provider, sets, port); err != nil {
 		klog.Error(err.Error())
 		os.Exit(1)
 	}
 }
 
-func mainInternal(provider string, sets []string, port int, refreshInterval time.Duration) error {
+func mainInternal(provider string, sets []string, port int) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
@@ -110,12 +96,8 @@ func mainInternal(provider string, sets []string, port int, refreshInterval time
 		return err
 	}
 
-	if refreshInterval > 0 {
-		go refreshNodeAnnotations(ctx, broker, refreshInterval)
-	}
-
 	// Keep the DaemonSet pod Running by serving a health endpoint until the pod
-	// is terminated. Periodic annotation refresh runs in the background.
+	// is terminated.
 	return serveHealth(ctx, port)
 }
 
@@ -131,32 +113,6 @@ func newInClusterClientset() (kubernetes.Interface, *rest.Config, error) {
 	}
 
 	return clientset, config, nil
-}
-
-type annotationApplier func(ctx context.Context) error
-
-// refreshNodeAnnotations re-applies node annotations on a fixed interval until
-// the context is cancelled. Failures are logged but do not terminate the pod.
-func refreshNodeAnnotations(ctx context.Context, broker *nodeBroker, interval time.Duration) {
-	runRefreshLoop(ctx, interval, func(ctx context.Context) error {
-		return broker.apply(ctx)
-	})
-}
-
-func runRefreshLoop(ctx context.Context, interval time.Duration, apply annotationApplier) {
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			if err := apply(ctx); err != nil {
-				klog.ErrorS(err, "periodic node annotation refresh failed")
-			}
-		}
-	}
 }
 
 func (b *nodeBroker) apply(ctx context.Context) error {

--- a/cmd/node-data-broker/main_test.go
+++ b/cmd/node-data-broker/main_test.go
@@ -1,17 +1,6 @@
 /*
- * Copyright (c) 2024-2026, NVIDIA CORPORATION.  All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright 2024-2026 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package main
@@ -21,7 +10,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"sync"
 	"testing"
 	"time"
 
@@ -178,90 +166,5 @@ func TestServeHealthShutsDownOnContextCancel(t *testing.T) {
 		require.NoError(t, err)
 	case <-time.After(5 * time.Second):
 		t.Fatal("serveHealth did not return after context cancellation")
-	}
-}
-
-func TestRunRefreshLoopAppliesOnInterval(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	var applyCount int
-	done := make(chan struct{})
-	var finishOnce sync.Once
-	finish := func() {
-		finishOnce.Do(func() {
-			cancel()
-			close(done)
-		})
-	}
-
-	go func() {
-		runRefreshLoop(ctx, 20*time.Millisecond, func(context.Context) error {
-			applyCount++
-			if applyCount >= 2 {
-				finish()
-			}
-			return nil
-		})
-	}()
-
-	select {
-	case <-done:
-		require.GreaterOrEqual(t, applyCount, 2)
-	case <-time.After(2 * time.Second):
-		t.Fatal("refresh loop did not invoke apply at least twice")
-	}
-}
-
-func TestRunRefreshLoopContinuesAfterApplyError(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	var applyCount int
-	done := make(chan struct{})
-	var finishOnce sync.Once
-	finish := func() {
-		finishOnce.Do(func() {
-			cancel()
-			close(done)
-		})
-	}
-
-	go func() {
-		runRefreshLoop(ctx, 20*time.Millisecond, func(context.Context) error {
-			applyCount++
-			if applyCount == 1 {
-				return context.Canceled
-			}
-			finish()
-			return nil
-		})
-	}()
-
-	select {
-	case <-done:
-		require.GreaterOrEqual(t, applyCount, 2)
-	case <-time.After(2 * time.Second):
-		t.Fatal("refresh loop stopped after apply error")
-	}
-}
-
-func TestRunRefreshLoopStopsOnContextCancel(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-
-	done := make(chan struct{})
-	go func() {
-		runRefreshLoop(ctx, time.Hour, func(context.Context) error {
-			return nil
-		})
-		close(done)
-	}()
-
-	cancel()
-
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		t.Fatal("refresh loop did not return after context cancellation")
 	}
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,7 @@ The API Server receives topology generation requests and returns results asynchr
 
 ### 2. Node Observer
 
-The Node Observer is used in Kubernetes deployments. It monitors configured node and pod changes, and it also watches the Topograph API pod. If a selected node or pod changes, or if the API server becomes ready after startup or a container restart, the Node Observer sends a request to the API Server to generate a new topology configuration.
+The Node Observer is used in Kubernetes deployments. It monitors configured node and pod changes, and it also watches the Topograph API pod. When the node-data-broker is enabled, it waits for the broker DaemonSet's ready replica count to match its desired count. If a selected node or pod changes, or if the API server becomes ready after startup or a container restart, the Node Observer sends a request to the API Server to generate a new topology configuration.
 
 ### 3. Node Data Broker
 

--- a/docs/engines/k8s.md
+++ b/docs/engines/k8s.md
@@ -119,7 +119,7 @@ Topology labels are most valuable when nodes in a topology domain are available 
 
 ## Configuration
 Topograph is deployed as a standard Kubernetes application using a [Helm chart](https://github.com/NVIDIA/topograph/tree/main/charts/topograph).
-The main chart directly renders the API server, node-observer, and node-data-broker; the component-specific settings remain under `nodeObserver.*` and `nodeDataBroker.*`.
+The main chart directly renders the API server, node-observer, and node-data-broker; the component-specific settings remain under `nodeObserver.*` and `nodeDataBroker.*`. When the broker is enabled, the chart passes its name and namespace to the node-observer through `NODE_DATA_BROKER_NAME` and `NODE_DATA_BROKER_NAMESPACE`. The observer waits until the broker DaemonSet's ready replica count matches its desired count before requesting topology generation. When `nodeDataBroker.enabled=false`, those variables are omitted and there is no broker readiness gate.
 Topograph is configured using a configuration file stored in a ConfigMap and mounted to the Topograph container at `/etc/topograph/topograph-config.yaml`.
 In addition, when sending a topology request, the request payload includes additional parameters.
 The provider and engine are defined as top-level Helm values, as shown below:
@@ -300,7 +300,7 @@ Apply alongside the chart. A bundled template is under consideration.
 
 ### Node Observer RBAC
 
-The node-observer `ClusterRole` grants `pods [list, watch]` unconditionally, and `nodes [list, watch]` only when `nodeObserver.topograph.trigger.nodeSelector` is set (the node informer that needs it is otherwise never started). Set `nodeObserver.rbac.create: false` to suppress the `ClusterRole`/`ClusterRoleBinding` when managing RBAC externally.
+The node-observer `ClusterRole` grants `pods [list, watch]` unconditionally, `apps/daemonsets [list, watch]` when `nodeDataBroker.enabled=true`, and `nodes [list, watch]` only when `nodeObserver.topograph.trigger.nodeSelector` is set. Set `nodeObserver.rbac.create: false` to suppress the `ClusterRole`/`ClusterRoleBinding` when managing RBAC externally.
 
 ## Validation and Testing
 

--- a/docs/providers/infiniband.md
+++ b/docs/providers/infiniband.md
@@ -132,12 +132,7 @@ nodeDataBroker:
     - device-plugin-daemonset=my-daemonset
 ```
 
-By default the node-data-broker re-applies node annotations every 5 minutes after the initial startup apply. Adjust or disable periodic refresh with `nodeDataBroker.refreshInterval` (set to `0` to apply only at pod start):
-
-```yaml
-nodeDataBroker:
-  refreshInterval: 10m
-```
+The node-data-broker applies node annotations once when its pod starts. Restart the broker pod to re-apply them after relevant node or provider metadata changes.
 
 If `ibnetdiscover` needs extra config files, the chart can render ConfigMaps and mount them into the node-data-broker pods:
 

--- a/pkg/node_observer/config.go
+++ b/pkg/node_observer/config.go
@@ -1,17 +1,6 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright 2024-2026 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package node_observer
@@ -28,17 +17,15 @@ import (
 )
 
 const (
-	defaultRetryDelay                  = 5 * time.Minute
-	defaultBrokerRetryDelay            = 10 * time.Second
-	defaultAPIServerContainerName      = "topograph"
-	defaultNodeDataBrokerContainerName = "node-data-broker"
+	defaultRetryDelay             = 5 * time.Minute
+	defaultBrokerRetryDelay       = 10 * time.Second
+	defaultAPIServerContainerName = "topograph"
 )
 
 type Config struct {
 	GenerateTopologyURL string            `yaml:"generateTopologyUrl"`
 	Trigger             Trigger           `yaml:"trigger"`
 	APIServer           APIServer         `yaml:"apiServer,omitempty"`
-	NodeDataBroker      NodeDataBroker    `yaml:"nodeDataBroker,omitempty"`
 	Provider            topology.Provider `yaml:"provider"`
 	Engine              topology.Engine   `yaml:"engine"`
 	RetryDelay          metav1.Duration   `yaml:"retryDelay"`
@@ -50,12 +37,6 @@ type Trigger struct {
 }
 
 type APIServer struct {
-	Namespace     string                `yaml:"namespace,omitempty"`
-	PodSelector   *metav1.LabelSelector `yaml:"podSelector,omitempty"`
-	ContainerName string                `yaml:"containerName,omitempty"`
-}
-
-type NodeDataBroker struct {
 	Namespace     string                `yaml:"namespace,omitempty"`
 	PodSelector   *metav1.LabelSelector `yaml:"podSelector,omitempty"`
 	ContainerName string                `yaml:"containerName,omitempty"`
@@ -79,10 +60,6 @@ func NewConfigFromFile(fname string) (*Config, error) {
 
 	if cfg.APIServer.PodSelector != nil && len(cfg.APIServer.ContainerName) == 0 {
 		cfg.APIServer.ContainerName = defaultAPIServerContainerName
-	}
-
-	if cfg.NodeDataBroker.PodSelector != nil && len(cfg.NodeDataBroker.ContainerName) == 0 {
-		cfg.NodeDataBroker.ContainerName = defaultNodeDataBrokerContainerName
 	}
 
 	if len(cfg.Trigger.NodeSelector) == 0 && cfg.Trigger.PodSelector == nil && cfg.APIServer.PodSelector == nil {

--- a/pkg/node_observer/config_test.go
+++ b/pkg/node_observer/config_test.go
@@ -1,17 +1,6 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright 2024-2026 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package node_observer
@@ -192,54 +181,6 @@ apiServer:
 						MatchLabels: map[string]string{
 							"app.kubernetes.io/component": "api-server",
 							"app.kubernetes.io/instance":  "topograph",
-						},
-					},
-				},
-				RetryDelay: metav1.Duration{Duration: defaultRetryDelay},
-			},
-		},
-		{
-			name: "Case 8: valid with node-data-broker gate and default container name",
-			data: `
-generateTopologyUrl: "http://topograph.default.svc.cluster.local:49021/v1/generate"
-provider:
-  name: test
-engine:
-  name: test
-apiServer:
-  namespace: topograph
-  podSelector:
-    matchLabels:
-      app.kubernetes.io/component: api-server
-      app.kubernetes.io/instance: topograph
-nodeDataBroker:
-  namespace: topograph
-  podSelector:
-    matchLabels:
-      app.kubernetes.io/name: node-data-broker
-      app.kubernetes.io/instance: topograph
-`,
-			cfg: &Config{
-				GenerateTopologyURL: "http://topograph.default.svc.cluster.local:49021/v1/generate",
-				Provider:            topology.Provider{Name: "test"},
-				Engine:              topology.Engine{Name: "test"},
-				APIServer: APIServer{
-					Namespace:     "topograph",
-					ContainerName: defaultAPIServerContainerName,
-					PodSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"app.kubernetes.io/component": "api-server",
-							"app.kubernetes.io/instance":  "topograph",
-						},
-					},
-				},
-				NodeDataBroker: NodeDataBroker{
-					Namespace:     "topograph",
-					ContainerName: defaultNodeDataBrokerContainerName,
-					PodSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"app.kubernetes.io/name":     "node-data-broker",
-							"app.kubernetes.io/instance": "topograph",
 						},
 					},
 				},

--- a/pkg/node_observer/controller.go
+++ b/pkg/node_observer/controller.go
@@ -1,17 +1,6 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright 2024-2026 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package node_observer
@@ -21,12 +10,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
 	"github.com/NVIDIA/topograph/internal/httpreq"
 	"github.com/NVIDIA/topograph/pkg/topology"
+)
+
+const (
+	nodeDataBrokerNameEnv      = "NODE_DATA_BROKER_NAME"
+	nodeDataBrokerNamespaceEnv = "NODE_DATA_BROKER_NAMESPACE"
 )
 
 type Controller struct {
@@ -50,7 +45,16 @@ func NewController(ctx context.Context, client kubernetes.Interface, cfg *Config
 	}
 
 	f := httpreq.GetRequestFunc(ctx, http.MethodPost, headers, nil, data, cfg.GenerateTopologyURL)
-	statusInformer, err := NewStatusInformer(ctx, client, &cfg.Trigger, &cfg.APIServer, &cfg.NodeDataBroker, cfg.RetryDelay.Duration, f)
+	statusInformer, err := NewStatusInformer(
+		ctx,
+		client,
+		&cfg.Trigger,
+		&cfg.APIServer,
+		os.Getenv(nodeDataBrokerNameEnv),
+		os.Getenv(nodeDataBrokerNamespaceEnv),
+		cfg.RetryDelay.Duration,
+		f,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/node_observer/status_informer.go
+++ b/pkg/node_observer/status_informer.go
@@ -7,10 +7,13 @@ package node_observer
 
 import (
 	"context"
+	"fmt"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
@@ -24,7 +27,6 @@ import (
 
 type StatusInformer struct {
 	ctx           context.Context
-	client        kubernetes.Interface
 	nodeFactory   informers.SharedInformerFactory
 	podFactory    informers.SharedInformerFactory
 	apiFactory    informers.SharedInformerFactory
@@ -37,15 +39,13 @@ type StatusInformer struct {
 	stopCh        chan struct{}
 
 	apiServerContainerName string
-	brokerContainerName    string
 }
 
-func NewStatusInformer(ctx context.Context, client kubernetes.Interface, trigger *Trigger, apiServer *APIServer, nodeDataBroker *NodeDataBroker, retryDelay time.Duration, reqFunc httpreq.RequestFunc) (*StatusInformer, error) {
-	klog.InfoS("Configuring status informer", "trigger", trigger, "apiServer", apiServer, "nodeDataBroker", nodeDataBroker)
+func NewStatusInformer(ctx context.Context, client kubernetes.Interface, trigger *Trigger, apiServer *APIServer, brokerName, brokerNamespace string, retryDelay time.Duration, reqFunc httpreq.RequestFunc) (*StatusInformer, error) {
+	klog.InfoS("Configuring status informer", "trigger", trigger, "apiServer", apiServer, "brokerName", brokerName, "brokerNamespace", brokerNamespace)
 
 	statusInformer := &StatusInformer{
 		ctx:         ctx,
-		client:      client,
 		retryDelay:  retryDelay,
 		reqFunc:     reqFunc,
 		reqExecFunc: httpreq.DoRequestWithRetries,
@@ -78,13 +78,16 @@ func NewStatusInformer(ctx context.Context, client kubernetes.Interface, trigger
 		statusInformer.apiServerContainerName = apiServer.ContainerName
 	}
 
-	if nodeDataBroker != nil && nodeDataBroker.PodSelector != nil {
-		podFactory, err := newPodFactory(client, nodeDataBroker.PodSelector, nodeDataBroker.Namespace)
-		if err != nil {
-			return nil, err
+	if brokerName != "" && brokerNamespace != "" {
+		listOptionsFunc := func(options *metav1.ListOptions) {
+			options.FieldSelector = fields.OneTermEqualSelector("metadata.name", brokerName).String()
 		}
-		statusInformer.brokerFactory = podFactory
-		statusInformer.brokerContainerName = nodeDataBroker.ContainerName
+		statusInformer.brokerFactory = informers.NewSharedInformerFactoryWithOptions(
+			client,
+			0,
+			informers.WithNamespace(brokerNamespace),
+			informers.WithTweakListOptions(listOptionsFunc),
+		)
 	}
 
 	return statusInformer, nil
@@ -224,40 +227,39 @@ func (s *StatusInformer) startAPIServerInformer() error {
 
 func (s *StatusInformer) startBrokerInformer() error {
 	if s.brokerFactory != nil {
-		informer := s.brokerFactory.Core().V1().Pods().Informer()
+		informer := s.brokerFactory.Apps().V1().DaemonSets().Informer()
 		_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj any) {
-				pod, ok := obj.(*corev1.Pod)
+				daemonSet, ok := obj.(*appsv1.DaemonSet)
 				if !ok {
 					return
 				}
-				if isWorkloadPodReady(pod, s.brokerContainerName) {
-					klog.V(4).Infof("Informer added ready node-data-broker pod %s/%s", pod.Namespace, pod.Name)
-					s.sendRequest()
-				}
+				klog.V(4).Infof("Informer added node-data-broker DaemonSet %s/%s", daemonSet.Namespace, daemonSet.Name)
+				s.sendRequest()
 			},
 			UpdateFunc: func(oldObj, newObj any) {
-				oldPod, ok := oldObj.(*corev1.Pod)
+				oldDaemonSet, ok := oldObj.(*appsv1.DaemonSet)
 				if !ok {
 					return
 				}
-				newPod, ok := newObj.(*corev1.Pod)
+				newDaemonSet, ok := newObj.(*appsv1.DaemonSet)
 				if !ok {
 					return
 				}
-				if shouldRequestOnWorkloadUpdate(oldPod, newPod, s.brokerContainerName) {
-					klog.V(4).Infof("Informer updated ready node-data-broker pod %s/%s", newPod.Namespace, newPod.Name)
+				if isBrokerDaemonSetReady(oldDaemonSet) != isBrokerDaemonSetReady(newDaemonSet) ||
+					oldDaemonSet.Status.DesiredNumberScheduled != newDaemonSet.Status.DesiredNumberScheduled {
+					klog.V(4).Infof("Informer updated node-data-broker DaemonSet %s/%s", newDaemonSet.Namespace, newDaemonSet.Name)
 					s.sendRequest()
 				}
 			},
 			DeleteFunc: func(obj any) {
 				switch v := obj.(type) {
-				case *corev1.Pod:
-					klog.V(4).Infof("Informer deleted node-data-broker pod %s/%s", v.Namespace, v.Name)
+				case *appsv1.DaemonSet:
+					klog.V(4).Infof("Informer deleted node-data-broker DaemonSet %s/%s", v.Namespace, v.Name)
 					s.sendRequest()
 				case cache.DeletedFinalStateUnknown:
-					if pod, ok := v.Obj.(*corev1.Pod); ok {
-						klog.V(4).Infof("Informer deleted node-data-broker pod %s/%s", pod.Namespace, pod.Name)
+					if daemonSet, ok := v.Obj.(*appsv1.DaemonSet); ok {
+						klog.V(4).Infof("Informer deleted node-data-broker DaemonSet %s/%s", daemonSet.Namespace, daemonSet.Name)
 						s.sendRequest()
 					}
 				}
@@ -411,37 +413,51 @@ func containerRestartCount(pod *corev1.Pod, containerName string) (int32, bool) 
 	return restarts, found
 }
 
-func (s *StatusInformer) allBrokerPodsReady() bool {
+func (s *StatusInformer) brokerReady() (bool, error) {
 	if s.brokerFactory == nil {
-		return true
+		return true, nil
 	}
 
-	informer := s.brokerFactory.Core().V1().Pods().Informer()
+	informer := s.brokerFactory.Apps().V1().DaemonSets().Informer()
 	if !informer.HasSynced() {
-		return false
+		return false, nil
 	}
 
 	items := informer.GetStore().List()
-	if len(items) == 0 {
-		// Broker watch is enabled but no pods exist yet; wait for the DaemonSet.
-		return false
+	if len(items) != 1 {
+		return false, nil
 	}
 
-	for _, item := range items {
-		pod, ok := item.(*corev1.Pod)
-		if !ok {
-			continue
-		}
-		if !isWorkloadPodReady(pod, s.brokerContainerName) {
-			return false
-		}
+	daemonSet, ok := items[0].(*appsv1.DaemonSet)
+	if !ok {
+		return false, nil
 	}
-	return true
+	return brokerDaemonSetReady(daemonSet)
+}
+
+func isBrokerDaemonSetReady(daemonSet *appsv1.DaemonSet) bool {
+	ready, _ := brokerDaemonSetReady(daemonSet)
+	return ready
+}
+
+func brokerDaemonSetReady(daemonSet *appsv1.DaemonSet) (bool, error) {
+	if daemonSet.Status.DesiredNumberScheduled == 0 {
+		return false, fmt.Errorf(
+			"node-data-broker DaemonSet %s/%s has 0 desired replicas; check its node selector, affinity, and tolerations",
+			daemonSet.Namespace,
+			daemonSet.Name,
+		)
+	}
+	return daemonSet.Status.DesiredNumberScheduled == daemonSet.Status.NumberReady, nil
 }
 
 func (s *StatusInformer) process() {
-	if !s.allBrokerPodsReady() {
-		klog.V(2).Info("Waiting for node-data-broker pods to become ready before topology generation")
+	brokerReady, err := s.brokerReady()
+	if err != nil {
+		klog.Error(err)
+	}
+	if !brokerReady {
+		klog.V(2).Info("Waiting for the node-data-broker DaemonSet to become ready before topology generation")
 		if s.timer != nil {
 			s.timer.Stop()
 		}

--- a/pkg/node_observer/status_informer_test.go
+++ b/pkg/node_observer/status_informer_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/NVIDIA/topograph/internal/httperr"
 	"github.com/NVIDIA/topograph/internal/httpreq"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -34,21 +35,67 @@ func TestNewStatusInformer(t *testing.T) {
 		},
 		ContainerName: "topograph",
 	}
-	nodeDataBroker := &NodeDataBroker{
-		Namespace: "topograph",
-		PodSelector: &metav1.LabelSelector{
-			MatchLabels: map[string]string{"app.kubernetes.io/name": "node-data-broker"},
-		},
-		ContainerName: "node-data-broker",
-	}
-	informer, err := NewStatusInformer(ctx, nil, trigger, apiServer, nodeDataBroker, 0, nil)
+	informer, err := NewStatusInformer(ctx, nil, trigger, apiServer, "topograph-node-data-broker", "topograph", 0, nil)
 	require.NoError(t, err)
 	require.NotNil(t, informer.nodeFactory)
 	require.NotNil(t, informer.podFactory)
 	require.NotNil(t, informer.apiFactory)
 	require.NotNil(t, informer.brokerFactory)
 	require.Equal(t, "topograph", informer.apiServerContainerName)
-	require.Equal(t, "node-data-broker", informer.brokerContainerName)
+}
+
+func TestNewStatusInformerBrokerGateRequiresNameAndNamespace(t *testing.T) {
+	testCases := []struct {
+		name            string
+		brokerName      string
+		brokerNamespace string
+	}{
+		{name: "neither is set"},
+		{name: "name only", brokerName: "topograph-node-data-broker"},
+		{name: "namespace only", brokerNamespace: "topograph"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			informer, err := NewStatusInformer(context.TODO(), nil, nil, nil, tc.brokerName, tc.brokerNamespace, 0, nil)
+			require.NoError(t, err)
+			require.Nil(t, informer.brokerFactory)
+		})
+	}
+}
+
+func TestBrokerDaemonSetReady(t *testing.T) {
+	testCases := []struct {
+		name    string
+		desired int32
+		ready   int32
+		want    bool
+	}{
+		{name: "all desired replicas ready", desired: 3, ready: 3, want: true},
+		{name: "replicas still becoming ready", desired: 3, ready: 2, want: false},
+		{name: "no replicas desired", want: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			daemonSet := &appsv1.DaemonSet{Status: appsv1.DaemonSetStatus{
+				DesiredNumberScheduled: tc.desired,
+				NumberReady:            tc.ready,
+			}}
+			require.Equal(t, tc.want, isBrokerDaemonSetReady(daemonSet))
+		})
+	}
+}
+
+func TestBrokerDaemonSetReadyRejectsZeroDesiredReplicas(t *testing.T) {
+	daemonSet := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{
+		Name:      "topograph-node-data-broker",
+		Namespace: "topograph",
+	}}
+
+	ready, err := brokerDaemonSetReady(daemonSet)
+	require.False(t, ready)
+	require.EqualError(t, err, "node-data-broker DaemonSet topograph/topograph-node-data-broker has 0 desired replicas; check its node selector, affinity, and tolerations")
 }
 
 func TestAPIServerPodUpdateTriggersOnReadyTransitionAndRestart(t *testing.T) {


### PR DESCRIPTION
Discover the node-data-broker through environment variables and wait for
the DaemonSet's desired replicas to become ready. Disable the gate when
the broker is disabled and remove periodic broker annotation refreshes.
