### PR TITLE
feat(engine/nfd): publish topology as NFD custom resources

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -26,7 +26,7 @@ This separation is load-bearing. If you find yourself reading the fabric in an e
 cmd/                  # Entry points: topograph, node-observer, node-data-broker, kwok-nodes
 pkg/
   providers/          # One directory per provider: aws, gcp, oci, nebius, netq, dra, infiniband, lambdai, cw, test
-  engines/            # One directory per engine: k8s, slinky, slurm
+  engines/            # One directory per engine: k8s, nfd, slinky, slurm
   topology/           # Canonical Graph, Vertex tree, and topology constants (DO NOT CHANGE CASUALLY)
   registry/           # Central NamedLoader wiring for providers + engines
   translate/          # topology.conf and block/tree generation shared by engines
@@ -151,7 +151,7 @@ A provider returns a `*topology.Graph` of the discovered topology. `Tiers` is th
 
 ### Adding a new engine
 
-Engines are much rarer (three exist: slurm, k8s, slinky). Follow the same registry pattern but register in `engines.NewRegistry(...)`. Coordinate with maintainers before starting — adding an engine implies a new output format that every provider's output must be translatable into.
+Engines are much rarer (four exist: slurm, k8s, nfd, slinky). Follow the same registry pattern but register in `engines.NewRegistry(...)`. Coordinate with maintainers before starting — adding an engine implies a new output format that every provider's output must be translatable into.
 
 ### Anti-patterns
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ This separation is load-bearing. If you find yourself reading the fabric in an e
 cmd/                  # Entry points: topograph, node-observer, node-data-broker, kwok-nodes
 pkg/
   providers/          # One directory per provider: aws, gcp, oci, nebius, netq, dra, infiniband, lambdai, cw, test
-  engines/            # One directory per engine: k8s, slinky, slurm
+  engines/            # One directory per engine: k8s, nfd, slinky, slurm
   topology/           # Canonical Graph, Vertex tree, and topology constants (DO NOT CHANGE CASUALLY)
   registry/           # Central NamedLoader wiring for providers + engines
   translate/          # topology.conf and block/tree generation shared by engines
@@ -151,7 +151,7 @@ A provider returns a `*topology.Graph` of the discovered topology. `Tiers` is th
 
 ### Adding a new engine
 
-Engines are much rarer (three exist: slurm, k8s, slinky). Follow the same registry pattern but register in `engines.NewRegistry(...)`. Coordinate with maintainers before starting — adding an engine implies a new output format that every provider's output must be translatable into.
+Engines are much rarer (four exist: slurm, k8s, nfd, slinky). Follow the same registry pattern but register in `engines.NewRegistry(...)`. Coordinate with maintainers before starting — adding an engine implies a new output format that every provider's output must be translatable into.
 
 ### Anti-patterns
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Security
 
+- Scoped the NFD engine's `NodeFeature` and `NodeFeatureGroup` permissions to the deployment-level `nfdNamespace` instead of granting them cluster-wide. Helm configures the same namespace at runtime through `NFD_NAMESPACE`; the namespace is no longer a request-level engine parameter, and the engine rejects a missing or blank environment variable.
+
 - Removed unused RBAC verbs from the Topograph API server and node-data-broker ClusterRoles (least-privilege): API server `pods` rule dropped `get` (list-only), `daemonsets` rule dropped `list` (get-only), and the Slinky `configmaps` rule dropped `list`; node-data-broker `nodes` rule dropped `list` (get/update), and the InfiniBand `daemonsets`/`pods` rules dropped `list`/`get` respectively (get-only, list-only).
 
 - node-observer ClusterRole no longer grants unused `get`; `nodes` list/watch now gated on `trigger.nodeSelector`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- The NFD engine now rejects an empty generated object set when cleanup is enabled, preserving the last published topology instead of deleting every Topograph-managed NFD object after an empty provider result or over-narrow node selection.
 - The NFD engine now groups nodes with `nvidia.com/gpu.clique` by that authoritative accelerator value instead of omitting their accelerator attribute.
 - The NFD engine now publishes the `system.name/nodename` attribute required by NFD to populate `NodeFeatureGroup.status.nodes`, including for simulated KWOK nodes where no NFD worker executes.
 - `kwok-nodes` now maps generated instance IDs back to model hostnames when naming Kubernetes nodes and writing the Topograph instance annotation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - `govulncheck` job in the Go CI workflow for symbol-level vulnerability scanning on pull requests.
+- **NFD engine** (`engine: nfd`) that publishes Topograph topology as NFD `NodeFeature` and `NodeFeatureGroup` custom resources.
 - OCI labels missing from `docker/metadata-action` on the Topograph container image: `org.opencontainers.image.documentation`, `authors`, and `vendor` ([#377](https://github.com/NVIDIA/topograph/pull/377)).
 - Helm chart metadata: `home`, `icon`, `maintainers`, `keywords`, and Artifact Hub annotations ([#377](https://github.com/NVIDIA/topograph/pull/377)).
 - Helm `env`, `initContainers`, and `lifecycle` overrides across the API server, node-observer, and node-data-broker containers.
@@ -27,6 +28,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- The NFD engine now groups nodes with `nvidia.com/gpu.clique` by that authoritative accelerator value instead of omitting their accelerator attribute.
+- The NFD engine now publishes the `system.name/nodename` attribute required by NFD to populate `NodeFeatureGroup.status.nodes`, including for simulated KWOK nodes where no NFD worker executes.
 - `kwok-nodes` now maps generated instance IDs back to model hostnames when naming Kubernetes nodes and writing the Topograph instance annotation.
 - The node-observer now discovers the optional node-data-broker through `NODE_DATA_BROKER_NAME` and `NODE_DATA_BROKER_NAMESPACE` and gates topology generation on the broker DaemonSet's desired and ready replica counts. Helm injects the variables only when `nodeDataBroker.enabled=true`, so disabling the broker cannot leave the observer waiting for nonexistent pods.
 - The node-observer reports an actionable error and defers topology generation when an enabled node-data-broker DaemonSet has zero desired replicas.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Topograph is a component that discovers the physical network topology of a clust
 
 Pick the install path that matches your scheduler:
 
-- **Kubernetes** — the same Helm chart covers native Kubernetes scheduling (`k8s` engine) and [Slinky](https://github.com/SlinkyProject) (Slurm-on-Kubernetes, `slinky` engine). See [Install on Kubernetes](docs/get-started/quickstart-k8s.md).
+- **Kubernetes** — the same Helm chart covers native Kubernetes scheduling (`k8s` engine), Node Feature Discovery CR output (`nfd` engine), and [Slinky](https://github.com/SlinkyProject) (Slurm-on-Kubernetes, `slinky` engine). See [Install on Kubernetes](docs/get-started/quickstart-k8s.md).
 - **Slurm (bare metal)** — install a `.deb` or `.rpm` package on the Slurm head node and run Topograph as a systemd service. See [Install on Slurm](docs/get-started/quickstart-slurm.md).
 
 ## Learn more

--- a/charts/topograph/README.md
+++ b/charts/topograph/README.md
@@ -42,9 +42,9 @@ The default `values.yaml` ships the `test` provider + `k8s` engine, suitable for
 
 ```yaml
 provider:
-  name: dra        # or aws, gcp, oci, nebius, netq, infiniband-k8s, ...
+  name: test       # or aws, gcp, oci, nebius, netq, infiniband-k8s, ...
 engine:
-  name: k8s        # or slurm, slinky, graph
+  name: k8s        # or nfd, slurm, slinky, graph
 ```
 
 For the full list of values and their defaults, see [`values.yaml`](./values.yaml). Example values files for specific deployment patterns:
@@ -111,7 +111,7 @@ The API server, node-observer, and node-data-broker containers all support `env`
 - **Project documentation site**: <https://topograph.docs.buildwithfern.com/topograph>
 - **Main repository**: <https://github.com/NVIDIA/topograph>
 - **Provider-specific setup**: `docs/providers/` in the main repository
-- **Engine documentation**: `docs/engines/k8s.md`, `docs/engines/slinky.md`, `docs/engines/slurm.md`, `docs/engines/graph.md`
+- **Engine documentation**: `docs/engines/k8s.md`, `docs/engines/nfd.md`, `docs/engines/slinky.md`, `docs/engines/slurm.md`, `docs/engines/graph.md`
 - **Node-labels reference**: `docs/reference/node-labels.md`
 - **Contributing**: see [`CONTRIBUTING.md`](https://github.com/NVIDIA/topograph/blob/main/CONTRIBUTING.md) in the main repository
 

--- a/charts/topograph/templates/NOTES.txt
+++ b/charts/topograph/templates/NOTES.txt
@@ -42,6 +42,11 @@
 
   NOTE: node-data-broker applies node annotations once when each broker pod starts.
 {{- end }}
+{{- if eq .Values.engine.name "nfd" }}
+
+  NOTE: The NFD engine writes NodeFeature and NodeFeatureGroup resources in
+        {{ .Values.nfdNamespace }}. This must be the namespace where NFD master runs.
+{{- end }}
 {{- if not .Values.serviceAccount.create }}
 
 2. Topograph is configured to use the existing ServiceAccount "{{ include "topograph.serviceAccountName" . }}".

--- a/charts/topograph/templates/_validation.tpl
+++ b/charts/topograph/templates/_validation.tpl
@@ -8,6 +8,10 @@
   {{- fail "gatewayAPI.enabled=true requires at least one entry in gatewayAPI.parentRefs referencing the existing Gateway resource this HTTPRoute should attach to. See charts/topograph/values.k8s.gateway-api-example.yaml for a complete example." }}
 {{- end }}
 
+{{- if and (eq .Values.engine.name "nfd") (hasKey (default dict .Values.env) "NFD_NAMESPACE") }}
+  {{- fail "env.NFD_NAMESPACE is managed by the chart for the nfd engine; configure nfdNamespace instead" }}
+{{- end }}
+
 {{- if eq .Values.provider.name "gcp" }}
 {{- $params := default dict .Values.provider.params }}
 

--- a/charts/topograph/templates/deployment.yaml
+++ b/charts/topograph/templates/deployment.yaml
@@ -1,6 +1,7 @@
 {{ include "topograph.validation" . }}
 {{- $providerParams := default dict .Values.provider.params }}
 {{- $hasGcpCredentials := and (eq .Values.provider.name "gcp") (or $providerParams.serviceAccountKeysSecret $providerParams.workloadIdentityFederation) }}
+{{- $isNFDEngine := eq .Values.engine.name "nfd" }}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -52,7 +53,7 @@ spec:
             {{- range $key, $value := .Values.topologyNodeLabels }}
             - -k8s-topology-key-{{ $key }}={{ $value }}
             {{- end }}
-          {{- if or .Values.nodeDataBroker.enabled $hasGcpCredentials .Values.env }}
+          {{- if or .Values.nodeDataBroker.enabled $hasGcpCredentials $isNFDEngine .Values.env }}
           env:
             {{- if .Values.nodeDataBroker.enabled }}
             - name: NODE_DATA_BROKER_NAME
@@ -68,6 +69,10 @@ spec:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /etc/topograph/gcp/credentials-config.json
             {{- end }}
+            {{- end }}
+            {{- if $isNFDEngine }}
+            - name: NFD_NAMESPACE
+              value: {{ .Values.nfdNamespace | quote }}
             {{- end }}
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}

--- a/charts/topograph/templates/rbac.yaml
+++ b/charts/topograph/templates/rbac.yaml
@@ -49,6 +49,11 @@ rules:
   resources: [configmaps]
   verbs: [create,get,update]
 {{- end }}
+{{- if eq .Values.engine.name "nfd" }}
+- apiGroups: [nfd.k8s-sigs.io]
+  resources: [nodefeatures,nodefeaturegroups]
+  verbs: [create,get,list,patch,update,delete]
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/topograph/templates/rbac.yaml
+++ b/charts/topograph/templates/rbac.yaml
@@ -49,11 +49,6 @@ rules:
   resources: [configmaps]
   verbs: [create,get,update]
 {{- end }}
-{{- if eq .Values.engine.name "nfd" }}
-- apiGroups: [nfd.k8s-sigs.io]
-  resources: [nodefeatures,nodefeaturegroups]
-  verbs: [create,get,list,patch,update,delete]
-{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -68,4 +63,31 @@ roleRef:
   kind: ClusterRole
   name: {{ include "topograph.rbacName" . }}
   apiGroup: ""
+{{- if eq .Values.engine.name "nfd" }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "topograph.rbacName" . }}
+  namespace: {{ .Values.nfdNamespace | quote }}
+rules:
+- apiGroups: [nfd.k8s-sigs.io]
+  resources: [nodefeatures,nodefeaturegroups]
+  verbs: [create,list,patch,delete]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "topograph.rbacName" . }}
+  namespace: {{ .Values.nfdNamespace | quote }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "topograph.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  apiGroup: ""
+roleRef:
+  kind: Role
+  name: {{ include "topograph.rbacName" . }}
+  apiGroup: ""
+{{- end }}
 {{- end }}

--- a/charts/topograph/tests/deployment_test.yaml
+++ b/charts/topograph/tests/deployment_test.yaml
@@ -223,6 +223,31 @@ tests:
             value: topograph
         template: templates/deployment.yaml
 
+  - it: injects the default NFD namespace for the nfd engine
+    set:
+      engine:
+        name: nfd
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NFD_NAMESPACE
+            value: node-feature-discovery
+        template: templates/deployment.yaml
+
+  - it: injects the configured NFD namespace
+    set:
+      engine:
+        name: nfd
+      nfdNamespace: custom-nfd
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NFD_NAMESPACE
+            value: custom-nfd
+        template: templates/deployment.yaml
+
   - it: omits the node-data-broker coordinates when the broker is disabled
     set:
       nodeDataBroker:

--- a/charts/topograph/tests/rbac_test.yaml
+++ b/charts/topograph/tests/rbac_test.yaml
@@ -71,7 +71,7 @@ tests:
             resources: [daemonsets]
             verbs: [get]
 
-  - it: does not grant pods/exec or configmaps with the default provider and engine
+  - it: does not grant provider- or engine-specific access by default
     documentIndex: 0
     asserts:
       - notContains:
@@ -85,7 +85,13 @@ tests:
           content:
             apiGroups: [""]
             resources: [configmaps]
-            verbs: [create, get, list, update]
+            verbs: [create, get, update]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [nfd.k8s-sigs.io]
+            resources: [nodefeatures, nodefeaturegroups]
+            verbs: [create, list, patch, delete]
       - notContains:
           path: rules
           content:
@@ -135,14 +141,60 @@ tests:
     set:
       engine:
         name: nfd
-    documentIndex: 0
     asserts:
+      - hasDocuments:
+          count: 4
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [nfd.k8s-sigs.io]
+            resources: [nodefeatures, nodefeaturegroups]
+            verbs: [create, list, patch, delete]
+        documentIndex: 0
+      - isKind:
+          of: Role
+        documentIndex: 2
+      - equal:
+          path: metadata.namespace
+          value: node-feature-discovery
+        documentIndex: 2
       - contains:
           path: rules
           content:
             apiGroups: [nfd.k8s-sigs.io]
             resources: [nodefeatures, nodefeaturegroups]
-            verbs: [create, get, list, patch, update, delete]
+            verbs: [create, list, patch, delete]
+        documentIndex: 2
+      - isKind:
+          of: RoleBinding
+        documentIndex: 3
+      - equal:
+          path: metadata.namespace
+          value: node-feature-discovery
+        documentIndex: 3
+      - equal:
+          path: roleRef.kind
+          value: Role
+        documentIndex: 3
+      - equal:
+          path: subjects[0].namespace
+          value: topograph
+        documentIndex: 3
+
+  - it: scopes NFD CR access to the configured namespace
+    set:
+      engine:
+        name: nfd
+      nfdNamespace: custom-nfd
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-nfd
+        documentIndex: 2
+      - equal:
+          path: metadata.namespace
+          value: custom-nfd
+        documentIndex: 3
 
   - it: does not grant pods/exec for slinky with a default flat cluster topology
     set:

--- a/charts/topograph/tests/rbac_test.yaml
+++ b/charts/topograph/tests/rbac_test.yaml
@@ -131,6 +131,19 @@ tests:
             resources: [configmaps]
             verbs: [create, get, list, update]
 
+  - it: grants NFD CR access for the nfd engine
+    set:
+      engine:
+        name: nfd
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [nfd.k8s-sigs.io]
+            resources: [nodefeatures, nodefeaturegroups]
+            verbs: [create, get, list, patch, update, delete]
+
   - it: does not grant pods/exec for slinky with a default flat cluster topology
     set:
       engine:

--- a/charts/topograph/tests/rbac_test.yaml
+++ b/charts/topograph/tests/rbac_test.yaml
@@ -137,6 +137,20 @@ tests:
             resources: [configmaps]
             verbs: [create, get, list, update]
 
+  - it: does not render NFD namespace RBAC for an explicit non-NFD engine
+    set:
+      engine:
+        name: slinky
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: ClusterRole
+        documentIndex: 0
+      - isKind:
+          of: ClusterRoleBinding
+        documentIndex: 1
+
   - it: grants NFD CR access for the nfd engine
     set:
       engine:

--- a/charts/topograph/tests/validation_test.yaml
+++ b/charts/topograph/tests/validation_test.yaml
@@ -50,3 +50,13 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "workloadIdentityFederation requires both credentialsConfigmap and audience"
+
+  - it: rejects overriding the chart-managed NFD namespace environment variable
+    set:
+      engine:
+        name: nfd
+      env:
+        NFD_NAMESPACE: other-nfd
+    asserts:
+      - failedTemplate:
+          errorMessage: "env.NFD_NAMESPACE is managed by the chart for the nfd engine; configure nfdNamespace instead"

--- a/charts/topograph/values.nfd.kind-kwok.yaml
+++ b/charts/topograph/values.nfd.kind-kwok.yaml
@@ -1,0 +1,28 @@
+provider:
+  name: test
+  params:
+    modelFileName: medium.yaml
+    generateResponseCode: 202
+    topologyResponseCode: 200
+engine:
+  name: nfd
+  params:
+    nodeSelector:
+      kwok.x-k8s.io/node: "fake"
+    cleanup: true
+
+nfdNamespace: node-feature-discovery
+
+nodeSelector:
+  node-role.kubernetes.io/control-plane: ""
+
+nodeObserver:
+  nodeSelector:
+    node-role.kubernetes.io/control-plane: ""
+  topograph:
+    trigger:
+      nodeSelector:
+        kwok.x-k8s.io/node: "fake"
+
+nodeDataBroker:
+  enabled: false

--- a/charts/topograph/values.schema.json
+++ b/charts/topograph/values.schema.json
@@ -55,6 +55,11 @@
       },
       "required": ["name"]
     },
+    "nfdNamespace": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Namespace where NFD master runs and where the nfd engine creates NodeFeature and NodeFeatureGroup resources."
+    },
     "service": {
       "type": "object",
       "properties": {

--- a/charts/topograph/values.schema.json
+++ b/charts/topograph/values.schema.json
@@ -35,7 +35,7 @@
         },
         "params": {
           "type": "object",
-          "description": "Provider-specific parameters. For infiniband-k8s, useGpuCliqueLabel=true reads nvidia.com/gpu.clique as the accelerator-domain source."
+          "description": "Provider-specific parameters. Requirements are documented in docs/providers/<name>.md."
         }
       },
       "required": ["name"]
@@ -46,7 +46,7 @@
         "name": {
           "type": "string",
           "description": "Scheduler-output engine. Must match a registered engine in pkg/registry/registry.go.",
-          "enum": ["graph", "k8s", "slinky", "slurm"]
+          "enum": ["graph", "k8s", "nfd", "slinky", "slurm"]
         },
         "params": {
           "type": "object",

--- a/charts/topograph/values.yaml
+++ b/charts/topograph/values.yaml
@@ -19,6 +19,10 @@ engine:
   #   # Kubernetes node label as the block-domain source.
   #   useGpuCliqueLabel: true
 
+# Namespace where NFD master runs. The nfd engine creates NodeFeature and
+# NodeFeatureGroup resources here, and its Role/RoleBinding are scoped here.
+nfdNamespace: node-feature-discovery
+
 service:
   type: ClusterIP
   port: 49021

--- a/charts/topograph/values.yaml
+++ b/charts/topograph/values.yaml
@@ -12,7 +12,7 @@ provider:
   #   useGpuCliqueLabel: true
 
 engine:
-  # name: "k8s", "slinky", "slurm" or "graph"
+  # name: "k8s", "nfd", "slinky", "slurm" or "graph"
   name: k8s
   # params:
   #   # For slinky topology/block output, use the GPU Operator's existing

--- a/docs/api.md
+++ b/docs/api.md
@@ -74,7 +74,7 @@ Topograph exposes three endpoints for interacting with the service. Below are th
     - **params**: (optional) A key-value map with provider-specific parameters. The `test` provider uses these parameters for response simulation; for complete behavior and examples, see [Test Mode and Test Provider](./providers/test.md).
       - **useGpuCliqueLabel**: (optional) Used in: [`infiniband-k8s`]. If `true`, reads the GPU Operator's `nvidia.com/gpu.clique` node label as the accelerator-domain source instead of using the `topograph.nvidia.com/cluster-id` node annotation.
   - **engine**: (optional) Selects the topology output and provides any engine-specific parameters.
-    - **name**: (optional) A string specifying the topology output, either `slurm`, `k8s`, `slinky`, or `graph`. This parameter will override the engine set in the topograph config.
+    - **name**: (optional) A string specifying the topology output, either `slurm`, `k8s`, `nfd`, `slinky`, or `graph`. This parameter will override the engine set in the topograph config.
     - **params**: (optional) A key-value map with engine-specific parameters.
       - **plugin**: (optional) Used in: [`slurm`, `slinky`]. A string specifying the cluster-wide topology plugin: `topology/tree` or `topology/block`. For `slurm`, this defaults to `topology/tree` when neither `plugin` nor `topologies` is set. Do not set `plugin` together with `topologies`.
       - **blockSizes**: (optional) Used in: [`slurm`, `slinky`]. An array of block sizes for `topology/block`.
@@ -87,9 +87,9 @@ Topograph exposes three endpoints for interacting with the service. Below are th
         - **podSelector**: (optional) Used in: [`slinky`]. A Kubernetes label selector for slurmd pods in this partition. `nodes` and `podSelector` are mutually exclusive on the same topology entry.
         - **clusterDefault**: (optional) Used in: [`slurm`, `slinky`]. If `true`, marks this topology as the default for nodes not assigned to another topology; commonly used with `plugin: topology/flat`.
       - **reconfigure**: (optional) Used in: [`slurm`]. If `true`, invoke `scontrol reconfigure` after topology config is generated. Default `false`.
-      - **namespace**: Used in: [`slinky`]. The required namespace where the SLURM cluster is running.
+      - **namespace**: Used in: [`slinky`]. The required namespace where the SLURM cluster is running. The NFD namespace is deployment-scoped and cannot be supplied in a topology request; Helm deployments configure it with the top-level `nfdNamespace` value.
       - **podSelector**: Used in: [`slinky`]. A required Kubernetes label selector for pods running SLURM nodes.
-      - **nodeSelector**: (optional) Used in: [`k8s`, `slinky`]. A Kubernetes node label map that filters which nodes participate in topology generation.
+      - **nodeSelector**: (optional) Used in: [`k8s`, `nfd`, `slinky`]. A Kubernetes node label map that filters which nodes participate in topology generation.
       - **topologyConfigmapName**: Used in: [`slinky`]. The required name of the ConfigMap containing the topology config.
       - **useDynamicNodes**: (optional) Used in: [`slinky`]. If `true`, Kubernetes nodes matched by the Node Selector will be annotated with the topology spec.
       - **useGpuCliqueLabel**: (optional) Used in: [`slinky`]. If `true`, `topology/block` domains are built from the GPU Operator's `nvidia.com/gpu.clique` node label instead of provider accelerator-domain data.

--- a/docs/design/nfd-engine-sdd.md
+++ b/docs/design/nfd-engine-sdd.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft.
+Implemented.
 
 ## Summary
 
@@ -66,6 +66,9 @@ metadata:
 spec:
   features:
     attributes:
+      system.name:
+        elements:
+          nodename: node-a
       topograph.network:
         elements:
           accelerator: nvl3

--- a/docs/design/nfd-engine-sdd.md
+++ b/docs/design/nfd-engine-sdd.md
@@ -112,7 +112,9 @@ Initial parameters:
 - `nodeSelector`: optional, same meaning as the `k8s` engine.
 - `cleanup`: optional boolean, default `true`, deleting stale Topograph-managed
   `NodeFeature` and `NodeFeatureGroup` objects no longer present in the latest
-  graph.
+  graph. An empty generated object set is rejected while cleanup is enabled so
+  a transient empty provider result cannot delete the entire published
+  topology.
 
 The NFD master namespace is deployment-scoped rather than request-scoped. Helm
 configures it through the top-level `nfdNamespace` value and passes it to the
@@ -221,6 +223,8 @@ small patches to reduce write amplification.
 - Unit-test graph-to-group generation for accelerator, leaf, spine, and core.
 - Verify long and invalid topology values produce stable CR names.
 - Verify stale Topograph-managed groups are removed when `cleanup` is enabled.
+- Verify an empty generated object set returns an error and preserves existing
+  objects when `cleanup` is enabled.
 - Verify nodes with `nvidia.com/gpu.clique` follow the same accelerator behavior
   as the `k8s` engine.
 - Add a fake dynamic-client test that applies generated `NodeFeature` and

--- a/docs/design/nfd-engine-sdd.md
+++ b/docs/design/nfd-engine-sdd.md
@@ -110,12 +110,15 @@ raw topology value is too long or contains invalid name characters.
 Initial parameters:
 
 - `nodeSelector`: optional, same meaning as the `k8s` engine.
-- `namespace`: optional if the installed NFD CRDs are namespaced. The
-  implementation should use discovery or the REST mapper rather than assuming
-  CRD scope.
 - `cleanup`: optional boolean, default `true`, deleting stale Topograph-managed
   `NodeFeature` and `NodeFeatureGroup` objects no longer present in the latest
   graph.
+
+The NFD master namespace is deployment-scoped rather than request-scoped. Helm
+configures it through the top-level `nfdNamespace` value and passes it to the
+engine as `NFD_NAMESPACE`; non-Helm deployments set that environment variable
+directly. The Helm value defaults to `node-feature-discovery`; the engine
+returns an error if `NFD_NAMESPACE` is unset or blank.
 
 ## Implementation Notes
 

--- a/docs/engines/nfd.md
+++ b/docs/engines/nfd.md
@@ -1,0 +1,121 @@
+# Topograph NFD Engine
+
+The `nfd` engine publishes Topograph topology through
+[Node Feature Discovery](https://kubernetes-sigs.github.io/node-feature-discovery/)
+custom resources instead of writing Kubernetes node labels directly.
+
+It creates:
+
+- one `NodeFeature` per topology node, carrying Topograph topology as
+  `spec.features.attributes.topograph.network.elements`
+- one `NodeFeatureGroup` per distinct accelerator, leaf, spine, and core value
+
+NFD master evaluates those features and writes matching nodes to
+`NodeFeatureGroup.status.nodes`.
+
+## When to Use
+
+Use `engine: nfd` only when a downstream component already consumes NFD
+`NodeFeatureGroup` objects. For native Kubernetes scheduling with
+`podAffinity.topologyKey`, use the [`k8s`](./k8s.md) engine instead.
+
+NFD `NodeFeatureGroup` is an alpha API and is disabled by default in NFD master
+at the time of writing. Enable the matching NFD feature gate before using this
+engine. See the NFD
+[custom resource documentation](https://kubernetes-sigs.github.io/node-feature-discovery/master/usage/custom-resources.html#nodefeaturegroup)
+for the current upstream state.
+
+## Configuration
+
+```yaml
+provider:
+  name: infiniband-k8s
+engine:
+  name: nfd
+  params:
+    nodeSelector:
+      nvidia.com/gpu.present: "true"
+    cleanup: true
+```
+
+Parameters:
+
+| Parameter | Required | Default | Description |
+|---|---:|---|---|
+| `nodeSelector` | No | all nodes | Limits the Kubernetes nodes used as provider input. Same meaning as the `k8s` engine selector. |
+| `cleanup` | No | `true` | Deletes stale Topograph-managed `NodeFeature` and `NodeFeatureGroup` objects that are no longer present in the generated topology. |
+| `namespace` | No | empty | Namespace for namespaced NFD CRs. Set it to the NFD master namespace because NFD resolves `NodeFeatureGroup` updates there. |
+
+## Generated Objects
+
+For a node on `leaf-12`, the engine writes a `NodeFeature` like:
+
+```yaml
+apiVersion: nfd.k8s-sigs.io/v1alpha1
+kind: NodeFeature
+metadata:
+  name: topograph-node-node-a-...
+  labels:
+    nfd.node.kubernetes.io/node-name: node-a
+    app.kubernetes.io/managed-by: topograph
+    topograph.nvidia.com/engine: nfd
+spec:
+  features:
+    attributes:
+      system.name:
+        elements:
+          nodename: node-a
+      topograph.network:
+        elements:
+          accelerator: nvl3
+          leaf: leaf-12
+          spine: spine-2
+          core: core-1
+```
+
+For each distinct value, it writes a matching `NodeFeatureGroup`:
+
+```yaml
+apiVersion: nfd.k8s-sigs.io/v1alpha1
+kind: NodeFeatureGroup
+metadata:
+  name: topograph-leaf-leaf-12-...
+  labels:
+    app.kubernetes.io/managed-by: topograph
+    topograph.nvidia.com/engine: nfd
+    topograph.nvidia.com/group-type: leaf
+  annotations:
+    topograph.nvidia.com/label-key: network.topology.nvidia.com/leaf
+    topograph.nvidia.com/label-value: leaf-12
+spec:
+  featureGroupRules:
+    - name: leaf equals leaf-12
+      matchFeatures:
+        - feature: topograph.network
+          matchExpressions:
+            leaf:
+              op: In
+              value: ["leaf-12"]
+```
+
+Topograph includes `system.name.elements.nodename` so NFD can populate group
+membership even when an NFD worker does not run on the node, as with simulated
+KWOK nodes. Topograph does not write `status.nodes`; NFD owns status updates.
+
+If a Kubernetes node already has `nvidia.com/gpu.clique`, the engine uses that
+label's value as the authoritative accelerator attribute instead of the value
+derived from the provider graph. The matching `NodeFeatureGroup` records
+`nvidia.com/gpu.clique` as its source label key. Leaf, spine, and core topology
+attributes are still published.
+
+## Caveats
+
+`NodeFeatureGroup` objects enumerate topology groups. A scheduler that wants to
+place a workload within one leaf switch must still decide which leaf group to
+use. This is different from native pod affinity, where the scheduler can compare
+candidate nodes using a single `topologyKey`.
+
+Large clusters may create many CRs and large `status.nodes` arrays. The design
+notes in [`docs/design/nfd-engine-sdd.md`](../design/nfd-engine-sdd.md) include
+the storage estimate and possible future NFD improvements such as group unions
+and compressed node-name ranges.

--- a/docs/engines/nfd.md
+++ b/docs/engines/nfd.md
@@ -19,11 +19,37 @@ Use `engine: nfd` only when a downstream component already consumes NFD
 `NodeFeatureGroup` objects. For native Kubernetes scheduling with
 `podAffinity.topologyKey`, use the [`k8s`](./k8s.md) engine instead.
 
-NFD `NodeFeatureGroup` is an alpha API and is disabled by default in NFD master
-at the time of writing. Enable the matching NFD feature gate before using this
-engine. See the NFD
-[custom resource documentation](https://kubernetes-sigs.github.io/node-feature-discovery/master/usage/custom-resources.html#nodefeaturegroup)
-for the current upstream state.
+## Install NFD
+
+The `NodeFeatureGroupAPI` feature gate is **disabled by default** in NFD. It has
+been Alpha since NFD v0.16 and must be enabled explicitly before using this
+engine. See the upstream
+[feature-gate reference](https://kubernetes-sigs.github.io/node-feature-discovery/master/reference/feature-gates.html#nodefeaturegroupapi)
+for its current status.
+
+The following example limits the NFD worker to nodes labeled
+`nfd-enabled=true`. Label each intended worker node first:
+
+```bash
+kubectl label node <node-name> nfd-enabled=true
+```
+
+Then install NFD with the `NodeFeatureGroupAPI` feature gate enabled:
+
+```bash
+helm repo add nfd https://kubernetes-sigs.github.io/node-feature-discovery/charts
+
+helm repo update
+
+helm install nfd nfd/node-feature-discovery \
+  --namespace node-feature-discovery \
+  --create-namespace \
+  --set-string worker.nodeSelector.nfd-enabled=true \
+  --set featureGates.NodeFeatureGroupAPI=true
+```
+
+Omit `worker.nodeSelector.nfd-enabled` if the NFD worker should run on all
+eligible nodes.
 
 ## Configuration
 
@@ -36,6 +62,7 @@ engine:
     nodeSelector:
       nvidia.com/gpu.present: "true"
     cleanup: true
+nfdNamespace: node-feature-discovery
 ```
 
 Parameters:
@@ -44,7 +71,19 @@ Parameters:
 |---|---:|---|---|
 | `nodeSelector` | No | all nodes | Limits the Kubernetes nodes used as provider input. Same meaning as the `k8s` engine selector. |
 | `cleanup` | No | `true` | Deletes stale Topograph-managed `NodeFeature` and `NodeFeatureGroup` objects that are no longer present in the generated topology. |
-| `namespace` | No | empty | Namespace for namespaced NFD CRs. Set it to the NFD master namespace because NFD resolves `NodeFeatureGroup` updates there. |
+
+`nfdNamespace` is a deployment-level Helm value, not an engine request
+parameter. It must be the namespace where NFD master runs because NFD updates
+`NodeFeatureGroup.status` there. The Helm value defaults to
+`node-feature-discovery`.
+
+When `rbac.create` is enabled, the chart creates a `Role` and `RoleBinding` in
+that namespace and configures the Topograph deployment with the same value
+through `NFD_NAMESPACE`. Outside Helm, set `NFD_NAMESPACE` on the Topograph
+process. The NFD engine returns an error if the variable is unset or blank.
+
+Topology requests cannot select an NFD namespace; the deployment environment is
+authoritative.
 
 ## Generated Objects
 
@@ -55,6 +94,7 @@ apiVersion: nfd.k8s-sigs.io/v1alpha1
 kind: NodeFeature
 metadata:
   name: topograph-node-node-a-...
+  namespace: node-feature-discovery
   labels:
     nfd.node.kubernetes.io/node-name: node-a
     app.kubernetes.io/managed-by: topograph
@@ -80,6 +120,7 @@ apiVersion: nfd.k8s-sigs.io/v1alpha1
 kind: NodeFeatureGroup
 metadata:
   name: topograph-leaf-leaf-12-...
+  namespace: node-feature-discovery
   labels:
     app.kubernetes.io/managed-by: topograph
     topograph.nvidia.com/engine: nfd

--- a/docs/engines/nfd.md
+++ b/docs/engines/nfd.md
@@ -70,7 +70,7 @@ Parameters:
 | Parameter | Required | Default | Description |
 |---|---:|---|---|
 | `nodeSelector` | No | all nodes | Limits the Kubernetes nodes used as provider input. Same meaning as the `k8s` engine selector. |
-| `cleanup` | No | `true` | Deletes stale Topograph-managed `NodeFeature` and `NodeFeatureGroup` objects that are no longer present in the generated topology. |
+| `cleanup` | No | `true` | Deletes stale Topograph-managed `NodeFeature` and `NodeFeatureGroup` objects that are no longer present in the generated topology. If generation produces no objects, the engine returns an error and preserves the existing topology. |
 
 `nfdNamespace` is a deployment-level Helm value, not an engine request
 parameter. It must be the namespace where NFD master runs because NFD updates

--- a/docs/get-started/quickstart-k8s.md
+++ b/docs/get-started/quickstart-k8s.md
@@ -14,7 +14,9 @@ Prerequisites, install flow, and verification are common to both — the engines
 - **Helm**: 3.10+ or 4.x
 - **`kubectl`** with permission to install a chart and create a `Namespace`
 - **A supported provider** for your environment — see the [provider documentation](../providers/) for per-provider setup (credentials, required cluster state, etc.)
-- **For the `nfd` engine only**: Node Feature Discovery installed with `NodeFeatureGroup` support enabled
+- **For the `nfd` engine only**: Node Feature Discovery installed with the
+  Alpha `NodeFeatureGroupAPI` feature gate enabled. It is disabled by default;
+  see the [NFD engine installation instructions](../engines/nfd.md#install-nfd).
 - **For the `slinky` engine only**: a Slinky cluster already deployed in the target Kubernetes cluster — Topograph does not deploy Slinky itself
 
 ## Install
@@ -73,7 +75,8 @@ kubectl logs -n topograph -l app.kubernetes.io/name=topograph
 Engine-specific install flag:
 
 ```bash
-  --set engine.name=nfd
+  --set engine.name=nfd \
+  --set nfdNamespace=node-feature-discovery
 ```
 
 The `nfd` engine creates `NodeFeature` and `NodeFeatureGroup` objects in the
@@ -83,7 +86,7 @@ The `nfd` engine creates `NodeFeature` and `NodeFeatureGroup` objects in the
 To inspect generated groups:
 
 ```bash
-kubectl get nodefeaturegroups.nfd.k8s-sigs.io
+kubectl get nodefeaturegroups.nfd.k8s-sigs.io -n node-feature-discovery
 ```
 
 Use this engine only for consumers that understand NFD groups. For native

--- a/docs/get-started/quickstart-k8s.md
+++ b/docs/get-started/quickstart-k8s.md
@@ -1,8 +1,9 @@
 # Install on Kubernetes
 
-Topograph installs on a Kubernetes cluster via a Helm chart. This quickstart covers the two Kubernetes-facing scheduler engines:
+Topograph installs on a Kubernetes cluster via a Helm chart. This quickstart covers the Kubernetes-facing scheduler engines:
 
 - **[`k8s` engine](#engine-k8s)** — labels Kubernetes nodes with topology keys so schedulers (native `podAffinity`, KAI Scheduler, Kueue TAS, etc.) can make topology-aware placement decisions
+- **[`nfd` engine](#engine-nfd)** — publishes topology as Node Feature Discovery `NodeFeature` and `NodeFeatureGroup` custom resources for NFD-aware consumers
 - **[`slinky` engine](#engine-slinky)** — writes Slurm topology configuration into a `ConfigMap` for [Slinky](https://github.com/SlinkyProject) (Slurm-on-Kubernetes) deployments
 
 Prerequisites, install flow, and verification are common to both — the engines differ only in a few `engine.*` values and in what downstream artifact is produced.
@@ -13,6 +14,7 @@ Prerequisites, install flow, and verification are common to both — the engines
 - **Helm**: 3.10+ or 4.x
 - **`kubectl`** with permission to install a chart and create a `Namespace`
 - **A supported provider** for your environment — see the [provider documentation](../providers/) for per-provider setup (credentials, required cluster state, etc.)
+- **For the `nfd` engine only**: Node Feature Discovery installed with `NodeFeatureGroup` support enabled
 - **For the `slinky` engine only**: a Slinky cluster already deployed in the target Kubernetes cluster — Topograph does not deploy Slinky itself
 
 ## Install
@@ -66,6 +68,27 @@ If labels are missing, inspect the Topograph logs:
 kubectl logs -n topograph -l app.kubernetes.io/name=topograph
 ```
 
+## Engine: `nfd` <a name="engine-nfd"></a>
+
+Engine-specific install flag:
+
+```bash
+  --set engine.name=nfd
+```
+
+The `nfd` engine creates `NodeFeature` and `NodeFeatureGroup` objects in the
+`nfd.k8s-sigs.io/v1alpha1` API group. NFD owns the group status and populates
+`NodeFeatureGroup.status.nodes` after evaluating the feature rules.
+
+To inspect generated groups:
+
+```bash
+kubectl get nodefeaturegroups.nfd.k8s-sigs.io
+```
+
+Use this engine only for consumers that understand NFD groups. For native
+Kubernetes pod affinity and topology keys, use `engine: k8s`.
+
 ## Engine: `slinky` <a name="engine-slinky"></a>
 
 Engine-specific install flags point the `slinky` engine at the Slinky deployment:
@@ -94,6 +117,7 @@ The key configured via `topologyConfigPath` (by default `topology.conf`) should 
 ## Where to go next
 
 - **[Kubernetes engine reference](../engines/k8s.md)** — configuration, access patterns (`Ingress`, `HTTPRoute`, `NetworkPolicy`, `ServiceMonitor`), mixed workload considerations
+- **[NFD engine reference](../engines/nfd.md)** — `NodeFeature` / `NodeFeatureGroup` output, requirements, and caveats
 - **[Slinky engine reference](../engines/slinky.md)** — `slinky` engine parameters, `ConfigMap` annotations, tree / block / per-partition usage examples (the chart-level deployment surface is shared with the `k8s` engine and is documented under the Kubernetes engine reference above)
 - **[Chart README](https://github.com/NVIDIA/topograph/blob/main/charts/topograph/README.md)** — full values reference, `helm test` details, air-gapped environments, and component layout
 - **[Node labels reference](../reference/node-labels.md)** — label key semantics, value behavior (FNV hashing for long values), integration with the NVIDIA GPU Operator, downstream consumer notes (relevant primarily to the `k8s` engine)

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -49,6 +49,8 @@ navigation:
         path: engines/slurm.md
       - page: Kubernetes
         path: engines/k8s.md
+      - page: Node Feature Discovery
+        path: engines/nfd.md
       - page: Slinky
         path: engines/slinky.md
       - page: Graph

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -49,6 +49,7 @@ Currently supported engines:
 
 - [SLURM](./engines/slurm.md)
 - [Kubernetes](./engines/k8s.md)
+- [Node Feature Discovery](./engines/nfd.md)
 - [SLURM-on-Kubernetes (Slinky)](./engines/slinky.md)
 - [Graph](./engines/graph.md) - returns instance-oriented topology metadata as JSON
 

--- a/docs/providers/infiniband.md
+++ b/docs/providers/infiniband.md
@@ -28,6 +28,7 @@ Both variants produce the same topology representation, and are in turn consumed
 
 - **Slurm engine** (`engine: slurm`) — writes a `topology.conf` file describing the switch tree, used by the Slurm topology plugin for topology-aware scheduling
 - **Kubernetes engine** (`engine: k8s`) — applies `network.topology.nvidia.com/` labels to nodes reflecting their position in the switch hierarchy and (where applicable) their NVLink domain
+- **NFD engine** (`engine: nfd`) — publishes topology as Node Feature Discovery `NodeFeature` and `NodeFeatureGroup` custom resources
 - **Slinky engine** (`engine: slinky`) — writes topology data to a Kubernetes ConfigMap for Slurm-on-Kubernetes deployments
 
 See the engine documentation (`docs/engines/`) for details on each output format.

--- a/docs/providers/netq.md
+++ b/docs/providers/netq.md
@@ -32,6 +32,7 @@ The NetQ provider produces the same topology representation as the InfiniBand pr
 
 - **Slurm engine** (`engine: slurm`) — writes a `topology.conf` file for Slurm topology-aware scheduling
 - **Kubernetes engine** (`engine: k8s`) — applies `network.topology.nvidia.com/` labels to nodes
+- **NFD engine** (`engine: nfd`) — publishes topology as Node Feature Discovery `NodeFeature` and `NodeFeatureGroup` custom resources
 - **Slinky engine** (`engine: slinky`) — writes topology data to a Kubernetes ConfigMap
 
 See the engine documentation (`docs/engines/`) for details on each output format.

--- a/docs/providers/test.md
+++ b/docs/providers/test.md
@@ -93,7 +93,7 @@ The test provider is configured through `provider.params` in the `/v1/generate` 
 }
 ```
 
-The `engine` object follows the normal Topograph engine configuration. For example, use `slurm` parameters to request `topology/tree` or `topology/block` output, use `k8s` parameters to write node labels, use `slinky` parameters to update a Slinky ConfigMap, or use `graph` to return model-backed instance metadata as JSON.
+The `engine` object follows the normal Topograph engine configuration. For example, use `slurm` parameters to request `topology/tree` or `topology/block` output, use `k8s` parameters to write node labels, use `nfd` parameters to publish NFD custom resources, use `slinky` parameters to update a Slinky ConfigMap, or use `graph` to return model-backed instance metadata as JSON.
 
 Names declared in a model's `blocks[].nodes` are treated as hostnames. The test provider generates the corresponding instance IDs by adding the `i-` prefix; for example, hostname `node1` maps from instance ID `i-node1`.
 

--- a/go.mod
+++ b/go.mod
@@ -19,12 +19,14 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/sync v0.21.0
 	google.golang.org/api v0.276.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.35.4
 	k8s.io/apimachinery v0.35.4
 	k8s.io/client-go v0.35.4
 	k8s.io/klog/v2 v2.140.0
+	sigs.k8s.io/node-feature-discovery/api/nfd v0.18.3
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -103,7 +105,6 @@ require (
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/text v0.38.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -264,6 +264,8 @@ k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 h1:kBawHLSnx/mYHmRnNUf9d4CpjREbe
 k8s.io/utils v0.0.0-20260319190234-28399d86e0b5/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
+sigs.k8s.io/node-feature-discovery/api/nfd v0.18.3 h1:l+ZtPZTdgsdG2POxY7oh7gdk/ML/FLI5VKwSDBl1fyk=
+sigs.k8s.io/node-feature-discovery/api/nfd v0.18.3/go.mod h1:XzGgUqDUyV/X+qkXEwG+CgfTUUeZix5iuobsmLoT0Ck=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
 sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=

--- a/internal/k8s/utils.go
+++ b/internal/k8s/utils.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 NVIDIA CORPORATION
+ * Copyright 2025-2026 NVIDIA CORPORATION
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/internal/k8s/utils.go
+++ b/internal/k8s/utils.go
@@ -18,6 +18,9 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/klog/v2"
+
+	"github.com/NVIDIA/topograph/pkg/topology"
 )
 
 func GetNodes(ctx context.Context, client kubernetes.Interface, opt *metav1.ListOptions) (*corev1.NodeList, error) {
@@ -96,4 +99,36 @@ func ExecInPod(ctx context.Context, client kubernetes.Interface, config *rest.Co
 	}
 
 	return &stdout, nil
+}
+
+// GetComputeInstances builds a ComputeInstances list from the node annotations
+// written by the node-data-broker (instance ID and region). Nodes missing either
+// annotation are skipped with a warning.
+func GetComputeInstances(nodes *corev1.NodeList) []topology.ComputeInstances {
+	regions := make(map[string]map[string]string)
+	regionNames := []string{}
+	for _, node := range nodes.Items {
+		instance, ok := node.Annotations[topology.KeyNodeInstance]
+		if !ok {
+			klog.Warningf("missing %q annotation in node %s", topology.KeyNodeInstance, node.Name)
+			continue
+		}
+		region, ok := node.Annotations[topology.KeyNodeRegion]
+		if !ok {
+			klog.Warningf("missing %q annotation in node %s", topology.KeyNodeRegion, node.Name)
+			continue
+		}
+		if _, ok = regions[region]; !ok {
+			regions[region] = make(map[string]string)
+			regionNames = append(regionNames, region)
+		}
+		regions[region][instance] = node.Name
+	}
+
+	cis := make([]topology.ComputeInstances, 0, len(regions))
+	for _, region := range regionNames {
+		cis = append(cis, topology.ComputeInstances{Region: region, Instances: regions[region]})
+	}
+
+	return cis
 }

--- a/pkg/engines/k8s/kubernetes.go
+++ b/pkg/engines/k8s/kubernetes.go
@@ -36,36 +36,7 @@ func (eng *K8sEngine) GetComputeInstances(ctx context.Context, _ any) ([]topolog
 	if err != nil {
 		return nil, httperr.NewError(http.StatusBadGateway, err.Error())
 	}
-	return getComputeInstances(nodes), nil
-}
-
-func getComputeInstances(nodes *corev1.NodeList) []topology.ComputeInstances {
-	regions := make(map[string]map[string]string)
-	regionNames := []string{}
-	for _, node := range nodes.Items {
-		instance, ok := node.Annotations[topology.KeyNodeInstance]
-		if !ok {
-			klog.Warningf("missing %q annotation in node %s", topology.KeyNodeInstance, node.Name)
-			continue
-		}
-		region, ok := node.Annotations[topology.KeyNodeRegion]
-		if !ok {
-			klog.Warningf("missing %q annotation in node %s", topology.KeyNodeRegion, node.Name)
-			continue
-		}
-		if _, ok = regions[region]; !ok {
-			regions[region] = make(map[string]string)
-			regionNames = append(regionNames, region)
-		}
-		regions[region][instance] = node.Name
-	}
-
-	cis := make([]topology.ComputeInstances, 0, len(regions))
-	for _, region := range regionNames {
-		cis = append(cis, topology.ComputeInstances{Region: region, Instances: regions[region]})
-	}
-
-	return cis
+	return k8s.GetComputeInstances(nodes), nil
 }
 
 func (eng *K8sEngine) AddNodeLabels(ctx context.Context, nodeName string, labels map[string]string) error {
@@ -92,15 +63,15 @@ func MergeNodeLabels(node *corev1.Node, labels map[string]string) {
 }
 
 func skipAcceleratorLabelWhenGPUCliqueExists(node *corev1.Node, labels map[string]string) map[string]string {
-	if labelAccelerator == "" || strings.TrimSpace(node.Labels[topology.KeyNvidiaGPUClique]) == "" {
+	if topologyLabelKeys.Accelerator == "" || strings.TrimSpace(node.Labels[topology.KeyNvidiaGPUClique]) == "" {
 		return labels
 	}
 
 	filtered := maps.Clone(labels)
-	delete(filtered, labelAccelerator)
+	delete(filtered, topologyLabelKeys.Accelerator)
 
-	if labelAccelerator != topology.KeyNvidiaGPUClique {
-		delete(node.Labels, labelAccelerator)
+	if topologyLabelKeys.Accelerator != topology.KeyNvidiaGPUClique {
+		delete(node.Labels, topologyLabelKeys.Accelerator)
 	}
 
 	return filtered

--- a/pkg/engines/k8s/kubernetes_test.go
+++ b/pkg/engines/k8s/kubernetes_test.go
@@ -8,10 +8,12 @@ package k8s
 import (
 	"testing"
 
-	"github.com/NVIDIA/topograph/pkg/topology"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	internalk8s "github.com/NVIDIA/topograph/internal/k8s"
+	"github.com/NVIDIA/topograph/pkg/topology"
 )
 
 func TestGetComputeInstances(t *testing.T) {
@@ -64,7 +66,7 @@ func TestGetComputeInstances(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cis := getComputeInstances(tc.nodes)
+			cis := internalk8s.GetComputeInstances(tc.nodes)
 			require.Equal(t, tc.cis, cis)
 		})
 	}

--- a/pkg/engines/k8s/labeler.go
+++ b/pkg/engines/k8s/labeler.go
@@ -31,22 +31,35 @@ const (
 	DefaultLabelCore        = "network.topology.nvidia.com/core"
 )
 
-var (
-	labelAccelerator, labelLeaf, labelSpine, labelCore string
+type TopologyLabelKeys struct {
+	Accelerator string
+	Leaf        string
+	Spine       string
+	Core        string
+}
 
-	switchNetworkHierarchy []string
-)
+var topologyLabelKeys = TopologyLabelKeys{
+	Accelerator: DefaultLabelAccelerator,
+	Leaf:        DefaultLabelLeaf,
+	Spine:       DefaultLabelSpine,
+	Core:        DefaultLabelCore,
+}
 
 func InitLabels(accelerator, leaf, spine, core string) {
-	labelAccelerator = accelerator
-	labelLeaf = leaf
-	labelSpine = spine
-	labelCore = core
-	switchNetworkHierarchy = []string{labelLeaf, labelSpine, labelCore}
+	topologyLabelKeys = TopologyLabelKeys{
+		Accelerator: accelerator,
+		Leaf:        leaf,
+		Spine:       spine,
+		Core:        core,
+	}
+}
+
+func CurrentTopologyLabelKeys() TopologyLabelKeys {
+	return topologyLabelKeys
 }
 
 // map nodename:[label name: label value]
-type nodeLabelMap map[string]map[string]string
+type NodeLabelMap map[string]map[string]string
 
 type Labeler interface {
 	AddNodeLabels(context.Context, string, map[string]string) error
@@ -63,25 +76,9 @@ func NewTopologyLabeler() *topologyLabeler {
 }
 
 func (l *topologyLabeler) ApplyNodeLabels(ctx context.Context, graph *topology.Graph, labeler Labeler) error {
-	if graph == nil || (graph.Domains == nil && graph.Tiers == nil) {
-		return nil
-	}
-
-	nodeMap := make(nodeLabelMap)
-	if graph.Domains != nil {
-		if err := l.getDomainLabels(graph.Domains, nodeMap); err != nil {
-			return err
-		}
-	}
-
-	if treeRoot := graph.Tiers; treeRoot != nil {
-		layers := []string{}
-		if len(treeRoot.ID) != 0 {
-			layers = append(layers, treeRoot.ID)
-		}
-		if err := l.getTierLabels(treeRoot, nodeMap, layers); err != nil {
-			return err
-		}
+	nodeMap, err := l.BuildNodeLabels(graph)
+	if err != nil {
+		return err
 	}
 
 	for nodeName, labels := range nodeMap {
@@ -93,7 +90,33 @@ func (l *topologyLabeler) ApplyNodeLabels(ctx context.Context, graph *topology.G
 	return nil
 }
 
-func (l *topologyLabeler) getDomainLabels(domains topology.DomainMap, nodeMap nodeLabelMap) error {
+func (l *topologyLabeler) BuildNodeLabels(graph *topology.Graph) (NodeLabelMap, error) {
+	nodeMap := make(NodeLabelMap)
+
+	if graph == nil || (graph.Domains == nil && graph.Tiers == nil) {
+		return nodeMap, nil
+	}
+
+	if graph.Domains != nil {
+		if err := l.getDomainLabels(graph.Domains, nodeMap); err != nil {
+			return nil, err
+		}
+	}
+
+	if treeRoot := graph.Tiers; treeRoot != nil {
+		layers := []string{}
+		if len(treeRoot.ID) != 0 {
+			layers = append(layers, treeRoot.ID)
+		}
+		if err := l.getTierLabels(treeRoot, nodeMap, layers); err != nil {
+			return nil, err
+		}
+	}
+
+	return nodeMap, nil
+}
+
+func (l *topologyLabeler) getDomainLabels(domains topology.DomainMap, nodeMap NodeLabelMap) error {
 	for domainName, domain := range domains {
 		for nodeName := range domain {
 			labels, ok := nodeMap[nodeName]
@@ -101,16 +124,16 @@ func (l *topologyLabeler) getDomainLabels(domains topology.DomainMap, nodeMap no
 				labels = make(map[string]string)
 				nodeMap[nodeName] = labels
 			}
-			if val, ok := labels[labelAccelerator]; ok {
+			if val, ok := labels[topologyLabelKeys.Accelerator]; ok {
 				return fmt.Errorf("multiple accelerator labels %s, %s for node %s", val, domainName, nodeName)
 			}
-			labels[labelAccelerator] = l.checkLabel(domainName)
+			labels[topologyLabelKeys.Accelerator] = l.checkLabel(domainName)
 		}
 	}
 	return nil
 }
 
-func (l *topologyLabeler) getTierLabels(v *topology.Vertex, nodeMap nodeLabelMap, layers []string) error {
+func (l *topologyLabeler) getTierLabels(v *topology.Vertex, nodeMap NodeLabelMap, layers []string) error {
 	if len(v.Vertices) == 0 { // compute node
 		if len(layers) != 0 {
 			if v.ID != layers[0] {
@@ -121,6 +144,11 @@ func (l *topologyLabeler) getTierLabels(v *topology.Vertex, nodeMap nodeLabelMap
 			if !ok {
 				labels = make(map[string]string)
 				nodeMap[nodeName] = labels
+			}
+			switchNetworkHierarchy := [...]string{
+				topologyLabelKeys.Leaf,
+				topologyLabelKeys.Spine,
+				topologyLabelKeys.Core,
 			}
 			for i, sw := range layers[1:] {
 				if len(sw) == 0 {

--- a/pkg/engines/k8s/labeler_test.go
+++ b/pkg/engines/k8s/labeler_test.go
@@ -142,6 +142,10 @@ func TestApplyNodeLabelsWithBlock(t *testing.T) {
 
 func TestInitLabels(t *testing.T) {
 	InitLabels("a", "b", "c", "d")
-	require.Equal(t, []string{"b", "c", "d"}, switchNetworkHierarchy)
-	require.Equal(t, "a", labelAccelerator)
+	require.Equal(t, TopologyLabelKeys{
+		Accelerator: "a",
+		Leaf:        "b",
+		Spine:       "c",
+		Core:        "d",
+	}, CurrentTopologyLabelKeys())
 }

--- a/pkg/engines/nfd/engine.go
+++ b/pkg/engines/nfd/engine.go
@@ -1,17 +1,6 @@
 /*
- * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright 2026 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package nfd
@@ -139,6 +128,10 @@ func (eng *NfdEngine) GenerateOutput(ctx context.Context, graph *topology.Graph,
 	nodeFeatures, nodeFeatureGroups, err := buildNFDObjects(nodeLabels, gpuCliqueValues(nodes))
 	if err != nil {
 		return nil, httperr.NewError(http.StatusBadRequest, err.Error())
+	}
+	if eng.params.Cleanup && len(nodeFeatures) == 0 && len(nodeFeatureGroups) == 0 {
+		return nil, httperr.NewError(http.StatusBadGateway,
+			"generated no NFD topology objects; keeping the existing topology")
 	}
 
 	if err := eng.applyObjects(ctx, nodeFeatures, nodeFeatureGroups); err != nil {

--- a/pkg/engines/nfd/engine.go
+++ b/pkg/engines/nfd/engine.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -37,21 +38,22 @@ import (
 	"github.com/NVIDIA/topograph/pkg/topology"
 )
 
-const NAME = "nfd"
+const (
+	NAME            = "nfd"
+	envNFDNamespace = "NFD_NAMESPACE"
+)
 
 type NfdEngine struct {
 	client        kubernetes.Interface
 	dynamicClient dynamic.Interface
 	params        *Params
+	namespace     string
 	cachedNodes   *corev1.NodeList
 }
 
 type Params struct {
 	// NodeSelector (optional) specifies nodes participating in the topology.
 	NodeSelector map[string]string `mapstructure:"nodeSelector"`
-	// Namespace (optional) is used only for NFD installs with namespaced CRDs.
-	// NFD NodeFeature and NodeFeatureGroup are normally cluster-scoped.
-	Namespace string `mapstructure:"namespace"`
 	// Cleanup deletes stale Topograph-managed NFD objects. Defaults to true.
 	Cleanup bool `mapstructure:"cleanup"`
 
@@ -67,6 +69,11 @@ func Loader(_ context.Context, params engines.Config) (engines.Engine, *httperr.
 	p, err := getParameters(params)
 	if err != nil {
 		return nil, httperr.NewError(http.StatusBadRequest, err.Error())
+	}
+
+	namespace, err := getNFDNamespace()
+	if err != nil {
+		return nil, httperr.NewError(http.StatusBadGateway, err.Error())
 	}
 
 	config, err := rest.InClusterConfig()
@@ -88,6 +95,7 @@ func Loader(_ context.Context, params engines.Config) (engines.Engine, *httperr.
 		client:        client,
 		dynamicClient: dynamicClient,
 		params:        p,
+		namespace:     namespace,
 	}, nil
 }
 
@@ -97,7 +105,6 @@ func getParameters(params engines.Config) (*Params, error) {
 		return nil, err
 	}
 
-	p.Namespace = strings.TrimSpace(p.Namespace)
 	if len(p.NodeSelector) != 0 {
 		p.nodeListOpt = &metav1.ListOptions{
 			LabelSelector: labels.Set(p.NodeSelector).String(),
@@ -105,6 +112,13 @@ func getParameters(params engines.Config) (*Params, error) {
 	}
 
 	return p, nil
+}
+
+func getNFDNamespace() (string, error) {
+	if namespace := strings.TrimSpace(os.Getenv(envNFDNamespace)); namespace != "" {
+		return namespace, nil
+	}
+	return "", fmt.Errorf("%s environment variable is required", envNFDNamespace)
 }
 
 func (eng *NfdEngine) GenerateOutput(ctx context.Context, graph *topology.Graph, _ map[string]any) ([]byte, *httperr.Error) {

--- a/pkg/engines/nfd/engine.go
+++ b/pkg/engines/nfd/engine.go
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nfd
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/NVIDIA/topograph/internal/config"
+	"github.com/NVIDIA/topograph/internal/httperr"
+	internalk8s "github.com/NVIDIA/topograph/internal/k8s"
+	"github.com/NVIDIA/topograph/pkg/engines"
+	k8sengine "github.com/NVIDIA/topograph/pkg/engines/k8s"
+	"github.com/NVIDIA/topograph/pkg/topology"
+)
+
+const NAME = "nfd"
+
+type NfdEngine struct {
+	client        kubernetes.Interface
+	dynamicClient dynamic.Interface
+	params        *Params
+	cachedNodes   *corev1.NodeList
+}
+
+type Params struct {
+	// NodeSelector (optional) specifies nodes participating in the topology.
+	NodeSelector map[string]string `mapstructure:"nodeSelector"`
+	// Namespace (optional) is used only for NFD installs with namespaced CRDs.
+	// NFD NodeFeature and NodeFeatureGroup are normally cluster-scoped.
+	Namespace string `mapstructure:"namespace"`
+	// Cleanup deletes stale Topograph-managed NFD objects. Defaults to true.
+	Cleanup bool `mapstructure:"cleanup"`
+
+	// derived fields
+	nodeListOpt *metav1.ListOptions
+}
+
+func NamedLoader() (string, engines.Loader) {
+	return NAME, Loader
+}
+
+func Loader(_ context.Context, params engines.Config) (engines.Engine, *httperr.Error) {
+	p, err := getParameters(params)
+	if err != nil {
+		return nil, httperr.NewError(http.StatusBadRequest, err.Error())
+	}
+
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, httperr.NewError(http.StatusBadGateway, err.Error())
+	}
+
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, httperr.NewError(http.StatusBadGateway, err.Error())
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, httperr.NewError(http.StatusBadGateway, err.Error())
+	}
+
+	return &NfdEngine{
+		client:        client,
+		dynamicClient: dynamicClient,
+		params:        p,
+	}, nil
+}
+
+func getParameters(params engines.Config) (*Params, error) {
+	p := &Params{Cleanup: true}
+	if err := config.Decode(params, p); err != nil {
+		return nil, err
+	}
+
+	p.Namespace = strings.TrimSpace(p.Namespace)
+	if len(p.NodeSelector) != 0 {
+		p.nodeListOpt = &metav1.ListOptions{
+			LabelSelector: labels.Set(p.NodeSelector).String(),
+		}
+	}
+
+	return p, nil
+}
+
+func (eng *NfdEngine) GenerateOutput(ctx context.Context, graph *topology.Graph, _ map[string]any) ([]byte, *httperr.Error) {
+	nodes := eng.cachedNodes
+	if nodes == nil {
+		var err error
+		nodes, err = internalk8s.GetNodes(ctx, eng.client, eng.params.nodeListOpt)
+		if err != nil {
+			return nil, httperr.NewError(http.StatusBadGateway, err.Error())
+		}
+	}
+
+	nodeLabels, err := k8sengine.NewTopologyLabeler().BuildNodeLabels(graph)
+	if err != nil {
+		return nil, httperr.NewError(http.StatusBadGateway, err.Error())
+	}
+
+	nodeFeatures, nodeFeatureGroups, err := buildNFDObjects(nodeLabels, gpuCliqueValues(nodes))
+	if err != nil {
+		return nil, httperr.NewError(http.StatusBadRequest, err.Error())
+	}
+
+	if err := eng.applyObjects(ctx, nodeFeatures, nodeFeatureGroups); err != nil {
+		return nil, httperr.NewError(http.StatusBadGateway, err.Error())
+	}
+
+	if eng.params.Cleanup {
+		if err := eng.cleanupObjects(ctx, nodeFeatures, nodeFeatureGroups); err != nil {
+			return nil, httperr.NewError(http.StatusBadGateway, err.Error())
+		}
+	}
+
+	return fmt.Appendf(nil, "OK nodeFeatures=%d nodeFeatureGroups=%d\n", len(nodeFeatures), len(nodeFeatureGroups)), nil
+}
+
+func gpuCliqueValues(nodes *corev1.NodeList) map[string]string {
+	out := make(map[string]string)
+	if nodes == nil {
+		return out
+	}
+
+	for _, node := range nodes.Items {
+		if value := strings.TrimSpace(node.Labels[topology.KeyNvidiaGPUClique]); value != "" {
+			out[node.Name] = value
+		}
+	}
+
+	return out
+}

--- a/pkg/engines/nfd/engine_test.go
+++ b/pkg/engines/nfd/engine_test.go
@@ -18,6 +18,7 @@ package nfd
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -33,10 +34,64 @@ import (
 	"github.com/NVIDIA/topograph/pkg/topology"
 )
 
+const testNFDNamespace = "node-feature-discovery"
+
 func TestNamedLoader(t *testing.T) {
 	name, loader := NamedLoader()
 	require.Equal(t, NAME, name)
 	require.NotNil(t, loader)
+}
+
+func TestGetNFDNamespace(t *testing.T) {
+	testCases := []struct {
+		name                string
+		configuredNamespace string
+		expectedNamespace   string
+		expectError         bool
+	}{
+		{
+			name:        "rejects missing environment configuration",
+			expectError: true,
+		},
+		{
+			name:                "uses trimmed environment configuration",
+			configuredNamespace: "  deployed-nfd  ",
+			expectedNamespace:   "deployed-nfd",
+		},
+		{
+			name:                "rejects blank environment configuration",
+			configuredNamespace: "  ",
+			expectError:         true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(envNFDNamespace, tc.configuredNamespace)
+			namespace, err := getNFDNamespace()
+			if tc.expectError {
+				require.EqualError(t, err, "NFD_NAMESPACE environment variable is required")
+				require.Empty(t, namespace)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedNamespace, namespace)
+		})
+	}
+}
+
+func TestLoaderRequiresNFDNamespace(t *testing.T) {
+	t.Setenv(envNFDNamespace, "")
+	eng, httpErr := Loader(context.Background(), nil)
+	require.Nil(t, eng)
+	require.Equal(t, http.StatusBadGateway, httpErr.Code())
+	require.ErrorContains(t, httpErr, "NFD_NAMESPACE environment variable is required")
+}
+
+func TestGetParametersDefaults(t *testing.T) {
+	params, err := getParameters(nil)
+	require.NoError(t, err)
+	require.True(t, params.Cleanup)
 }
 
 func TestGenerateOutputCreatesNodeFeaturesAndGroups(t *testing.T) {
@@ -68,15 +123,17 @@ func TestGenerateOutputCreatesNodeFeaturesAndGroups(t *testing.T) {
 		client:        client,
 		dynamicClient: dynamicClient,
 		params:        &Params{Cleanup: true},
+		namespace:     testNFDNamespace,
 	}
 
 	out, httpErr := eng.GenerateOutput(context.Background(), testGraph(), nil)
 	require.Nil(t, httpErr)
 	require.Equal(t, "OK nodeFeatures=3 nodeFeatureGroups=6\n", string(out))
 
-	features, err := dynamicClient.Resource(nodeFeatureGVR).List(context.Background(), metav1.ListOptions{})
+	features, err := dynamicClient.Resource(nodeFeatureGVR).Namespace(testNFDNamespace).List(context.Background(), metav1.ListOptions{})
 	require.NoError(t, err)
 	require.Len(t, features.Items, 3)
+	require.Equal(t, testNFDNamespace, features.Items[0].GetNamespace())
 
 	nodeA := findNodeFeature(t, features.Items, "node-a")
 	require.Equal(t, map[string]string{nfdNodeName: "node-a"}, attributeElements(t, nodeA, nfdSystemName))
@@ -94,9 +151,10 @@ func TestGenerateOutputCreatesNodeFeaturesAndGroups(t *testing.T) {
 		topologyTypeSpine:       "spine-1",
 	}, attributeElements(t, nodeB, nfdFeatureSet))
 
-	groups, err := dynamicClient.Resource(nodeFeatureGroupGVR).List(context.Background(), metav1.ListOptions{})
+	groups, err := dynamicClient.Resource(nodeFeatureGroupGVR).Namespace(testNFDNamespace).List(context.Background(), metav1.ListOptions{})
 	require.NoError(t, err)
 	require.Len(t, groups.Items, 6)
+	require.Equal(t, testNFDNamespace, groups.Items[0].GetNamespace())
 
 	leafGroup := findGroup(t, groups.Items, topologyTypeLeaf, "leaf-1")
 	require.Equal(t, []interface{}{"leaf-1"}, groupRuleValues(t, leafGroup, topologyTypeLeaf))
@@ -117,6 +175,8 @@ func TestGenerateOutputCleansStaleObjects(t *testing.T) {
 	require.NoError(t, err)
 	staleGroup, err := makeNodeFeatureGroup(topologyTypeLeaf, "stale-leaf", k8sengine.DefaultLabelLeaf)
 	require.NoError(t, err)
+	staleFeature.SetNamespace(testNFDNamespace)
+	staleGroup.SetNamespace(testNFDNamespace)
 	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
 		runtime.NewScheme(),
 		map[schema.GroupVersionResource]string{
@@ -130,18 +190,53 @@ func TestGenerateOutputCleansStaleObjects(t *testing.T) {
 		client:        k8sfake.NewSimpleClientset(),
 		dynamicClient: dynamicClient,
 		params:        &Params{Cleanup: true},
+		namespace:     testNFDNamespace,
 	}
 
 	out, httpErr := eng.GenerateOutput(context.Background(), nil, nil)
 	require.Nil(t, httpErr)
 	require.Equal(t, "OK nodeFeatures=0 nodeFeatureGroups=0\n", string(out))
 
-	features, err := dynamicClient.Resource(nodeFeatureGVR).List(context.Background(), metav1.ListOptions{})
+	features, err := dynamicClient.Resource(nodeFeatureGVR).Namespace(testNFDNamespace).List(context.Background(), metav1.ListOptions{})
 	require.NoError(t, err)
 	require.Empty(t, features.Items)
-	groups, err := dynamicClient.Resource(nodeFeatureGroupGVR).List(context.Background(), metav1.ListOptions{})
+	groups, err := dynamicClient.Resource(nodeFeatureGroupGVR).Namespace(testNFDNamespace).List(context.Background(), metav1.ListOptions{})
 	require.NoError(t, err)
 	require.Empty(t, groups.Items)
+}
+
+func TestUpsertObjectRemovesStaleTopologyAttributes(t *testing.T) {
+	existing, err := makeNodeFeature("node-a", map[string]string{
+		topologyTypeLeaf: "leaf-1",
+		topologyTypeCore: "stale-core",
+	})
+	require.NoError(t, err)
+	existing.SetNamespace(testNFDNamespace)
+	existing.SetLabels(map[string]string{
+		labelManagedBy:       managedByTopograph,
+		"example.com/retain": "true",
+	})
+
+	dynamicClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), existing)
+	eng := &NfdEngine{
+		dynamicClient: dynamicClient,
+		params:        &Params{},
+		namespace:     testNFDNamespace,
+	}
+	desired, err := makeNodeFeature("node-a", map[string]string{
+		topologyTypeLeaf: "leaf-1",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, eng.upsertObject(context.Background(), nodeFeatureGVR, desired))
+
+	updated, err := dynamicClient.Resource(nodeFeatureGVR).Namespace(testNFDNamespace).
+		Get(context.Background(), existing.GetName(), metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{
+		topologyTypeLeaf: "leaf-1",
+	}, attributeElements(t, *updated, nfdFeatureSet))
+	require.Equal(t, "true", updated.GetLabels()["example.com/retain"])
 }
 
 func TestBuildNFDObjectsRejectsInvalidNFDNodeNameLabelValue(t *testing.T) {

--- a/pkg/engines/nfd/engine_test.go
+++ b/pkg/engines/nfd/engine_test.go
@@ -1,0 +1,254 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nfd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	k8sengine "github.com/NVIDIA/topograph/pkg/engines/k8s"
+	"github.com/NVIDIA/topograph/pkg/topology"
+)
+
+func TestNamedLoader(t *testing.T) {
+	name, loader := NamedLoader()
+	require.Equal(t, NAME, name)
+	require.NotNil(t, loader)
+}
+
+func TestGenerateOutputCreatesNodeFeaturesAndGroups(t *testing.T) {
+	k8sengine.InitLabels(
+		k8sengine.DefaultLabelAccelerator,
+		k8sengine.DefaultLabelLeaf,
+		k8sengine.DefaultLabelSpine,
+		k8sengine.DefaultLabelCore,
+	)
+
+	client := k8sfake.NewSimpleClientset(
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}},
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{
+			Name: "node-b",
+			Labels: map[string]string{
+				topology.KeyNvidiaGPUClique: "cluster.0",
+			},
+		}},
+		&corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-c"}},
+	)
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			nodeFeatureGVR:      "NodeFeatureList",
+			nodeFeatureGroupGVR: "NodeFeatureGroupList",
+		},
+	)
+	eng := &NfdEngine{
+		client:        client,
+		dynamicClient: dynamicClient,
+		params:        &Params{Cleanup: true},
+	}
+
+	out, httpErr := eng.GenerateOutput(context.Background(), testGraph(), nil)
+	require.Nil(t, httpErr)
+	require.Equal(t, "OK nodeFeatures=3 nodeFeatureGroups=6\n", string(out))
+
+	features, err := dynamicClient.Resource(nodeFeatureGVR).List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, features.Items, 3)
+
+	nodeA := findNodeFeature(t, features.Items, "node-a")
+	require.Equal(t, map[string]string{nfdNodeName: "node-a"}, attributeElements(t, nodeA, nfdSystemName))
+	require.Equal(t, map[string]string{
+		topologyTypeAccelerator: "nvl-a",
+		topologyTypeLeaf:        "leaf-1",
+		topologyTypeSpine:       "spine-1",
+	}, attributeElements(t, nodeA, nfdFeatureSet))
+
+	nodeB := findNodeFeature(t, features.Items, "node-b")
+	require.Equal(t, map[string]string{nfdNodeName: "node-b"}, attributeElements(t, nodeB, nfdSystemName))
+	require.Equal(t, map[string]string{
+		topologyTypeAccelerator: "cluster.0",
+		topologyTypeLeaf:        "leaf-1",
+		topologyTypeSpine:       "spine-1",
+	}, attributeElements(t, nodeB, nfdFeatureSet))
+
+	groups, err := dynamicClient.Resource(nodeFeatureGroupGVR).List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, groups.Items, 6)
+
+	leafGroup := findGroup(t, groups.Items, topologyTypeLeaf, "leaf-1")
+	require.Equal(t, []interface{}{"leaf-1"}, groupRuleValues(t, leafGroup, topologyTypeLeaf))
+	cliqueGroup := findGroup(t, groups.Items, topologyTypeAccelerator, "cluster.0")
+	require.Equal(t, topology.KeyNvidiaGPUClique, cliqueGroup.GetAnnotations()[annotationTopologyLabelKey])
+	require.Equal(t, []interface{}{"cluster.0"}, groupRuleValues(t, cliqueGroup, topologyTypeAccelerator))
+}
+
+func TestGenerateOutputCleansStaleObjects(t *testing.T) {
+	k8sengine.InitLabels(
+		k8sengine.DefaultLabelAccelerator,
+		k8sengine.DefaultLabelLeaf,
+		k8sengine.DefaultLabelSpine,
+		k8sengine.DefaultLabelCore,
+	)
+
+	staleFeature, err := makeNodeFeature("stale-node", map[string]string{topologyTypeLeaf: "stale-leaf"})
+	require.NoError(t, err)
+	staleGroup, err := makeNodeFeatureGroup(topologyTypeLeaf, "stale-leaf", k8sengine.DefaultLabelLeaf)
+	require.NoError(t, err)
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			nodeFeatureGVR:      "NodeFeatureList",
+			nodeFeatureGroupGVR: "NodeFeatureGroupList",
+		},
+		staleFeature,
+		staleGroup,
+	)
+	eng := &NfdEngine{
+		client:        k8sfake.NewSimpleClientset(),
+		dynamicClient: dynamicClient,
+		params:        &Params{Cleanup: true},
+	}
+
+	out, httpErr := eng.GenerateOutput(context.Background(), nil, nil)
+	require.Nil(t, httpErr)
+	require.Equal(t, "OK nodeFeatures=0 nodeFeatureGroups=0\n", string(out))
+
+	features, err := dynamicClient.Resource(nodeFeatureGVR).List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Empty(t, features.Items)
+	groups, err := dynamicClient.Resource(nodeFeatureGroupGVR).List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Empty(t, groups.Items)
+}
+
+func TestBuildNFDObjectsRejectsInvalidNFDNodeNameLabelValue(t *testing.T) {
+	k8sengine.InitLabels(
+		k8sengine.DefaultLabelAccelerator,
+		k8sengine.DefaultLabelLeaf,
+		k8sengine.DefaultLabelSpine,
+		k8sengine.DefaultLabelCore,
+	)
+
+	nodeLabels := k8sengine.NodeLabelMap{
+		"node-name-that-is-too-long-for-a-kubernetes-label-value-because-it-has-more-than-sixty-three-characters": {
+			k8sengine.DefaultLabelLeaf: "leaf-1",
+		},
+	}
+
+	_, _, err := buildNFDObjects(nodeLabels, nil)
+	require.ErrorContains(t, err, "cannot be used as")
+}
+
+func testGraph() *topology.Graph {
+	domains := topology.NewDomainMap()
+	domains.AddHost("nvl-a", "inst-a", "node-a")
+	domains.AddHost("nvl-a", "inst-b", "node-b")
+	domains.AddHost("nvl-b", "inst-c", "node-c")
+
+	leaf1 := &topology.Vertex{
+		ID: "leaf-1",
+		Vertices: map[string]*topology.Vertex{
+			"inst-a": {ID: "inst-a", Name: "node-a"},
+			"inst-b": {ID: "inst-b", Name: "node-b"},
+		},
+	}
+	leaf2 := &topology.Vertex{
+		ID: "leaf-2",
+		Vertices: map[string]*topology.Vertex{
+			"inst-c": {ID: "inst-c", Name: "node-c"},
+		},
+	}
+	spine := &topology.Vertex{
+		ID: "spine-1",
+		Vertices: map[string]*topology.Vertex{
+			"leaf-1": leaf1,
+			"leaf-2": leaf2,
+		},
+	}
+
+	return &topology.Graph{
+		Tiers: &topology.Vertex{
+			Vertices: map[string]*topology.Vertex{
+				"spine-1": spine,
+			},
+		},
+		Domains: domains,
+	}
+}
+
+func findNodeFeature(t *testing.T, items []unstructured.Unstructured, nodeName string) unstructured.Unstructured {
+	t.Helper()
+	for _, item := range items {
+		if item.GetAnnotations()[annotationNodeName] == nodeName {
+			return item
+		}
+	}
+	require.FailNowf(t, "missing NodeFeature", "node %q not found", nodeName)
+	return unstructured.Unstructured{}
+}
+
+func findGroup(t *testing.T, items []unstructured.Unstructured, kind, value string) unstructured.Unstructured {
+	t.Helper()
+	for _, item := range items {
+		annotations := item.GetAnnotations()
+		if item.GetLabels()[labelGroupType] == kind && annotations[annotationTopologyValue] == value {
+			return item
+		}
+	}
+	require.FailNowf(t, "missing NodeFeatureGroup", "kind %q value %q not found", kind, value)
+	return unstructured.Unstructured{}
+}
+
+func attributeElements(t *testing.T, item unstructured.Unstructured, feature string) map[string]string {
+	t.Helper()
+	elements, found, err := unstructured.NestedStringMap(item.Object, "spec", "features", "attributes", feature, "elements")
+	require.NoError(t, err)
+	require.True(t, found)
+	return elements
+}
+
+func groupRuleValues(t *testing.T, item unstructured.Unstructured, kind string) []interface{} {
+	t.Helper()
+	spec, ok := item.Object["spec"].(map[string]interface{})
+	require.True(t, ok)
+	rules, ok := spec["featureGroupRules"].([]interface{})
+	require.True(t, ok)
+	require.NotEmpty(t, rules)
+	rule, ok := rules[0].(map[string]interface{})
+	require.True(t, ok)
+	matchFeatures, ok := rule["matchFeatures"].([]interface{})
+	require.True(t, ok)
+	require.NotEmpty(t, matchFeatures)
+	matcher, ok := matchFeatures[0].(map[string]interface{})
+	require.True(t, ok)
+	matchExpressions, ok := matcher["matchExpressions"].(map[string]interface{})
+	require.True(t, ok)
+	expression, ok := matchExpressions[kind].(map[string]interface{})
+	require.True(t, ok)
+	values, ok := expression["value"].([]interface{})
+	require.True(t, ok)
+	return values
+}

--- a/pkg/engines/nfd/engine_test.go
+++ b/pkg/engines/nfd/engine_test.go
@@ -1,17 +1,6 @@
 /*
- * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright 2026 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package nfd
@@ -23,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -175,6 +165,68 @@ func TestGenerateOutputCleansStaleObjects(t *testing.T) {
 	require.NoError(t, err)
 	staleGroup, err := makeNodeFeatureGroup(topologyTypeLeaf, "stale-leaf", k8sengine.DefaultLabelLeaf)
 	require.NoError(t, err)
+	retainedFeature, err := makeNodeFeature("node-a", map[string]string{topologyTypeLeaf: "old-leaf"})
+	require.NoError(t, err)
+	retainedGroup, err := makeNodeFeatureGroup(topologyTypeLeaf, "leaf-1", k8sengine.DefaultLabelLeaf)
+	require.NoError(t, err)
+	staleFeature.SetNamespace(testNFDNamespace)
+	staleGroup.SetNamespace(testNFDNamespace)
+	retainedFeature.SetNamespace(testNFDNamespace)
+	retainedGroup.SetNamespace(testNFDNamespace)
+	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{
+			nodeFeatureGVR:      "NodeFeatureList",
+			nodeFeatureGroupGVR: "NodeFeatureGroupList",
+		},
+		staleFeature,
+		staleGroup,
+		retainedFeature,
+		retainedGroup,
+	)
+	eng := &NfdEngine{
+		client:        k8sfake.NewSimpleClientset(),
+		dynamicClient: dynamicClient,
+		params:        &Params{Cleanup: true},
+		namespace:     testNFDNamespace,
+	}
+
+	out, httpErr := eng.GenerateOutput(context.Background(), testGraph(), nil)
+	require.Nil(t, httpErr)
+	require.Equal(t, "OK nodeFeatures=3 nodeFeatureGroups=5\n", string(out))
+
+	features, err := dynamicClient.Resource(nodeFeatureGVR).Namespace(testNFDNamespace).List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, features.Items, 3)
+	groups, err := dynamicClient.Resource(nodeFeatureGroupGVR).Namespace(testNFDNamespace).List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, groups.Items, 5)
+
+	resource := dynamicClient.Resource(nodeFeatureGVR).Namespace(testNFDNamespace)
+	_, err = resource.Get(context.Background(), retainedFeature.GetName(), metav1.GetOptions{})
+	require.NoError(t, err)
+	_, err = resource.Get(context.Background(), staleFeature.GetName(), metav1.GetOptions{})
+	require.True(t, apierrors.IsNotFound(err))
+
+	resource = dynamicClient.Resource(nodeFeatureGroupGVR).Namespace(testNFDNamespace)
+	_, err = resource.Get(context.Background(), retainedGroup.GetName(), metav1.GetOptions{})
+	require.NoError(t, err)
+	_, err = resource.Get(context.Background(), staleGroup.GetName(), metav1.GetOptions{})
+	require.True(t, apierrors.IsNotFound(err))
+}
+
+func TestGenerateOutputRejectsEmptyDesiredStateWithCleanup(t *testing.T) {
+	k8sengine.InitLabels(
+		k8sengine.DefaultLabelAccelerator,
+		k8sengine.DefaultLabelLeaf,
+		k8sengine.DefaultLabelSpine,
+		k8sengine.DefaultLabelCore,
+	)
+
+	staleFeature, err := makeNodeFeature("stale-node", map[string]string{topologyTypeLeaf: "stale-leaf"})
+	require.NoError(t, err)
+	staleGroup, err := makeNodeFeatureGroup(topologyTypeLeaf, "stale-leaf", k8sengine.DefaultLabelLeaf)
+	require.NoError(t, err)
 	staleFeature.SetNamespace(testNFDNamespace)
 	staleGroup.SetNamespace(testNFDNamespace)
 	dynamicClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
@@ -194,15 +246,29 @@ func TestGenerateOutputCleansStaleObjects(t *testing.T) {
 	}
 
 	out, httpErr := eng.GenerateOutput(context.Background(), nil, nil)
-	require.Nil(t, httpErr)
-	require.Equal(t, "OK nodeFeatures=0 nodeFeatureGroups=0\n", string(out))
+	require.Nil(t, out)
+	require.Equal(t, http.StatusBadGateway, httpErr.Code())
+	require.ErrorContains(t, httpErr, "generated no NFD topology objects; keeping the existing topology")
 
 	features, err := dynamicClient.Resource(nodeFeatureGVR).Namespace(testNFDNamespace).List(context.Background(), metav1.ListOptions{})
 	require.NoError(t, err)
-	require.Empty(t, features.Items)
+	require.Len(t, features.Items, 1)
 	groups, err := dynamicClient.Resource(nodeFeatureGroupGVR).Namespace(testNFDNamespace).List(context.Background(), metav1.ListOptions{})
 	require.NoError(t, err)
-	require.Empty(t, groups.Items)
+	require.Len(t, groups.Items, 1)
+}
+
+func TestGenerateOutputAllowsEmptyDesiredStateWithoutCleanup(t *testing.T) {
+	eng := &NfdEngine{
+		client:        k8sfake.NewSimpleClientset(),
+		dynamicClient: dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()),
+		params:        &Params{Cleanup: false},
+		namespace:     testNFDNamespace,
+	}
+
+	out, httpErr := eng.GenerateOutput(context.Background(), nil, nil)
+	require.Nil(t, httpErr)
+	require.Equal(t, "OK nodeFeatures=0 nodeFeatureGroups=0\n", string(out))
 }
 
 func TestUpsertObjectRemovesStaleTopologyAttributes(t *testing.T) {

--- a/pkg/engines/nfd/kubernetes.go
+++ b/pkg/engines/nfd/kubernetes.go
@@ -1,17 +1,6 @@
 /*
- * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright 2026 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package nfd

--- a/pkg/engines/nfd/kubernetes.go
+++ b/pkg/engines/nfd/kubernetes.go
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nfd
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/NVIDIA/topograph/internal/httperr"
+	internalk8s "github.com/NVIDIA/topograph/internal/k8s"
+	"github.com/NVIDIA/topograph/pkg/topology"
+)
+
+func (eng *NfdEngine) GetComputeInstances(ctx context.Context, _ any) ([]topology.ComputeInstances, *httperr.Error) {
+	nodes, err := internalk8s.GetNodes(ctx, eng.client, eng.params.nodeListOpt)
+	if err != nil {
+		return nil, httperr.NewError(http.StatusBadGateway, err.Error())
+	}
+	eng.cachedNodes = nodes
+	return internalk8s.GetComputeInstances(nodes), nil
+}

--- a/pkg/engines/nfd/objects.go
+++ b/pkg/engines/nfd/objects.go
@@ -1,17 +1,6 @@
 /*
- * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright 2026 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 package nfd

--- a/pkg/engines/nfd/objects.go
+++ b/pkg/engines/nfd/objects.go
@@ -242,7 +242,7 @@ func makeNodeFeatureGroup(kind, value, labelKey string) (*unstructured.Unstructu
 }
 
 // toUnstructured converts a typed NFD API object for use with the dynamic client.
-func toUnstructured(obj interface{}) (*unstructured.Unstructured, error) {
+func toUnstructured(obj any) (*unstructured.Unstructured, error) {
 	object, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 	if err != nil {
 		return nil, fmt.Errorf("convert NFD object to unstructured: %w", err)
@@ -293,29 +293,46 @@ func (eng *NfdEngine) cleanupObjects(
 	return g.Wait()
 }
 
-// upsertObject patches an existing object or creates it when it does not exist.
+// upsertObject replaces the desired spec on an existing object or creates it
+// when it does not exist. Replacing spec ensures attributes omitted from the
+// latest topology are removed instead of surviving a JSON merge patch.
 func (eng *NfdEngine) upsertObject(ctx context.Context, gvr schema.GroupVersionResource, obj *unstructured.Unstructured) error {
+	obj = obj.DeepCopy()
+	obj.SetNamespace(eng.namespace)
 	resource := eng.resource(gvr)
-	data, err := json.Marshal(map[string]interface{}{
-		"metadata": map[string]interface{}{
-			"labels":      obj.GetLabels(),
-			"annotations": obj.GetAnnotations(),
-		},
-		"spec": obj.Object["spec"],
-	})
+	patch := []map[string]any{
+		{"op": "add", "path": "/spec", "value": obj.Object["spec"]},
+	}
+	for key, value := range obj.GetLabels() {
+		patch = append(patch, map[string]any{
+			"op": "add", "path": "/metadata/labels/" + jsonPointerToken(key), "value": value,
+		})
+	}
+	for key, value := range obj.GetAnnotations() {
+		patch = append(patch, map[string]any{
+			"op": "add", "path": "/metadata/annotations/" + jsonPointerToken(key), "value": value,
+		})
+	}
+
+	data, err := json.Marshal(patch)
 	if err != nil {
 		return err
 	}
 
-	_, err = resource.Patch(ctx, obj.GetName(), types.MergePatchType, data, metav1.PatchOptions{})
+	_, err = resource.Patch(ctx, obj.GetName(), types.JSONPatchType, data, metav1.PatchOptions{})
 	if apierrors.IsNotFound(err) {
 		_, err = resource.Create(ctx, obj.DeepCopy(), metav1.CreateOptions{})
 		if apierrors.IsAlreadyExists(err) {
-			_, err = resource.Patch(ctx, obj.GetName(), types.MergePatchType, data, metav1.PatchOptions{})
+			_, err = resource.Patch(ctx, obj.GetName(), types.JSONPatchType, data, metav1.PatchOptions{})
 		}
 	}
 
 	return err
+}
+
+// jsonPointerToken escapes a JSON object key for use as a JSON Patch path.
+func jsonPointerToken(value string) string {
+	return strings.NewReplacer("~", "~0", "/", "~1").Replace(value)
 }
 
 // cleanupResource deletes managed objects whose names are absent from desired.
@@ -349,13 +366,9 @@ func (eng *NfdEngine) cleanupResource(
 	return nil
 }
 
-// resource returns the dynamic resource client for the configured scope.
+// resource returns the dynamic resource client for the NFD namespace.
 func (eng *NfdEngine) resource(gvr schema.GroupVersionResource) dynamic.ResourceInterface {
-	resource := eng.dynamicClient.Resource(gvr)
-	if eng.params != nil && eng.params.Namespace != "" {
-		return resource.Namespace(eng.params.Namespace)
-	}
-	return resource
+	return eng.dynamicClient.Resource(gvr).Namespace(eng.namespace)
 }
 
 // objectNames returns the names of objects as a set.

--- a/pkg/engines/nfd/objects.go
+++ b/pkg/engines/nfd/objects.go
@@ -1,0 +1,430 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nfd
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"golang.org/x/sync/errgroup"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/client-go/dynamic"
+	nfdv1alpha1 "sigs.k8s.io/node-feature-discovery/api/nfd/v1alpha1"
+
+	k8sengine "github.com/NVIDIA/topograph/pkg/engines/k8s"
+	"github.com/NVIDIA/topograph/pkg/topology"
+)
+
+const (
+	nfdAPIGroup   = "nfd.k8s-sigs.io"
+	nfdAPIVersion = "v1alpha1"
+	nfdFeatureSet = "topograph.network"
+	nfdSystemName = "system.name"
+	nfdNodeName   = "nodename"
+
+	nfdNodeFeatureKind      = "NodeFeature"
+	nfdNodeFeatureGroupKind = "NodeFeatureGroup"
+	topologyTypeAccelerator = "accelerator"
+	topologyTypeLeaf        = "leaf"
+	topologyTypeSpine       = "spine"
+	topologyTypeCore        = "core"
+
+	labelNFDNodeName = "nfd.node.kubernetes.io/node-name"
+	labelManagedBy   = "app.kubernetes.io/managed-by"
+	labelEngine      = "topograph.nvidia.com/engine"
+	labelResource    = "topograph.nvidia.com/resource"
+	labelGroupType   = "topograph.nvidia.com/group-type"
+
+	managedByTopograph         = "topograph"
+	resourceNodeFeature        = "nodefeature"
+	resourceNodeFeatureGroup   = "nodefeaturegroup"
+	annotationNodeName         = "topograph.nvidia.com/node-name"
+	annotationTopologyLabelKey = "topograph.nvidia.com/label-key"
+	annotationTopologyValue    = "topograph.nvidia.com/label-value"
+)
+
+var (
+	nodeFeatureGVR = schema.GroupVersionResource{
+		Group:    nfdAPIGroup,
+		Version:  nfdAPIVersion,
+		Resource: "nodefeatures",
+	}
+	nodeFeatureGroupGVR = schema.GroupVersionResource{
+		Group:    nfdAPIGroup,
+		Version:  nfdAPIVersion,
+		Resource: "nodefeaturegroups",
+	}
+)
+
+// buildNFDObjects converts node topology labels into per-node features and
+// groups for each distinct topology value.
+func buildNFDObjects(nodeLabels k8sengine.NodeLabelMap, gpuCliqueValues map[string]string) ([]*unstructured.Unstructured, []*unstructured.Unstructured, error) {
+	keys := k8sengine.CurrentTopologyLabelKeys()
+	configuredLabels := [...]struct {
+		kind string
+		key  string
+	}{
+		{kind: topologyTypeAccelerator, key: keys.Accelerator},
+		{kind: topologyTypeLeaf, key: keys.Leaf},
+		{kind: topologyTypeSpine, key: keys.Spine},
+		{kind: topologyTypeCore, key: keys.Core},
+	}
+	groupValues := make(map[string]map[string]string)
+	nodeFeatures := make([]*unstructured.Unstructured, 0, len(nodeLabels))
+
+	for _, nodeName := range slices.Sorted(maps.Keys(nodeLabels)) {
+		if errs := validation.IsValidLabelValue(nodeName); len(errs) != 0 {
+			return nil, nil, fmt.Errorf("node name %q cannot be used as %q label value: %s",
+				nodeName, labelNFDNodeName, strings.Join(errs, "; "))
+		}
+
+		labels := nodeLabels[nodeName]
+		elements := make(map[string]string, len(configuredLabels))
+		for _, label := range configuredLabels {
+			labelKey := label.key
+			value := ""
+			if label.kind == topologyTypeAccelerator {
+				if gpuCliqueValue := gpuCliqueValues[nodeName]; gpuCliqueValue != "" {
+					labelKey = topology.KeyNvidiaGPUClique
+					value = gpuCliqueValue
+				}
+			}
+			if labelKey == "" {
+				continue
+			}
+			if value == "" {
+				value = strings.TrimSpace(labels[labelKey])
+			}
+			if value == "" {
+				continue
+			}
+
+			elements[label.kind] = value
+			if _, ok := groupValues[label.kind]; !ok {
+				groupValues[label.kind] = make(map[string]string)
+			}
+			groupValues[label.kind][value] = labelKey
+		}
+		if len(elements) == 0 {
+			continue
+		}
+
+		nodeFeature, err := makeNodeFeature(nodeName, elements)
+		if err != nil {
+			return nil, nil, err
+		}
+		nodeFeatures = append(nodeFeatures, nodeFeature)
+	}
+
+	nodeFeatureGroups := make([]*unstructured.Unstructured, 0)
+	for _, kind := range topologyTypeOrder {
+		valuesByLabelKey, ok := groupValues[kind]
+		if !ok {
+			continue
+		}
+		for _, value := range slices.Sorted(maps.Keys(valuesByLabelKey)) {
+			nodeFeatureGroup, err := makeNodeFeatureGroup(kind, value, valuesByLabelKey[value])
+			if err != nil {
+				return nil, nil, err
+			}
+			nodeFeatureGroups = append(nodeFeatureGroups, nodeFeatureGroup)
+		}
+	}
+
+	return nodeFeatures, nodeFeatureGroups, nil
+}
+
+// makeNodeFeature builds the NFD feature data published for one node.
+func makeNodeFeature(nodeName string, elements map[string]string) (*unstructured.Unstructured, error) {
+	obj := &nfdv1alpha1.NodeFeature{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: nfdAPIGroup + "/" + nfdAPIVersion,
+			Kind:       nfdNodeFeatureKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: stableObjectName("topograph-node", nodeName),
+			Labels: map[string]string{
+				labelNFDNodeName: nodeName,
+				labelManagedBy:   managedByTopograph,
+				labelEngine:      NAME,
+				labelResource:    resourceNodeFeature,
+			},
+			Annotations: map[string]string{
+				annotationNodeName: nodeName,
+			},
+		},
+		Spec: nfdv1alpha1.NodeFeatureSpec{
+			Features: nfdv1alpha1.Features{
+				Attributes: map[string]nfdv1alpha1.AttributeFeatureSet{
+					nfdSystemName: {
+						Elements: map[string]string{nfdNodeName: nodeName},
+					},
+					nfdFeatureSet: {
+						Elements: elements,
+					},
+				},
+			},
+		},
+	}
+
+	return toUnstructured(obj)
+}
+
+// makeNodeFeatureGroup builds an NFD group that matches one topology value.
+func makeNodeFeatureGroup(kind, value, labelKey string) (*unstructured.Unstructured, error) {
+	matchExpressions := nfdv1alpha1.MatchExpressionSet{
+		kind: {
+			Op:    nfdv1alpha1.MatchIn,
+			Value: nfdv1alpha1.MatchValue{value},
+		},
+	}
+	obj := &nfdv1alpha1.NodeFeatureGroup{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: nfdAPIGroup + "/" + nfdAPIVersion,
+			Kind:       nfdNodeFeatureGroupKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: stableObjectName("topograph-"+kind, value),
+			Labels: map[string]string{
+				labelManagedBy: managedByTopograph,
+				labelEngine:    NAME,
+				labelResource:  resourceNodeFeatureGroup,
+				labelGroupType: kind,
+			},
+			Annotations: map[string]string{
+				annotationTopologyLabelKey: labelKey,
+				annotationTopologyValue:    value,
+			},
+		},
+		Spec: nfdv1alpha1.NodeFeatureGroupSpec{
+			Rules: []nfdv1alpha1.GroupRule{
+				{
+					Name: fmt.Sprintf("%s equals %s", kind, value),
+					MatchFeatures: nfdv1alpha1.FeatureMatcher{
+						{
+							Feature:          nfdFeatureSet,
+							MatchExpressions: &matchExpressions,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return toUnstructured(obj)
+}
+
+// toUnstructured converts a typed NFD API object for use with the dynamic client.
+func toUnstructured(obj interface{}) (*unstructured.Unstructured, error) {
+	object, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, fmt.Errorf("convert NFD object to unstructured: %w", err)
+	}
+	return &unstructured.Unstructured{Object: object}, nil
+}
+
+// applyObjects creates or updates node features and feature groups concurrently.
+func (eng *NfdEngine) applyObjects(
+	ctx context.Context,
+	nodeFeatures []*unstructured.Unstructured,
+	nodeFeatureGroups []*unstructured.Unstructured,
+) error {
+	g, ctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		for _, obj := range nodeFeatures {
+			if err := eng.upsertObject(ctx, nodeFeatureGVR, obj); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	g.Go(func() error {
+		for _, obj := range nodeFeatureGroups {
+			if err := eng.upsertObject(ctx, nodeFeatureGroupGVR, obj); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	return g.Wait()
+}
+
+// cleanupObjects removes managed node features and feature groups that are no
+// longer part of the generated topology.
+func (eng *NfdEngine) cleanupObjects(
+	ctx context.Context,
+	nodeFeatures []*unstructured.Unstructured,
+	nodeFeatureGroups []*unstructured.Unstructured,
+) error {
+	g, ctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		return eng.cleanupResource(ctx, nodeFeatureGVR, resourceNodeFeature, objectNames(nodeFeatures))
+	})
+	g.Go(func() error {
+		return eng.cleanupResource(ctx, nodeFeatureGroupGVR, resourceNodeFeatureGroup, objectNames(nodeFeatureGroups))
+	})
+	return g.Wait()
+}
+
+// upsertObject patches an existing object or creates it when it does not exist.
+func (eng *NfdEngine) upsertObject(ctx context.Context, gvr schema.GroupVersionResource, obj *unstructured.Unstructured) error {
+	resource := eng.resource(gvr)
+	data, err := json.Marshal(map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"labels":      obj.GetLabels(),
+			"annotations": obj.GetAnnotations(),
+		},
+		"spec": obj.Object["spec"],
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = resource.Patch(ctx, obj.GetName(), types.MergePatchType, data, metav1.PatchOptions{})
+	if apierrors.IsNotFound(err) {
+		_, err = resource.Create(ctx, obj.DeepCopy(), metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(err) {
+			_, err = resource.Patch(ctx, obj.GetName(), types.MergePatchType, data, metav1.PatchOptions{})
+		}
+	}
+
+	return err
+}
+
+// cleanupResource deletes managed objects whose names are absent from desired.
+func (eng *NfdEngine) cleanupResource(
+	ctx context.Context,
+	gvr schema.GroupVersionResource,
+	resourceKind string,
+	desired map[string]struct{},
+) error {
+	selector := labels.Set{
+		labelManagedBy: managedByTopograph,
+		labelEngine:    NAME,
+		labelResource:  resourceKind,
+	}.String()
+	res := eng.resource(gvr)
+	list, err := res.List(ctx, metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return err
+	}
+
+	for i := range list.Items {
+		name := list.Items[i].GetName()
+		if _, ok := desired[name]; ok {
+			continue
+		}
+		if err := res.Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// resource returns the dynamic resource client for the configured scope.
+func (eng *NfdEngine) resource(gvr schema.GroupVersionResource) dynamic.ResourceInterface {
+	resource := eng.dynamicClient.Resource(gvr)
+	if eng.params != nil && eng.params.Namespace != "" {
+		return resource.Namespace(eng.params.Namespace)
+	}
+	return resource
+}
+
+// objectNames returns the names of objects as a set.
+func objectNames(objects []*unstructured.Unstructured) map[string]struct{} {
+	names := make(map[string]struct{}, len(objects))
+	for _, obj := range objects {
+		names[obj.GetName()] = struct{}{}
+	}
+	return names
+}
+
+var topologyTypeOrder = []string{
+	topologyTypeAccelerator,
+	topologyTypeLeaf,
+	topologyTypeSpine,
+	topologyTypeCore,
+}
+
+// stableObjectName produces a deterministic DNS label from a prefix and value.
+func stableObjectName(prefix, value string) string {
+	prefix = dnsLabelPart(prefix)
+	if prefix == "" {
+		prefix = "topograph"
+	}
+
+	hash := shortHash(value)
+	part := dnsLabelPart(value)
+	if part == "" {
+		part = "value"
+	}
+
+	maxPartLen := 63 - len(prefix) - len(hash) - 2
+	if maxPartLen < 1 {
+		maxPartLen = 1
+	}
+	if len(part) > maxPartLen {
+		part = strings.Trim(part[:maxPartLen], "-")
+		if part == "" {
+			part = "value"
+		}
+	}
+
+	return fmt.Sprintf("%s-%s-%s", prefix, part, hash)
+}
+
+// shortHash returns the first eight hexadecimal characters of a SHA-256 hash.
+func shortHash(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])[:8]
+}
+
+// dnsLabelPart normalizes a value into characters allowed in a DNS label.
+func dnsLabelPart(value string) string {
+	value = strings.ToLower(value)
+	var b strings.Builder
+	lastDash := false
+
+	for _, r := range value {
+		valid := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+		if valid {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+
+	return strings.Trim(b.String(), "-")
+}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -20,6 +20,7 @@ import (
 	"github.com/NVIDIA/topograph/pkg/engines"
 	"github.com/NVIDIA/topograph/pkg/engines/graph"
 	"github.com/NVIDIA/topograph/pkg/engines/k8s"
+	"github.com/NVIDIA/topograph/pkg/engines/nfd"
 	"github.com/NVIDIA/topograph/pkg/engines/slinky"
 	"github.com/NVIDIA/topograph/pkg/engines/slurm"
 	"github.com/NVIDIA/topograph/pkg/providers"
@@ -62,6 +63,7 @@ var Providers = providers.NewRegistry(
 
 var Engines = engines.NewRegistry(
 	k8s.NamedLoader,
+	nfd.NamedLoader,
 	graph.NamedLoader,
 	slurm.NamedLoader,
 	slinky.NamedLoader,


### PR DESCRIPTION
Add an NFD engine that translates the canonical topology graph into
NodeFeature and NodeFeatureGroup resources.

Publish accelerator, leaf, spine, and core topology attributes, including the
system node name required for NFD to populate group membership. Support node
selection, namespaced NFD installations, stale-resource cleanup, and existing
GPU clique labels.