### PR TITLE
fix(models): distinguish hostnames from instance IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Simulation model node names are now treated as hostnames; the model-backed test provider generates their instance IDs with an `i-` prefix.
 - The node-observer and node-data-broker are now rendered directly by the main Topograph Helm chart instead of local subcharts. Their existing `node-observer.*` and `node-data-broker.*` values paths are unchanged.
 - **BREAKING (Helm chart `0.5.0` → `0.6.0`):** the chart now ships a hardened default security context across the API server, node-observer, and node-data-broker: non-root (`runAsNonRoot`, UID/GID `65532`), `seccompProfile: RuntimeDefault`, `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, and all capabilities dropped — satisfying the Kubernetes `restricted` Pod Security Standard out of the box. This changes the default runtime posture of every workload; operators who relied on root, a writable rootfs, or added capabilities must override the relevant keys (see the migration note below). `appVersion` is unchanged (`v0.5.0`; no binary change).
 - Go toolchain bumped to **1.26.5** (`go.mod`, `Dockerfile`, CI) to address reachable stdlib vulnerabilities reported by `govulncheck`.

--- a/docs/modeling.md
+++ b/docs/modeling.md
@@ -116,7 +116,7 @@ The `blocks` list describes sets of compute instances with similar hardware and 
 | Field | Description |
 |---|---|
 | `switch` | Optional leaf switch ID. When set, this block's `nodes` are attached to that switch. |
-| `nodes` | Required non-empty list of node names in this block. Compact ranges are supported. |
+| `nodes` | Required non-empty list of hostnames in this block. Compact ranges are supported. The model-backed test provider generates each instance ID by prefixing the hostname with `i-`. |
 | `labels` | Optional labels applied to nodes generated from this block. For example, `network.topology.nvidia.com/accelerator` can identify an NVLink / accelerator domain. |
 
 Example:
@@ -194,6 +194,7 @@ blocks:
 
 After loading:
 
+- `n1`, `n2`, and `n3` are hostnames mapped from instance IDs `i-n1`, `i-n2`, and `i-n3`
 - `n1` and `n2` belong to the first block and have `network.topology.nvidia.com/accelerator: nvl1` label
 - `n3` belongs to the second block and has `network.topology.nvidia.com/accelerator: nvl2` label
 - All three nodes have network layers `[leaf, core]`

--- a/docs/providers/test.md
+++ b/docs/providers/test.md
@@ -95,6 +95,8 @@ The test provider is configured through `provider.params` in the `/v1/generate` 
 
 The `engine` object follows the normal Topograph engine configuration. For example, use `slurm` parameters to request `topology/tree` or `topology/block` output, use `k8s` parameters to write node labels, use `slinky` parameters to update a Slinky ConfigMap, or use `graph` to return model-backed instance metadata as JSON.
 
+Names declared in a model's `blocks[].nodes` are treated as hostnames. The test provider generates the corresponding instance IDs by adding the `i-` prefix; for example, hostname `node1` maps from instance ID `i-node1`.
+
 ### Test Provider Parameters
 
 | Parameter | Required | Default | Description |

--- a/pkg/engines/slinky/engine_test.go
+++ b/pkg/engines/slinky/engine_test.go
@@ -1254,7 +1254,11 @@ func TestGenerateDynamicNodesOutput(t *testing.T) {
 
 			model, err := models.NewModelFromFile(tc.topologyFile)
 			require.NoError(t, err)
-			topo, _ := model.ToGraph(nil)
+			instance2node := make(map[string]string, len(model.Nodes))
+			for hostName := range model.Nodes {
+				instance2node[fmt.Sprintf("i-%s", hostName)] = hostName
+			}
+			topo, _ := model.ToGraph([]topology.ComputeInstances{{Instances: instance2node}})
 
 			podListSel, err := metav1.LabelSelectorAsSelector(&slinkyPodSel)
 			require.NoError(t, err)

--- a/pkg/models/model.go
+++ b/pkg/models/model.go
@@ -168,11 +168,11 @@ func (m *Model) derive() error {
 	}
 
 	regions := make(map[string]map[string]string)
-	for _, node := range m.Nodes {
+	for hostName, node := range m.Nodes {
 		var netLayers []string
 		var labels map[string]string
 
-		if sw, ok := maps.switchByNode[node.ID]; ok {
+		if sw, ok := maps.switchByNode[hostName]; ok {
 			netLayers, labels, err = getNetworkLayers(sw, maps.parentBySwitch)
 			if err != nil {
 				return err
@@ -181,7 +181,7 @@ func (m *Model) derive() error {
 
 		node.Labels = mergeLabels(labels, node.Labels)
 		node.NetLayers = netLayers
-		addInstanceRegion(regions, node.Labels, node.ID)
+		addInstanceRegion(regions, node.Labels, hostName)
 	}
 
 	m.setInstances(regions)
@@ -258,7 +258,7 @@ func mergeLabels(base, overlay map[string]string) map[string]string {
 	return labels
 }
 
-func addInstanceRegion(regions map[string]map[string]string, labels map[string]string, name string) {
+func addInstanceRegion(regions map[string]map[string]string, labels map[string]string, hostName string) {
 	region := labels[LabelTopologyRegion]
 	if region == "" {
 		region = "none"
@@ -268,7 +268,7 @@ func addInstanceRegion(regions map[string]map[string]string, labels map[string]s
 		r = make(map[string]string)
 		regions[region] = r
 	}
-	r[name] = fmt.Sprintf("n-%s", name)
+	r[fmt.Sprintf("i-%s", hostName)] = hostName
 }
 
 func (m *Model) setInstances(regions map[string]map[string]string) {
@@ -320,10 +320,17 @@ func (model *Model) ToGraph(instances []topology.ComputeInstances) (*topology.Gr
 	swRootMap := make(map[string]bool)
 	domainMap := topology.NewDomainMap()
 
-	// Create all the vertices for each node
-	for k, v := range model.Nodes {
-		instance2node[k] = fmt.Sprintf("n-%s", k)
-		nodeVertexMap[k] = &topology.Vertex{ID: v.ID, Name: v.ID}
+	for hostName := range model.Nodes {
+		instance2node[fmt.Sprintf("i-%s", hostName)] = hostName
+	}
+
+	// Create all the vertices for each node.
+	for hostName := range model.Nodes {
+		instanceID := fmt.Sprintf("i-%s", hostName)
+		nodeVertexMap[hostName] = &topology.Vertex{
+			ID:   instanceID,
+			Name: instance2node[instanceID],
+		}
 	}
 
 	// Initialize all the vertices for each switch (setting each on to be a possible root)
@@ -333,9 +340,10 @@ func (model *Model) ToGraph(instances []topology.ComputeInstances) (*topology.Gr
 	}
 
 	// Initializes accelerator domain membership from node labels.
-	for _, node := range model.Nodes {
-		if accelerator := node.AcceleratorID(); accelerator != "" {
-			domainMap.AddHost(accelerator, node.ID, node.ID)
+	for hostName, instance := range model.Nodes {
+		if accelerator := instance.AcceleratorID(); accelerator != "" {
+			instanceID := fmt.Sprintf("i-%s", hostName)
+			domainMap.AddHost(accelerator, instanceID, instance2node[instanceID])
 		}
 	}
 
@@ -346,7 +354,8 @@ func (model *Model) ToGraph(instances []topology.ComputeInstances) (*topology.Gr
 			swVertexMap[sw.Name].Vertices[subsw] = swVertexMap[subsw]
 		}
 		for _, node := range sw.Nodes {
-			swVertexMap[sw.Name].Vertices[node] = nodeVertexMap[node]
+			vertex := nodeVertexMap[node]
+			swVertexMap[sw.Name].Vertices[vertex.ID] = vertex
 		}
 	}
 
@@ -364,24 +373,42 @@ func (model *Model) ToGraph(instances []topology.ComputeInstances) (*topology.Gr
 	if len(domainMap) != 0 {
 		graph.Domains = domainMap
 	}
-	if instanceMap := model.InstanceMap(instances); len(instanceMap) != 0 {
+	if instanceMap := model.graphInstanceMap(instances); len(instanceMap) != 0 {
 		graph.Instances = instanceMap
 	}
 
 	return graph, instance2node
 }
 
-func (model *Model) InstanceMap(computeInstances []topology.ComputeInstances) map[string]topology.Instance {
+func (model *Model) graphInstanceMap(computeInstances []topology.ComputeInstances) map[string]topology.Instance {
 	wanted := requestedInstanceIDs(computeInstances)
 	instances := make(map[string]topology.Instance)
 
-	for instanceID, inst := range model.Nodes {
+	for hostName, inst := range model.Nodes {
+		instanceID := fmt.Sprintf("i-%s", hostName)
 		if len(wanted) != 0 {
 			if _, ok := wanted[instanceID]; !ok {
 				continue
 			}
 		}
-		instances[instanceID] = inst.CloneForTopology()
+		clone := inst.CloneForTopology()
+		clone.ID = instanceID
+		instances[instanceID] = clone
+	}
+	return instances
+}
+
+func (model *Model) InstanceMap(computeInstances []topology.ComputeInstances) map[string]topology.Instance {
+	wanted := requestedInstanceIDs(computeInstances)
+	instances := make(map[string]topology.Instance)
+
+	for _, inst := range model.Nodes {
+		if len(wanted) != 0 {
+			if _, ok := wanted[inst.ID]; !ok {
+				continue
+			}
+		}
+		instances[inst.ID] = inst.CloneForTopology()
 	}
 	return instances
 }

--- a/pkg/models/model_test.go
+++ b/pkg/models/model_test.go
@@ -77,14 +77,14 @@ func TestNewModelFromFileMedium(t *testing.T) {
 		{
 			Region: "us-west",
 			Instances: map[string]string{
-				"1101": "n-1101",
-				"1102": "n-1102",
-				"1201": "n-1201",
-				"1202": "n-1202",
-				"1301": "n-1301",
-				"1302": "n-1302",
-				"1401": "n-1401",
-				"1402": "n-1402",
+				"i-1101": "1101",
+				"i-1102": "1102",
+				"i-1201": "1201",
+				"i-1202": "1202",
+				"i-1301": "1301",
+				"i-1302": "1302",
+				"i-1401": "1401",
+				"i-1402": "1402",
 			},
 		},
 	}, cfg.Instances)
@@ -173,7 +173,7 @@ blocks:
 				Instances: []topology.ComputeInstances{
 					{
 						Region:    "none",
-						Instances: map[string]string{"n1": "n-n1", "n2": "n-n2", "n3": "n-n3"},
+						Instances: map[string]string{"i-n1": "n1", "i-n2": "n2", "i-n3": "n3"},
 					},
 				},
 			},
@@ -206,7 +206,7 @@ blocks:
 				Instances: []topology.ComputeInstances{
 					{
 						Region:    "none",
-						Instances: map[string]string{"n1": "n-n1", "n2": "n-n2"},
+						Instances: map[string]string{"i-n1": "n1", "i-n2": "n2"},
 					},
 				},
 			},
@@ -296,7 +296,52 @@ blocks:
 	require.Equal(t, []topology.ComputeInstances{
 		{
 			Region:    "region1",
-			Instances: map[string]string{"n1": "n-n1"},
+			Instances: map[string]string{"i-n1": "n1"},
 		},
 	}, model.Instances)
+}
+
+func TestToGraphUsesHostNames(t *testing.T) {
+	model, err := NewModelFromData([]byte(`
+switches:
+  leaf: {}
+blocks:
+- switch: leaf
+  nodes: [instance-1]
+  labels:
+    network.topology.nvidia.com/accelerator: nvl1
+`), "inline")
+	require.NoError(t, err)
+
+	graph, instance2node := model.ToGraph(nil)
+
+	require.Equal(t, "instance-1", instance2node["i-instance-1"])
+	require.Equal(t, &topology.Vertex{
+		ID:   "i-instance-1",
+		Name: "instance-1",
+	}, graph.Tiers.Vertices["leaf"].Vertices["i-instance-1"])
+	require.Equal(t, &topology.HostInfo{
+		Domain:     "nvl1",
+		InstanceID: "i-instance-1",
+		HostName:   "instance-1",
+	}, graph.Domains["nvl1"]["instance-1"])
+}
+
+func TestToGraphKeepsModelHostNames(t *testing.T) {
+	model, err := NewModelFromData([]byte(`
+switches:
+  leaf: {}
+blocks:
+- switch: leaf
+  nodes: [node1]
+`), "inline")
+	require.NoError(t, err)
+
+	graph, instance2node := model.ToGraph([]topology.ComputeInstances{
+		{Instances: map[string]string{"i-node1": "request-node1"}},
+	})
+
+	require.Equal(t, "node1", instance2node["i-node1"])
+	require.Equal(t, "node1", graph.Tiers.Vertices["leaf"].Vertices["i-node1"].Name)
+	require.Contains(t, graph.Instances, "i-node1")
 }

--- a/pkg/providers/providers_sim.go
+++ b/pkg/providers/providers_sim.go
@@ -55,9 +55,23 @@ type BaseSimProvider struct {
 
 // NewBaseSimProvider builds the shared model-derived data used by simulation providers.
 func NewBaseSimProvider(model *models.Model, trimTiers int) *BaseSimProvider {
+	// Provider-specific simulations must expose IDs that match their simulated
+	// APIs (for example, numeric GCP IDs), not the i-prefixed IDs generated for
+	// the model-backed test provider.
+	computeInstances := make([]topology.ComputeInstances, 0, len(model.Instances))
+	for _, ci := range model.Instances {
+		providerInstances := make(map[string]string, len(ci.Instances))
+		for _, hostName := range ci.Instances {
+			providerInstances[model.Nodes[hostName].ID] = hostName
+		}
+		computeInstances = append(computeInstances, topology.ComputeInstances{
+			Region:    ci.Region,
+			Instances: providerInstances,
+		})
+	}
 	return &BaseSimProvider{
 		instances:        model.InstanceMap(nil),
-		computeInstances: model.Instances,
+		computeInstances: computeInstances,
 		trimTiers:        trimTiers,
 	}
 }

--- a/pkg/server/http_server_test.go
+++ b/pkg/server/http_server_test.go
@@ -147,29 +147,29 @@ SwitchName=no-topology Nodes=n-CPU
 }
 `
 	slurmBlockConfig = `# block001=nvl-1-1
-BlockName=block001 Nodes=n-[1101-1108]
+BlockName=block001 Nodes=[1101-1108]
 # block002=nvl-1-2
-BlockName=block002 Nodes=n-[1201-1208]
+BlockName=block002 Nodes=[1201-1208]
 # block003=nvl-2-1
-BlockName=block003 Nodes=n-[2101-2108]
+BlockName=block003 Nodes=[2101-2108]
 # block004=nvl-2-2
-BlockName=block004 Nodes=n-[2201-2208]
+BlockName=block004 Nodes=[2201-2208]
 # block005=nvl-3-1
-BlockName=block005 Nodes=n-[3101-3108]
+BlockName=block005 Nodes=[3101-3108]
 # block006=nvl-3-2
-BlockName=block006 Nodes=n-[3201-3208]
+BlockName=block006 Nodes=[3201-3208]
 # block007=nvl-4-1
-BlockName=block007 Nodes=n-[4101-4108]
+BlockName=block007 Nodes=[4101-4108]
 # block008=nvl-4-2
-BlockName=block008 Nodes=n-[4201-4208]
+BlockName=block008 Nodes=[4201-4208]
 # block009=nvl-5-1
-BlockName=block009 Nodes=n-[5101-5108]
+BlockName=block009 Nodes=[5101-5108]
 # block010=nvl-5-2
-BlockName=block010 Nodes=n-[5201-5208]
+BlockName=block010 Nodes=[5201-5208]
 # block011=nvl-6-1
-BlockName=block011 Nodes=n-[6101-6108]
+BlockName=block011 Nodes=[6101-6108]
 # block012=nvl-6-2
-BlockName=block012 Nodes=n-[6201-6208]
+BlockName=block012 Nodes=[6201-6208]
 BlockSizes=8,16,32
 `
 	testPayload = `
@@ -207,8 +207,8 @@ BlockSizes=8,16,32
     {
       "region": "none",
       "instances": {
-        "I21": "n-I21",
-        "I22": "n-I22"
+        "i-I21": "I21",
+        "i-I22": "I22"
       }
     }
   ]
@@ -217,7 +217,7 @@ BlockSizes=8,16,32
 	graphInstancesJSON = `{
   "instances": [
     {
-      "id": "I21",
+      "id": "i-I21",
       "network_layers": [
         "S2",
         "S1"
@@ -227,7 +227,7 @@ BlockSizes=8,16,32
       }
     },
     {
-      "id": "I22",
+      "id": "i-I22",
       "network_layers": [
         "S2",
         "S1"


### PR DESCRIPTION
Treat model node names as hostnames and generate i-prefixed instance IDs for the test provider.
