### PR TITLE
fix(k8s): reconcile managed topology labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- The Kubernetes engine now reconciles its configured topology label keys, removing stale higher-tier labels when a node's network path becomes shallower while avoiding per-node GETs and unchanged-node Updates.
 - `kwok-nodes` now maps generated instance IDs back to model hostnames when naming Kubernetes nodes and writing the Topograph instance annotation.
 - The node-observer now discovers the optional node-data-broker through `NODE_DATA_BROKER_NAME` and `NODE_DATA_BROKER_NAMESPACE` and gates topology generation on the broker DaemonSet's desired and ready replica counts. Helm injects the variables only when `nodeDataBroker.enabled=true`, so disabling the broker cannot leave the observer waiting for nonexistent pods.
 - The node-observer reports an actionable error and defers topology generation when an enabled node-data-broker DaemonSet has zero desired replicas.

--- a/docs/engines/k8s.md
+++ b/docs/engines/k8s.md
@@ -5,7 +5,7 @@ Topograph is a tool designed to enhance scheduling decisions in Kubernetes clust
 ## Overview
 
 Topograph maps both the multi-tier network hierarchy and accelerated network domains (such as NVLink) using node labels.
-Most cloud providers expose three levels of network topology through their APIs. To provide a unified view, Topograph assigns four labels to each node:
+Most cloud providers expose three levels of network topology through their APIs. To provide a unified view, Topograph can assign four labels to each node:
 * `network.topology.nvidia.com/accelerator`: Identifies high-speed interconnect domains, such as NVLink. If the node already has `nvidia.com/gpu.clique`, Topograph leaves the accelerator label unset and uses the GPU Operator label as the accelerator-domain signal.
 * `network.topology.nvidia.com/leaf`: Indicates the switches directly connected to compute nodes.
 * `network.topology.nvidia.com/spine`: Represents the next tier of switches above the leaf level.
@@ -21,6 +21,14 @@ For example, if a node belongs to NVLink domain `nvl1` and connects to switch `s
   network.topology.nvidia.com/spine: s2
   network.topology.nvidia.com/core: s3
 ```
+
+### Managed label reconciliation
+
+Each time the Kubernetes engine generates output, it builds a complete label plan from the newly discovered graph and then lists the nodes selected by `engine.params.nodeSelector`. It compares the plan with that fresh Node List snapshot and updates only nodes whose managed labels changed. A normal run therefore performs one logical, paginated List and one Update per changed node; it does not GET every node. If an Update conflicts, only that node is fetched again and retried.
+
+For every node present in the graph's tree topology, the currently configured `leaf`, `spine`, and `core` keys are authoritative. When a discovered path becomes shallower, the engine removes obsolete higher-tier labels, such as a stale `core` label after a three-tier path becomes two-tier. Accelerator labels are reconciled only for nodes present in an accelerator domain. A node that is absent from the current graph is left unchanged because an empty or partial discovery result does not prove that the node permanently left the fabric.
+
+Only the exact keys in the current `topologyNodeLabels` configuration are managed. Other labels, annotations, and Node fields are preserved, and keys from an older Topograph configuration are not removed automatically.
 
 <p align="center"><img src="../assets/topograph-k8s.png" width="600" alt="Design" /></p>
 

--- a/docs/reference/node-labels.md
+++ b/docs/reference/node-labels.md
@@ -15,7 +15,14 @@ Labels are set by the [Kubernetes engine](../engines/k8s.md) (`engine: k8s`) and
 | `network.topology.nvidia.com/spine` | Tree (`topology/tree`) | Spine switch identifier — second-tier aggregation switch |
 | `network.topology.nvidia.com/core` | Tree (`topology/tree`) | Core switch identifier — third tier, present in large three-tier fabrics |
 
-Labels are **additive**: a node that belongs to both a block topology (NVLink domain) and a tree topology (switch fabric) normally carries both `accelerator` and `leaf`/`spine`/`core` simultaneously. The exception is nodes that already have `nvidia.com/gpu.clique`; for those, the k8s engine leaves the accelerator domain on `nvidia.com/gpu.clique` and only writes the switch-hierarchy labels.
+Block and tree labels are combined: a node that belongs to both a block topology (NVLink domain) and a tree topology (switch fabric) normally carries both `accelerator` and `leaf`/`spine`/`core` simultaneously. The exception is nodes that already have `nvidia.com/gpu.clique`; for those, the k8s engine leaves the accelerator domain on `nvidia.com/gpu.clique` and only writes the switch-hierarchy labels.
+
+On every generation, the Kubernetes engine reconciles only the exact label keys in the current `topologyNodeLabels` configuration:
+
+- A node present in the tree topology has its configured `leaf`, `spine`, and `core` keys reconciled. Labels for higher tiers that are no longer present in its path are removed.
+- A node present in an accelerator domain has only its configured `accelerator` key reconciled by that domain. Domain-only nodes retain existing tree labels, while tree-only nodes retain their accelerator label.
+- A Kubernetes node absent from both parts of the current graph is not modified. This protects labels when discovery returns an empty or partial topology.
+- Non-Topograph labels, annotations, and other Node fields are preserved. Topograph does not remove keys from an older configuration because the current process cannot safely establish ownership of them.
 
 Not all providers produce both topology types:
 

--- a/pkg/engines/k8s/engine.go
+++ b/pkg/engines/k8s/engine.go
@@ -35,7 +35,7 @@ const NAME = "k8s"
 
 type K8sEngine struct {
 	config *rest.Config
-	client *kubernetes.Clientset
+	client kubernetes.Interface
 	params *Params
 }
 
@@ -90,7 +90,7 @@ func getParameters(params engines.Config) (*Params, error) {
 }
 
 func (eng *K8sEngine) GenerateOutput(ctx context.Context, graph *topology.Graph, _ map[string]any) ([]byte, *httperr.Error) {
-	if err := NewTopologyLabeler().ApplyNodeLabels(ctx, graph, eng); err != nil {
+	if err := newTopologyLabeler().applyNodeLabels(ctx, graph, eng); err != nil {
 		return nil, httperr.NewError(http.StatusBadGateway, err.Error())
 	}
 

--- a/pkg/engines/k8s/kubernetes.go
+++ b/pkg/engines/k8s/kubernetes.go
@@ -18,12 +18,16 @@ package k8s
 
 import (
 	"context"
+	"fmt"
 	"maps"
 	"net/http"
+	"slices"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 
 	"github.com/NVIDIA/topograph/internal/httperr"
@@ -68,40 +72,151 @@ func getComputeInstances(nodes *corev1.NodeList) []topology.ComputeInstances {
 	return cis
 }
 
-func (eng *K8sEngine) AddNodeLabels(ctx context.Context, nodeName string, labels map[string]string) error {
-	klog.Infof("Applying labels on node %s : %v", nodeName, labels)
-	node, err := eng.client.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+func (eng *K8sEngine) reconcileNodeLabelPlans(ctx context.Context, plans nodeLabelPlans) error {
+	if len(plans) == 0 {
+		return nil
+	}
+
+	nodes, err := eng.listNodesForReconciliation(ctx)
 	if err != nil {
 		return err
 	}
 
-	MergeNodeLabels(node, labels)
+	for _, nodeName := range slices.Sorted(maps.Keys(plans)) {
+		node, ok := nodes[nodeName]
+		if !ok {
+			klog.Warningf("skipping topology labels for node %q because it was not returned by the Node List", nodeName)
+			continue
+		}
+		if err := eng.reconcileNodeLabels(ctx, node, plans[nodeName]); err != nil {
+			return fmt.Errorf("failed to reconcile topology labels on node %q: %w", nodeName, err)
+		}
+	}
 
-	_, err = eng.client.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
-
-	return err
+	return nil
 }
 
-func MergeNodeLabels(node *corev1.Node, labels map[string]string) {
-	if node.Labels == nil {
-		node.Labels = make(map[string]string)
+func (eng *K8sEngine) listNodesForReconciliation(ctx context.Context) (map[string]*corev1.Node, error) {
+	baseOptions := metav1.ListOptions{}
+	if eng.params != nil && eng.params.nodeListOpt != nil {
+		baseOptions = *eng.params.nodeListOpt.DeepCopy()
 	}
+	baseOptions.Continue = ""
 
-	labels = skipAcceleratorLabelWhenGPUCliqueExists(node, labels)
-	maps.Copy(node.Labels, labels)
+	nodes := make(map[string]*corev1.Node)
+	continueToken := ""
+	for {
+		options := baseOptions
+		options.Continue = continueToken
+		page, err := eng.client.CoreV1().Nodes().List(ctx, options)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list nodes for topology label reconciliation: %w", err)
+		}
+		for i := range page.Items {
+			node := page.Items[i].DeepCopy()
+			nodes[node.Name] = node
+		}
+
+		if page.Continue == "" {
+			return nodes, nil
+		}
+		if page.Continue == continueToken {
+			return nil, fmt.Errorf("node List returned repeated continue token %q", page.Continue)
+		}
+		continueToken = page.Continue
+	}
 }
 
-func skipAcceleratorLabelWhenGPUCliqueExists(node *corev1.Node, labels map[string]string) map[string]string {
-	if labelAccelerator == "" || strings.TrimSpace(node.Labels[topology.KeyNvidiaGPUClique]) == "" {
-		return labels
+func (eng *K8sEngine) reconcileNodeLabels(ctx context.Context, node *corev1.Node, plan *nodeLabelPlan) error {
+	updated, changed := nodeWithReconciledLabels(node, plan)
+	if !changed {
+		return nil
 	}
 
-	filtered := maps.Clone(labels)
-	delete(filtered, labelAccelerator)
+	klog.Infof("Reconciling managed topology labels on node %s", node.Name)
+	if _, err := eng.client.CoreV1().Nodes().Update(ctx, updated, metav1.UpdateOptions{}); err != nil {
+		if apierrors.IsNotFound(err) {
+			klog.Warningf("skipping topology labels for node %q because it was deleted after the Node List", node.Name)
+			return nil
+		}
+		if !apierrors.IsConflict(err) {
+			return err
+		}
 
-	if labelAccelerator != topology.KeyNvidiaGPUClique {
-		delete(node.Labels, labelAccelerator)
+		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			latest, getErr := eng.client.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
+			if getErr != nil {
+				if apierrors.IsNotFound(getErr) {
+					klog.Warningf("skipping topology labels for node %q because it was deleted during conflict retry", node.Name)
+					return nil
+				}
+				return getErr
+			}
+
+			updated, changed := nodeWithReconciledLabels(latest, plan)
+			if !changed {
+				return nil
+			}
+			_, updateErr := eng.client.CoreV1().Nodes().Update(ctx, updated, metav1.UpdateOptions{})
+			if apierrors.IsNotFound(updateErr) {
+				klog.Warningf("skipping topology labels for node %q because it was deleted during conflict retry", node.Name)
+				return nil
+			}
+			return updateErr
+		})
 	}
 
-	return filtered
+	return nil
+}
+
+func nodeWithReconciledLabels(node *corev1.Node, plan *nodeLabelPlan) (*corev1.Node, bool) {
+	effectivePlan := effectiveNodeLabelPlan(node, plan)
+	updated := node.DeepCopy()
+	changed := false
+
+	for _, key := range slices.Sorted(maps.Keys(effectivePlan.ManagedKeys)) {
+		desired, desiredExists := effectivePlan.Desired[key]
+		current, currentExists := node.Labels[key]
+		switch {
+		case desiredExists && (!currentExists || current != desired):
+			if updated.Labels == nil {
+				updated.Labels = make(map[string]string)
+			}
+			updated.Labels[key] = desired
+			changed = true
+		case !desiredExists && currentExists:
+			delete(updated.Labels, key)
+			changed = true
+		}
+	}
+
+	return updated, changed
+}
+
+func effectiveNodeLabelPlan(node *corev1.Node, plan *nodeLabelPlan) nodeLabelPlan {
+	effective := nodeLabelPlan{
+		Desired:        maps.Clone(plan.Desired),
+		ManagedKeys:    maps.Clone(plan.ManagedKeys),
+		acceleratorKey: plan.acceleratorKey,
+	}
+	if strings.TrimSpace(node.Labels[topology.KeyNvidiaGPUClique]) == "" {
+		return effective
+	}
+
+	// nvidia.com/gpu.clique belongs to GPU Operator. Protect an existing,
+	// non-empty value even when a custom tier key collides with it.
+	delete(effective.Desired, topology.KeyNvidiaGPUClique)
+	delete(effective.ManagedKeys, topology.KeyNvidiaGPUClique)
+
+	if plan.acceleratorKey == "" || plan.acceleratorKey == topology.KeyNvidiaGPUClique {
+		return effective
+	}
+	if _, managed := plan.ManagedKeys[plan.acceleratorKey]; !managed {
+		return effective
+	}
+
+	// A distinct Topograph accelerator key remains managed, but should be
+	// absent while GPU Operator provides the authoritative clique value.
+	delete(effective.Desired, plan.acceleratorKey)
+	return effective
 }

--- a/pkg/engines/k8s/kubernetes_test.go
+++ b/pkg/engines/k8s/kubernetes_test.go
@@ -1,18 +1,29 @@
 /*
- * Copyright 2025 NVIDIA CORPORATION
+ * Copyright 2025-2026 NVIDIA CORPORATION
  * SPDX-License-Identifier: Apache-2.0
  */
 
 package k8s
 
 import (
+	"context"
+	"errors"
+	"maps"
 	"testing"
 
-	"github.com/NVIDIA/topograph/pkg/topology"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/NVIDIA/topograph/pkg/topology"
 )
+
+var nodeGVR = corev1.SchemeGroupVersion.WithResource("nodes")
 
 func TestGetComputeInstances(t *testing.T) {
 	nodeErr1 := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "err1"}}
@@ -30,34 +41,22 @@ func TestGetComputeInstances(t *testing.T) {
 			name:  "Case 1: missing instance",
 			nodes: &corev1.NodeList{Items: []corev1.Node{node1, nodeErr1}},
 			cis: []topology.ComputeInstances{
-				{
-					Region:    "r1",
-					Instances: map[string]string{"i1": "node1"},
-				},
+				{Region: "r1", Instances: map[string]string{"i1": "node1"}},
 			},
 		},
 		{
 			name:  "Case 2: missing region",
 			nodes: &corev1.NodeList{Items: []corev1.Node{nodeErr2, node2}},
 			cis: []topology.ComputeInstances{
-				{
-					Region:    "r1",
-					Instances: map[string]string{"i2": "node2"},
-				},
+				{Region: "r1", Instances: map[string]string{"i2": "node2"}},
 			},
 		},
 		{
 			name:  "Case 3: valid input",
 			nodes: &corev1.NodeList{Items: []corev1.Node{node1, node2, node3}},
 			cis: []topology.ComputeInstances{
-				{
-					Region:    "r1",
-					Instances: map[string]string{"i1": "node1", "i2": "node2"},
-				},
-				{
-					Region:    "r2",
-					Instances: map[string]string{"i3": "node3"},
-				},
+				{Region: "r1", Instances: map[string]string{"i1": "node1", "i2": "node2"}},
+				{Region: "r2", Instances: map[string]string{"i3": "node3"}},
 			},
 		},
 	}
@@ -70,93 +69,719 @@ func TestGetComputeInstances(t *testing.T) {
 	}
 }
 
-func TestMergeNodeLabels(t *testing.T) {
-	InitLabels(DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
-
+func TestGenerateOutputReconcilesTierDepthChanges(t *testing.T) {
+	setTestLabels(t, DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
 	testCases := []struct {
-		name             string
-		acceleratorLabel string
-		node             *corev1.Node
-		in               map[string]string
-		out              map[string]string
+		name       string
+		initial    map[string]string
+		tiers      []string
+		wantLabels map[string]string
 	}{
 		{
-			name: "Case 1: no labels",
-			node: &corev1.Node{},
-			out:  map[string]string{},
-		},
-		{
-			name: "Case 2: copy",
-			node: &corev1.Node{},
-			in:   map[string]string{"a": "1", "b": "2"},
-			out:  map[string]string{"a": "1", "b": "2"},
-		},
-		{
-			name: "Case 3: merge",
-			node: &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels:      map[string]string{"a": "1", "b": "2", "c": "x"},
-					Annotations: map[string]string{"a": "1", "b": "2", "c": "x"},
-				},
+			name: "three tiers to two",
+			initial: map[string]string{
+				DefaultLabelLeaf: "old-leaf", DefaultLabelSpine: "old-spine", DefaultLabelCore: "old-core",
 			},
-			in:  map[string]string{"c": "3", "d": "4"},
-			out: map[string]string{"a": "1", "b": "2", "c": "3", "d": "4"},
-		},
-		{
-			name: "Case 4: skip accelerator when GPU clique exists",
-			node: &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						topology.KeyNvidiaGPUClique: "cluster-a.0",
-						DefaultLabelAccelerator:     "old-domain",
-						DefaultLabelLeaf:            "old-leaf",
-						"workload.example/label":    "keep",
-					},
-				},
-			},
-			in: map[string]string{
-				DefaultLabelAccelerator: "api-domain",
-				DefaultLabelLeaf:        "new-leaf",
-				DefaultLabelSpine:       "new-spine",
-			},
-			out: map[string]string{
-				topology.KeyNvidiaGPUClique: "cluster-a.0",
-				DefaultLabelLeaf:            "new-leaf",
-				DefaultLabelSpine:           "new-spine",
-				"workload.example/label":    "keep",
+			tiers: []string{"leaf-a", "spine-a"},
+			wantLabels: map[string]string{
+				DefaultLabelLeaf: "leaf-a", DefaultLabelSpine: "spine-a",
 			},
 		},
 		{
-			name:             "Case 5: do not overwrite GPU clique when it is the configured accelerator label",
-			acceleratorLabel: topology.KeyNvidiaGPUClique,
-			node: &corev1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						topology.KeyNvidiaGPUClique: "cluster-a.0",
-					},
-				},
+			name: "two tiers to one",
+			initial: map[string]string{
+				DefaultLabelLeaf: "old-leaf", DefaultLabelSpine: "old-spine", DefaultLabelCore: "stale-core",
 			},
-			in: map[string]string{
-				topology.KeyNvidiaGPUClique: "api-domain",
-				DefaultLabelLeaf:            "new-leaf",
-				DefaultLabelSpine:           "new-spine",
+			tiers: []string{"leaf-a"},
+			wantLabels: map[string]string{
+				DefaultLabelLeaf: "leaf-a",
 			},
-			out: map[string]string{
-				topology.KeyNvidiaGPUClique: "cluster-a.0",
-				DefaultLabelLeaf:            "new-leaf",
-				DefaultLabelSpine:           "new-spine",
+		},
+		{
+			name: "one tier to three",
+			initial: map[string]string{
+				DefaultLabelLeaf: "old-leaf",
+			},
+			tiers: []string{"leaf-a", "spine-a", "core-a"},
+			wantLabels: map[string]string{
+				DefaultLabelLeaf: "leaf-a", DefaultLabelSpine: "spine-a", DefaultLabelCore: "core-a",
 			},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.acceleratorLabel != "" {
-				InitLabels(tc.acceleratorLabel, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
-				defer InitLabels(DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
-			}
-			MergeNodeLabels(tc.node, tc.in)
-			require.Equal(t, tc.out, tc.node.Labels)
+			client := newFakeClient(testNode("node-a", tc.initial))
+			generateOutputSuccessfully(t, testEngine(client), graphWithTiers(map[string][]string{"node-a": tc.tiers}))
+
+			require.Equal(t, tc.wantLabels, trackedNode(t, client, "node-a").Labels)
+			assertNodeActionCounts(t, client, 1, 0, 1)
 		})
 	}
+}
+
+func TestGenerateOutputUpdatesChangedTierValues(t *testing.T) {
+	setTestLabels(t, DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+	client := newFakeClient(testNode("node-a", map[string]string{
+		DefaultLabelLeaf: "old-leaf", DefaultLabelSpine: "old-spine", DefaultLabelCore: "old-core",
+	}))
+
+	generateOutputSuccessfully(
+		t,
+		testEngine(client),
+		graphWithTiers(map[string][]string{"node-a": {"new-leaf", "new-spine", "new-core"}}),
+	)
+
+	require.Equal(t, map[string]string{
+		DefaultLabelLeaf: "new-leaf", DefaultLabelSpine: "new-spine", DefaultLabelCore: "new-core",
+	}, trackedNode(t, client, "node-a").Labels)
+	assertNodeActionCounts(t, client, 1, 0, 1)
+}
+
+func TestGenerateOutputNoOpUsesOnlyOneList(t *testing.T) {
+	setTestLabels(t, DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+	client := newFakeClient(testNode("node-a", map[string]string{
+		DefaultLabelLeaf: "leaf-a", DefaultLabelSpine: "spine-a", "workload.example/label": "keep",
+	}))
+
+	generateOutputSuccessfully(
+		t,
+		testEngine(client),
+		graphWithTiers(map[string][]string{"node-a": {"leaf-a", "spine-a"}}),
+	)
+
+	assertNodeActionCounts(t, client, 1, 0, 0)
+}
+
+func TestGenerateOutputOnlyUpdatesChangedNodes(t *testing.T) {
+	setTestLabels(t, DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+	client := newFakeClient(
+		testNode("node-a", map[string]string{DefaultLabelLeaf: "leaf-a"}),
+		testNode("node-b", map[string]string{DefaultLabelLeaf: "old-leaf"}),
+		testNode("node-c", map[string]string{DefaultLabelLeaf: "leaf-a"}),
+	)
+	graph := graphWithTiers(map[string][]string{
+		"node-a": {"leaf-a"},
+		"node-b": {"leaf-a"},
+		"node-c": {"leaf-a"},
+	})
+
+	generateOutputSuccessfully(t, testEngine(client), graph)
+
+	assertNodeActionCounts(t, client, 1, 0, 1)
+	require.Equal(t, []string{"node-b"}, updatedNodeNames(client))
+}
+
+func TestGenerateOutputPreservesUnmanagedNodeFields(t *testing.T) {
+	setTestLabels(t, DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+	node := testNode("node-a", map[string]string{
+		DefaultLabelLeaf: "old-leaf", "workload.example/label": "keep",
+	})
+	node.Annotations = map[string]string{"workload.example/annotation": "keep"}
+	node.Spec.Unschedulable = true
+	node.Status.Phase = corev1.NodeRunning
+	client := newFakeClient(node)
+
+	generateOutputSuccessfully(
+		t,
+		testEngine(client),
+		graphWithTiers(map[string][]string{"node-a": {"new-leaf"}}),
+	)
+
+	updated := trackedNode(t, client, "node-a")
+	require.Equal(t, "keep", updated.Labels["workload.example/label"])
+	require.Equal(t, node.Annotations, updated.Annotations)
+	require.Equal(t, node.Spec, updated.Spec)
+	require.Equal(t, node.Status, updated.Status)
+	assertNodeActionCounts(t, client, 1, 0, 1)
+}
+
+func TestGenerateOutputUsesCustomKeysWithoutCleaningPreviousConfiguration(t *testing.T) {
+	setTestLabels(t, "custom.example/accelerator", "custom.example/leaf", "custom.example/spine", "custom.example/core")
+	node := testNode("node-a", map[string]string{
+		"custom.example/leaf": "old-leaf",
+		DefaultLabelLeaf:      "previous-config-kept",
+	})
+	client := newFakeClient(node)
+	graph := graphWithTiers(map[string][]string{"node-a": {"new-leaf", "new-spine"}})
+	graph.Domains = domainsByNode(map[string]string{"node-a": "domain-a"})
+
+	generateOutputSuccessfully(t, testEngine(client), graph)
+
+	require.Equal(t, map[string]string{
+		"custom.example/accelerator": "domain-a",
+		"custom.example/leaf":        "new-leaf",
+		"custom.example/spine":       "new-spine",
+		DefaultLabelLeaf:             "previous-config-kept",
+	}, trackedNode(t, client, "node-a").Labels)
+	assertNodeActionCounts(t, client, 1, 0, 1)
+}
+
+func TestGenerateOutputRespectsPlanAuthority(t *testing.T) {
+	setTestLabels(t, DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+	testCases := []struct {
+		name       string
+		initial    map[string]string
+		graph      *topology.Graph
+		wantLabels map[string]string
+	}{
+		{
+			name: "domain only coordinates only accelerator",
+			initial: map[string]string{
+				DefaultLabelAccelerator: "old-domain", DefaultLabelLeaf: "old-leaf", DefaultLabelSpine: "old-spine", DefaultLabelCore: "old-core",
+			},
+			graph: &topology.Graph{Domains: domainsByNode(map[string]string{"node-a": "new-domain"})},
+			wantLabels: map[string]string{
+				DefaultLabelAccelerator: "new-domain", DefaultLabelLeaf: "old-leaf", DefaultLabelSpine: "old-spine", DefaultLabelCore: "old-core",
+			},
+		},
+		{
+			name: "tiers and domain merge all authority",
+			initial: map[string]string{
+				DefaultLabelAccelerator: "old-domain", DefaultLabelLeaf: "old-leaf", DefaultLabelSpine: "old-spine", DefaultLabelCore: "old-core",
+			},
+			graph: func() *topology.Graph {
+				graph := graphWithTiers(map[string][]string{"node-a": {"new-leaf", "new-spine"}})
+				graph.Domains = domainsByNode(map[string]string{"node-a": "new-domain"})
+				return graph
+			}(),
+			wantLabels: map[string]string{
+				DefaultLabelAccelerator: "new-domain", DefaultLabelLeaf: "new-leaf", DefaultLabelSpine: "new-spine",
+			},
+		},
+		{
+			name: "tiers only leave accelerator unchanged",
+			initial: map[string]string{
+				DefaultLabelAccelerator: "keep-domain", DefaultLabelLeaf: "old-leaf", DefaultLabelSpine: "old-spine", DefaultLabelCore: "old-core",
+				topology.KeyNvidiaGPUClique: "cluster-a.0",
+			},
+			graph: graphWithTiers(map[string][]string{"node-a": {"new-leaf"}}),
+			wantLabels: map[string]string{
+				DefaultLabelAccelerator: "keep-domain", DefaultLabelLeaf: "new-leaf", topology.KeyNvidiaGPUClique: "cluster-a.0",
+			},
+		},
+		{
+			name: "empty tiers and domains do not coordinate tier labels",
+			initial: map[string]string{
+				DefaultLabelAccelerator: "old-domain", DefaultLabelLeaf: "old-leaf", DefaultLabelSpine: "old-spine", DefaultLabelCore: "old-core",
+			},
+			graph: &topology.Graph{
+				Tiers:   &topology.Vertex{Vertices: map[string]*topology.Vertex{}},
+				Domains: domainsByNode(map[string]string{"node-a": "new-domain"}),
+			},
+			wantLabels: map[string]string{
+				DefaultLabelAccelerator: "new-domain", DefaultLabelLeaf: "old-leaf", DefaultLabelSpine: "old-spine", DefaultLabelCore: "old-core",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := newFakeClient(testNode("node-a", tc.initial))
+			generateOutputSuccessfully(t, testEngine(client), tc.graph)
+			require.Equal(t, tc.wantLabels, trackedNode(t, client, "node-a").Labels)
+			assertNodeActionCounts(t, client, 1, 0, 1)
+		})
+	}
+}
+
+func TestGenerateOutputDoesNotTouchNodesOutsideGraph(t *testing.T) {
+	setTestLabels(t, DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+	outside := testNode("node-outside", map[string]string{
+		DefaultLabelLeaf: "old-leaf", DefaultLabelSpine: "old-spine", DefaultLabelCore: "old-core",
+	})
+	client := newFakeClient(
+		testNode("node-in-graph", map[string]string{DefaultLabelLeaf: "leaf-a"}),
+		outside,
+	)
+
+	generateOutputSuccessfully(
+		t,
+		testEngine(client),
+		graphWithTiers(map[string][]string{"node-in-graph": {"leaf-a"}}),
+	)
+
+	require.Equal(t, outside.Labels, trackedNode(t, client, "node-outside").Labels)
+	assertNodeActionCounts(t, client, 1, 0, 0)
+}
+
+func TestGenerateOutputEmptyGraphDoesNotListOrWrite(t *testing.T) {
+	setTestLabels(t, DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+	client := newFakeClient(testNode("node-a", map[string]string{DefaultLabelCore: "keep"}))
+
+	generateOutputSuccessfully(t, testEngine(client), &topology.Graph{})
+
+	assertNodeActionCounts(t, client, 0, 0, 0)
+}
+
+func TestGenerateOutputSkipsGraphNodeMissingFromList(t *testing.T) {
+	setTestLabels(t, DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+	client := newFakeClient()
+
+	generateOutputSuccessfully(
+		t,
+		testEngine(client),
+		graphWithTiers(map[string][]string{"missing-node": {"leaf-a"}}),
+	)
+
+	assertNodeActionCounts(t, client, 1, 0, 0)
+}
+
+func TestGenerateOutputPreservesGPUClique(t *testing.T) {
+	testCases := []struct {
+		name             string
+		acceleratorKey   string
+		initial          map[string]string
+		wantLabels       map[string]string
+		wantAccelerator  bool
+		acceleratorValue string
+	}{
+		{
+			name:           "distinct accelerator key removes stale Topograph accelerator",
+			acceleratorKey: DefaultLabelAccelerator,
+			initial: map[string]string{
+				topology.KeyNvidiaGPUClique: "cluster-a.0", DefaultLabelAccelerator: "old-domain", DefaultLabelLeaf: "old-leaf",
+			},
+			wantLabels: map[string]string{
+				topology.KeyNvidiaGPUClique: "cluster-a.0", DefaultLabelLeaf: "new-leaf",
+			},
+		},
+		{
+			name:           "GPU clique key configured as accelerator remains protected",
+			acceleratorKey: topology.KeyNvidiaGPUClique,
+			initial: map[string]string{
+				topology.KeyNvidiaGPUClique: "cluster-a.0", DefaultLabelLeaf: "old-leaf",
+			},
+			wantLabels: map[string]string{
+				topology.KeyNvidiaGPUClique: "cluster-a.0", DefaultLabelLeaf: "new-leaf",
+			},
+		},
+		{
+			name:             "blank GPU clique does not suppress accelerator",
+			acceleratorKey:   DefaultLabelAccelerator,
+			initial:          map[string]string{topology.KeyNvidiaGPUClique: "  ", DefaultLabelLeaf: "new-leaf"},
+			wantLabels:       map[string]string{topology.KeyNvidiaGPUClique: "  ", DefaultLabelLeaf: "new-leaf", DefaultLabelAccelerator: "api-domain"},
+			wantAccelerator:  true,
+			acceleratorValue: "api-domain",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			setTestLabels(t, tc.acceleratorKey, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+			client := newFakeClient(testNode("node-a", tc.initial))
+			graph := graphWithTiers(map[string][]string{"node-a": {"new-leaf"}})
+			graph.Domains = domainsByNode(map[string]string{"node-a": "api-domain"})
+
+			generateOutputSuccessfully(t, testEngine(client), graph)
+
+			updated := trackedNode(t, client, "node-a")
+			require.Equal(t, tc.wantLabels, updated.Labels)
+			value, found := updated.Labels[tc.acceleratorKey]
+			if tc.wantAccelerator {
+				require.True(t, found)
+				require.Equal(t, tc.acceleratorValue, value)
+			}
+			assertNodeActionCounts(t, client, 1, 0, 1)
+		})
+	}
+}
+
+func TestGenerateOutputGPUCliqueSuppressesRedundantAcceleratorUpdate(t *testing.T) {
+	setTestLabels(t, DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+	client := newFakeClient(testNode("node-a", map[string]string{
+		topology.KeyNvidiaGPUClique: "cluster-a.0",
+	}))
+
+	generateOutputSuccessfully(
+		t,
+		testEngine(client),
+		&topology.Graph{Domains: domainsByNode(map[string]string{"node-a": "api-domain"})},
+	)
+
+	require.Equal(t, map[string]string{
+		topology.KeyNvidiaGPUClique: "cluster-a.0",
+	}, trackedNode(t, client, "node-a").Labels)
+	assertNodeActionCounts(t, client, 1, 0, 0)
+}
+
+func TestGenerateOutputProtectsGPUCliqueFromCustomTierKeys(t *testing.T) {
+	testCases := []struct {
+		name       string
+		leafKey    string
+		coreKey    string
+		initial    map[string]string
+		tierValues []string
+	}{
+		{
+			name:       "does not overwrite clique through leaf key",
+			leafKey:    topology.KeyNvidiaGPUClique,
+			coreKey:    DefaultLabelCore,
+			initial:    map[string]string{topology.KeyNvidiaGPUClique: "cluster-a.0"},
+			tierValues: []string{"new-leaf"},
+		},
+		{
+			name:    "does not delete clique through absent core tier",
+			leafKey: DefaultLabelLeaf,
+			coreKey: topology.KeyNvidiaGPUClique,
+			initial: map[string]string{
+				topology.KeyNvidiaGPUClique: "cluster-a.0",
+				DefaultLabelLeaf:            "leaf-a",
+			},
+			tierValues: []string{"leaf-a"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			setTestLabels(t, DefaultLabelAccelerator, tc.leafKey, DefaultLabelSpine, tc.coreKey)
+			client := newFakeClient(testNode("node-a", tc.initial))
+
+			generateOutputSuccessfully(
+				t,
+				testEngine(client),
+				graphWithTiers(map[string][]string{"node-a": tc.tierValues}),
+			)
+
+			require.Equal(t, tc.initial, trackedNode(t, client, "node-a").Labels)
+			assertNodeActionCounts(t, client, 1, 0, 0)
+		})
+	}
+}
+
+func TestGenerateOutputIgnoresAllEmptyManagedKeys(t *testing.T) {
+	setTestLabels(t, "", " ", "", "\t")
+	client := newFakeClient(testNode("node-a", map[string]string{DefaultLabelLeaf: "keep"}))
+	graph := graphWithTiers(map[string][]string{"node-a": {"leaf-a", "spine-a", "core-a"}})
+	graph.Domains = domainsByNode(map[string]string{"node-a": "domain-a"})
+
+	generateOutputSuccessfully(t, testEngine(client), graph)
+
+	require.Equal(t, map[string]string{DefaultLabelLeaf: "keep"}, trackedNode(t, client, "node-a").Labels)
+	assertNodeActionCounts(t, client, 0, 0, 0)
+}
+
+func TestGenerateOutputRetriesOnlyConflictingNode(t *testing.T) {
+	setTestLabels(t, DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+	client := newFakeClient(
+		testNode("node-a", map[string]string{DefaultLabelLeaf: "old-leaf-a"}),
+		testNode("node-b", map[string]string{DefaultLabelLeaf: "old-leaf-b"}),
+	)
+	updateCalls := 0
+	client.PrependReactor("update", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		updateCalls++
+		if updateCalls != 1 {
+			return false, nil, nil
+		}
+		require.Equal(t, "node-a", action.(k8stesting.UpdateAction).GetObject().(*corev1.Node).Name)
+		concurrent := trackedNode(t, client, "node-a").DeepCopy()
+		concurrent.ResourceVersion = "2"
+		concurrent.Labels["concurrent.example/label"] = "keep"
+		require.NoError(t, client.Tracker().Update(nodeGVR, concurrent, ""))
+		return true, nil, apierrors.NewConflict(schema.GroupResource{Resource: "nodes"}, "node-a", errors.New("conflict"))
+	})
+
+	generateOutputSuccessfully(
+		t,
+		testEngine(client),
+		graphWithTiers(map[string][]string{
+			"node-a": {"new-leaf-a"},
+			"node-b": {"new-leaf-b"},
+		}),
+	)
+
+	updated := trackedNode(t, client, "node-a")
+	require.Equal(t, "new-leaf-a", updated.Labels[DefaultLabelLeaf])
+	require.Equal(t, "keep", updated.Labels["concurrent.example/label"])
+	require.Equal(t, "new-leaf-b", trackedNode(t, client, "node-b").Labels[DefaultLabelLeaf])
+	assertNodeActionCounts(t, client, 1, 1, 3)
+	require.Equal(t, []string{"node-a"}, nodeGetNames(client))
+	updates := nodeUpdateActions(client)
+	require.Equal(t, "1", updates[0].GetObject().(*corev1.Node).ResourceVersion)
+	require.Equal(t, "2", updates[1].GetObject().(*corev1.Node).ResourceVersion)
+}
+
+func TestGenerateOutputStopsRetryWhenConcurrentWriterAlreadyConverged(t *testing.T) {
+	setTestLabels(t, DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+	client := newFakeClient(testNode("node-a", map[string]string{DefaultLabelLeaf: "old-leaf"}))
+	client.PrependReactor("update", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		concurrent := trackedNode(t, client, "node-a").DeepCopy()
+		concurrent.ResourceVersion = "2"
+		concurrent.Labels[DefaultLabelLeaf] = "new-leaf"
+		concurrent.Labels["concurrent.example/label"] = "keep"
+		require.NoError(t, client.Tracker().Update(nodeGVR, concurrent, ""))
+		return true, nil, apierrors.NewConflict(schema.GroupResource{Resource: "nodes"}, "node-a", errors.New("conflict"))
+	})
+
+	generateOutputSuccessfully(
+		t,
+		testEngine(client),
+		graphWithTiers(map[string][]string{"node-a": {"new-leaf"}}),
+	)
+
+	updated := trackedNode(t, client, "node-a")
+	require.Equal(t, "new-leaf", updated.Labels[DefaultLabelLeaf])
+	require.Equal(t, "keep", updated.Labels["concurrent.example/label"])
+	assertNodeActionCounts(t, client, 1, 1, 1)
+}
+
+func TestGenerateOutputRecomputesGPUCliqueAfterConflict(t *testing.T) {
+	setTestLabels(t, DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+	client := newFakeClient(testNode("node-a", map[string]string{DefaultLabelAccelerator: "old-domain"}))
+	updateCalls := 0
+	client.PrependReactor("update", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		updateCalls++
+		if updateCalls != 1 {
+			return false, nil, nil
+		}
+		concurrent := trackedNode(t, client, "node-a").DeepCopy()
+		concurrent.ResourceVersion = "2"
+		concurrent.Labels[topology.KeyNvidiaGPUClique] = "cluster-a.0"
+		require.NoError(t, client.Tracker().Update(nodeGVR, concurrent, ""))
+		return true, nil, apierrors.NewConflict(schema.GroupResource{Resource: "nodes"}, "node-a", errors.New("conflict"))
+	})
+
+	generateOutputSuccessfully(
+		t,
+		testEngine(client),
+		&topology.Graph{Domains: domainsByNode(map[string]string{"node-a": "api-domain"})},
+	)
+
+	updated := trackedNode(t, client, "node-a")
+	require.Equal(t, "cluster-a.0", updated.Labels[topology.KeyNvidiaGPUClique])
+	require.NotContains(t, updated.Labels, DefaultLabelAccelerator)
+	assertNodeActionCounts(t, client, 1, 1, 2)
+}
+
+func TestGenerateOutputReturnsNonConflictUpdateError(t *testing.T) {
+	setTestLabels(t, DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+	client := newFakeClient(testNode("node-a", map[string]string{DefaultLabelLeaf: "old-leaf"}))
+	client.PrependReactor("update", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("write failed")
+	})
+
+	_, err := testEngine(client).GenerateOutput(
+		context.Background(),
+		graphWithTiers(map[string][]string{"node-a": {"new-leaf"}}),
+		nil,
+	)
+	require.NotNil(t, err)
+	require.ErrorContains(t, err, "write failed")
+	assertNodeActionCounts(t, client, 1, 0, 1)
+}
+
+func TestGenerateOutputListFailurePerformsNoUpdates(t *testing.T) {
+	setTestLabels(t, DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+	client := newFakeClient(testNode("node-a", map[string]string{DefaultLabelLeaf: "old-leaf"}))
+	client.PrependReactor("list", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("list failed")
+	})
+
+	_, err := testEngine(client).GenerateOutput(
+		context.Background(),
+		graphWithTiers(map[string][]string{"node-a": {"new-leaf"}}),
+		nil,
+	)
+	require.NotNil(t, err)
+	require.ErrorContains(t, err, "list failed")
+	assertNodeActionCounts(t, client, 1, 0, 0)
+}
+
+func TestGenerateOutputLaterListPageFailurePerformsNoUpdates(t *testing.T) {
+	setTestLabels(t, DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+	client := newFakeClient(testNode("node-a", map[string]string{DefaultLabelLeaf: "old-leaf"}))
+	client.PrependReactor("list", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		options := action.(interface{ GetListOptions() metav1.ListOptions }).GetListOptions()
+		if options.Continue == "" {
+			return true, &corev1.NodeList{
+				ListMeta: metav1.ListMeta{Continue: "next-page"},
+				Items:    []corev1.Node{*testNode("node-a", map[string]string{DefaultLabelLeaf: "old-leaf"})},
+			}, nil
+		}
+		return true, nil, errors.New("second page failed")
+	})
+
+	_, err := testEngine(client).GenerateOutput(
+		context.Background(),
+		graphWithTiers(map[string][]string{"node-a": {"new-leaf"}}),
+		nil,
+	)
+	require.NotNil(t, err)
+	require.ErrorContains(t, err, "second page failed")
+	assertNodeActionCounts(t, client, 2, 0, 0)
+}
+
+func TestGenerateOutputPlanFailurePerformsNoAPIAction(t *testing.T) {
+	setTestLabels(t, DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+	client := newFakeClient(testNode("node-a", nil))
+	graph := &topology.Graph{Domains: topology.DomainMap{
+		"domain-a": {"node-a": &topology.HostInfo{HostName: "node-a"}},
+		"domain-b": {"node-a": &topology.HostInfo{HostName: "node-a"}},
+	}}
+
+	_, err := testEngine(client).GenerateOutput(context.Background(), graph, nil)
+	require.NotNil(t, err)
+	require.ErrorContains(t, err, "multiple accelerator labels")
+	assertNodeActionCounts(t, client, 0, 0, 0)
+}
+
+func TestGenerateOutputSkipsNodeDeletedAfterList(t *testing.T) {
+	setTestLabels(t, DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+	client := newFakeClient(testNode("node-a", map[string]string{DefaultLabelLeaf: "old-leaf"}))
+	client.PrependReactor("update", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewNotFound(schema.GroupResource{Resource: "nodes"}, "node-a")
+	})
+
+	generateOutputSuccessfully(
+		t,
+		testEngine(client),
+		graphWithTiers(map[string][]string{"node-a": {"new-leaf"}}),
+	)
+	assertNodeActionCounts(t, client, 1, 0, 1)
+}
+
+func TestGenerateOutputSkipsNodeDeletedDuringConflictRetry(t *testing.T) {
+	setTestLabels(t, DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+	client := newFakeClient(testNode("node-a", map[string]string{DefaultLabelLeaf: "old-leaf"}))
+	client.PrependReactor("update", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		require.NoError(t, client.Tracker().Delete(nodeGVR, "", "node-a"))
+		return true, nil, apierrors.NewConflict(schema.GroupResource{Resource: "nodes"}, "node-a", errors.New("conflict"))
+	})
+
+	generateOutputSuccessfully(
+		t,
+		testEngine(client),
+		graphWithTiers(map[string][]string{"node-a": {"new-leaf"}}),
+	)
+	assertNodeActionCounts(t, client, 1, 1, 1)
+}
+
+func TestGenerateOutputCompletesPaginatedListBeforeUpdates(t *testing.T) {
+	setTestLabels(t, DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+	alpha := testNode("alpha", map[string]string{"pool": "selected", DefaultLabelLeaf: "old-alpha"})
+	beta := testNode("beta", map[string]string{"pool": "selected", DefaultLabelLeaf: "old-beta"})
+	client := newFakeClient(alpha, beta)
+	sharedOptions := &metav1.ListOptions{LabelSelector: "pool=selected", Continue: "do-not-mutate"}
+	eng := &K8sEngine{client: client, params: &Params{nodeListOpt: sharedOptions}}
+	var listOptions []metav1.ListOptions
+	client.PrependReactor("list", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		options := action.(interface{ GetListOptions() metav1.ListOptions }).GetListOptions()
+		listOptions = append(listOptions, options)
+		switch options.Continue {
+		case "":
+			return true, &corev1.NodeList{
+				ListMeta: metav1.ListMeta{Continue: "next-page"},
+				Items:    []corev1.Node{*beta.DeepCopy()},
+			}, nil
+		case "next-page":
+			return true, &corev1.NodeList{Items: []corev1.Node{*alpha.DeepCopy()}}, nil
+		default:
+			return true, nil, errors.New("unexpected continue token")
+		}
+	})
+	graph := graphWithTiers(map[string][]string{
+		"beta":  {"new-beta"},
+		"alpha": {"new-alpha"},
+	})
+
+	generateOutputSuccessfully(t, eng, graph)
+
+	require.Equal(t, []metav1.ListOptions{
+		{LabelSelector: "pool=selected"},
+		{LabelSelector: "pool=selected", Continue: "next-page"},
+	}, listOptions)
+	require.Equal(t, "do-not-mutate", sharedOptions.Continue)
+	require.Equal(t, []string{"alpha", "beta"}, updatedNodeNames(client))
+	assertNodeActionCounts(t, client, 2, 0, 2)
+	require.Equal(t, []string{"list", "list", "update", "update"}, nodeActionVerbs(client))
+}
+
+func generateOutputSuccessfully(t *testing.T, eng *K8sEngine, graph *topology.Graph) {
+	t.Helper()
+	output, err := eng.GenerateOutput(context.Background(), graph, nil)
+	require.Nil(t, err)
+	require.Equal(t, []byte("OK\n"), output)
+}
+
+func testEngine(client *k8sfake.Clientset) *K8sEngine {
+	return &K8sEngine{client: client, params: &Params{}}
+}
+
+func testNode(name string, labels map[string]string) *corev1.Node {
+	return &corev1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name:            name,
+		ResourceVersion: "1",
+		Labels:          maps.Clone(labels),
+	}}
+}
+
+func newFakeClient(nodes ...*corev1.Node) *k8sfake.Clientset {
+	objects := make([]runtime.Object, 0, len(nodes))
+	for _, node := range nodes {
+		objects = append(objects, node)
+	}
+	return k8sfake.NewSimpleClientset(objects...)
+}
+
+func trackedNode(t *testing.T, client *k8sfake.Clientset, name string) *corev1.Node {
+	t.Helper()
+	object, err := client.Tracker().Get(nodeGVR, "", name)
+	require.NoError(t, err)
+	return object.(*corev1.Node).DeepCopy()
+}
+
+func nodeActionCount(client *k8sfake.Clientset, verb string) int {
+	count := 0
+	for _, action := range client.Actions() {
+		if action.GetResource().Resource == "nodes" && action.GetVerb() == verb {
+			count++
+		}
+	}
+	return count
+}
+
+func assertNodeActionCounts(t *testing.T, client *k8sfake.Clientset, lists, gets, updates int) {
+	t.Helper()
+	require.Equal(t, lists, nodeActionCount(client, "list"), "unexpected Node List action count")
+	require.Equal(t, gets, nodeActionCount(client, "get"), "unexpected Node GET action count")
+	require.Equal(t, updates, nodeActionCount(client, "update"), "unexpected Node Update action count")
+	require.Zero(t, nodeActionCount(client, "patch"), "unexpected Node Patch action count")
+}
+
+func nodeUpdateActions(client *k8sfake.Clientset) []k8stesting.UpdateAction {
+	updates := []k8stesting.UpdateAction{}
+	for _, action := range client.Actions() {
+		if action.GetResource().Resource == "nodes" && action.GetVerb() == "update" {
+			updates = append(updates, action.(k8stesting.UpdateAction))
+		}
+	}
+	return updates
+}
+
+func updatedNodeNames(client *k8sfake.Clientset) []string {
+	names := []string{}
+	for _, action := range nodeUpdateActions(client) {
+		names = append(names, action.GetObject().(*corev1.Node).Name)
+	}
+	return names
+}
+
+func nodeActionVerbs(client *k8sfake.Clientset) []string {
+	verbs := []string{}
+	for _, action := range client.Actions() {
+		if action.GetResource().Resource == "nodes" {
+			verbs = append(verbs, action.GetVerb())
+		}
+	}
+	return verbs
+}
+
+func nodeGetNames(client *k8sfake.Clientset) []string {
+	names := []string{}
+	for _, action := range client.Actions() {
+		if action.GetResource().Resource == "nodes" && action.GetVerb() == "get" {
+			names = append(names, action.(k8stesting.GetAction).GetName())
+		}
+	}
+	return names
 }

--- a/pkg/engines/k8s/labeler.go
+++ b/pkg/engines/k8s/labeler.go
@@ -20,6 +20,9 @@ import (
 	"context"
 	"fmt"
 	"hash/fnv"
+	"maps"
+	"slices"
+	"strings"
 
 	"github.com/NVIDIA/topograph/pkg/topology"
 )
@@ -33,8 +36,6 @@ const (
 
 var (
 	labelAccelerator, labelLeaf, labelSpine, labelCore string
-
-	switchNetworkHierarchy []string
 )
 
 func InitLabels(accelerator, leaf, spine, core string) {
@@ -42,104 +43,181 @@ func InitLabels(accelerator, leaf, spine, core string) {
 	labelLeaf = leaf
 	labelSpine = spine
 	labelCore = core
-	switchNetworkHierarchy = []string{labelLeaf, labelSpine, labelCore}
 }
 
-// map nodename:[label name: label value]
-type nodeLabelMap map[string]map[string]string
+type labelKeySet map[string]struct{}
 
-type Labeler interface {
-	AddNodeLabels(context.Context, string, map[string]string) error
+type nodeLabelPlan struct {
+	Desired        map[string]string
+	ManagedKeys    labelKeySet
+	acceleratorKey string
+}
+
+type nodeLabelPlans map[string]*nodeLabelPlan
+
+type nodeLabelReconciler interface {
+	reconcileNodeLabelPlans(context.Context, nodeLabelPlans) error
 }
 
 type topologyLabeler struct {
-	mapper map[string]string
+	mapper         map[string]string
+	acceleratorKey string
+	tierKeys       [3]string
 }
 
-func NewTopologyLabeler() *topologyLabeler {
+func newTopologyLabeler() *topologyLabeler {
 	return &topologyLabeler{
-		mapper: make(map[string]string),
+		mapper:         make(map[string]string),
+		acceleratorKey: labelAccelerator,
+		tierKeys:       [3]string{labelLeaf, labelSpine, labelCore},
 	}
 }
 
-func (l *topologyLabeler) ApplyNodeLabels(ctx context.Context, graph *topology.Graph, labeler Labeler) error {
-	if graph == nil || (graph.Domains == nil && graph.Tiers == nil) {
-		return nil
+func (l *topologyLabeler) applyNodeLabels(ctx context.Context, graph *topology.Graph, labeler nodeLabelReconciler) error {
+	plans, err := l.buildNodeLabelPlans(graph)
+	if err != nil || len(plans) == 0 {
+		return err
+	}
+	return labeler.reconcileNodeLabelPlans(ctx, plans)
+}
+
+func (l *topologyLabeler) buildNodeLabelPlans(graph *topology.Graph) (nodeLabelPlans, error) {
+	plans := make(nodeLabelPlans)
+	if graph == nil {
+		return plans, nil
 	}
 
-	nodeMap := make(nodeLabelMap)
-	if graph.Domains != nil {
-		if err := l.getDomainLabels(graph.Domains, nodeMap); err != nil {
-			return err
-		}
+	if err := l.getDomainLabels(graph.Domains, plans); err != nil {
+		return nil, err
 	}
 
 	if treeRoot := graph.Tiers; treeRoot != nil {
 		layers := []string{}
-		if len(treeRoot.ID) != 0 {
+		if treeRoot.ID != "" {
 			layers = append(layers, treeRoot.ID)
 		}
-		if err := l.getTierLabels(treeRoot, nodeMap, layers); err != nil {
-			return err
+		if err := l.getTierLabels(treeRoot, plans, layers); err != nil {
+			return nil, err
+		}
+	}
+	for nodeName, plan := range plans {
+		if len(plan.ManagedKeys) == 0 {
+			delete(plans, nodeName)
 		}
 	}
 
-	for nodeName, labels := range nodeMap {
-		if err := labeler.AddNodeLabels(ctx, nodeName, labels); err != nil {
-			return err
-		}
+	return plans, nil
+}
+
+func (l *topologyLabeler) getDomainLabels(domains topology.DomainMap, plans nodeLabelPlans) error {
+	if !validLabelKey(l.acceleratorKey) {
+		return nil
 	}
 
+	domainByNode := make(map[string]string)
+	for _, domainName := range slices.Sorted(maps.Keys(domains)) {
+		domain := domains[domainName]
+		for _, nodeName := range slices.Sorted(maps.Keys(domain)) {
+			if nodeName == "" {
+				return fmt.Errorf("accelerator domain %q contains an empty node name", domainName)
+			}
+			if previous, ok := domainByNode[nodeName]; ok && previous != domainName {
+				return fmt.Errorf("multiple accelerator labels %s, %s for node %s", previous, domainName, nodeName)
+			}
+			domainByNode[nodeName] = domainName
+
+			plan := getOrCreatePlan(plans, nodeName)
+			plan.acceleratorKey = l.acceleratorKey
+			addManagedKey(plan, l.acceleratorKey)
+			if err := l.addDesiredLabel(nodeName, plan, l.acceleratorKey, domainName); err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }
 
-func (l *topologyLabeler) getDomainLabels(domains topology.DomainMap, nodeMap nodeLabelMap) error {
-	for domainName, domain := range domains {
-		for nodeName := range domain {
-			labels, ok := nodeMap[nodeName]
-			if !ok {
-				labels = make(map[string]string)
-				nodeMap[nodeName] = labels
-			}
-			if val, ok := labels[labelAccelerator]; ok {
-				return fmt.Errorf("multiple accelerator labels %s, %s for node %s", val, domainName, nodeName)
-			}
-			labels[labelAccelerator] = l.checkLabel(domainName)
-		}
+func (l *topologyLabeler) getTierLabels(v *topology.Vertex, plans nodeLabelPlans, layers []string) error {
+	if v == nil {
+		return fmt.Errorf("topology contains a nil vertex")
 	}
-	return nil
-}
 
-func (l *topologyLabeler) getTierLabels(v *topology.Vertex, nodeMap nodeLabelMap, layers []string) error {
 	if len(v.Vertices) == 0 { // compute node
-		if len(layers) != 0 {
-			if v.ID != layers[0] {
-				return fmt.Errorf("instance ID mismatch: expected %s, got %s", v.ID, layers[0])
+		// An empty synthetic root represents an empty or partial topology, not a
+		// Kubernetes Node.
+		if v.Name == "" {
+			return nil
+		}
+		if len(layers) != 0 && v.ID != layers[0] {
+			return fmt.Errorf("instance ID mismatch: expected %s, got %s", v.ID, layers[0])
+		}
+
+		plan := getOrCreatePlan(plans, v.Name)
+		for _, key := range l.tierKeys {
+			addManagedKey(plan, key)
+		}
+		for i, sw := range layers[1:] {
+			if sw == "" || i >= len(l.tierKeys) {
+				break
 			}
-			nodeName := v.Name
-			labels, ok := nodeMap[nodeName]
-			if !ok {
-				labels = make(map[string]string)
-				nodeMap[nodeName] = labels
-			}
-			for i, sw := range layers[1:] {
-				if len(sw) == 0 {
-					break
-				}
-				if i < len(switchNetworkHierarchy) {
-					labels[(switchNetworkHierarchy[i])] = l.checkLabel(sw)
-				}
+			if err := l.addDesiredLabel(v.Name, plan, l.tierKeys[i], sw); err != nil {
+				return err
 			}
 		}
 		return nil
 	}
 
-	for _, w := range v.Vertices {
-		if err := l.getTierLabels(w, nodeMap, append([]string{w.ID}, layers...)); err != nil {
+	for _, vertexID := range slices.Sorted(maps.Keys(v.Vertices)) {
+		w := v.Vertices[vertexID]
+		if w == nil {
+			return fmt.Errorf("topology vertex %q contains a nil child", v.ID)
+		}
+		if err := l.getTierLabels(w, plans, append([]string{w.ID}, layers...)); err != nil {
 			return err
 		}
 	}
 
+	return nil
+}
+
+func getOrCreatePlan(plans nodeLabelPlans, nodeName string) *nodeLabelPlan {
+	plan, ok := plans[nodeName]
+	if ok {
+		return plan
+	}
+	plan = &nodeLabelPlan{
+		Desired:     make(map[string]string),
+		ManagedKeys: make(labelKeySet),
+	}
+	plans[nodeName] = plan
+	return plan
+}
+
+func validLabelKey(key string) bool {
+	return strings.TrimSpace(key) != ""
+}
+
+func addManagedKey(plan *nodeLabelPlan, key string) {
+	if validLabelKey(key) {
+		plan.ManagedKeys[key] = struct{}{}
+	}
+}
+
+func (l *topologyLabeler) addDesiredLabel(nodeName string, plan *nodeLabelPlan, key, value string) error {
+	if !validLabelKey(key) {
+		return nil
+	}
+	value = l.checkLabel(value)
+	if previous, ok := plan.Desired[key]; ok && previous != value {
+		return fmt.Errorf(
+			"conflicting desired values %q and %q for label %q on node %q",
+			previous,
+			value,
+			key,
+			nodeName,
+		)
+	}
+	plan.Desired[key] = value
 	return nil
 }
 

--- a/pkg/engines/k8s/labeler_test.go
+++ b/pkg/engines/k8s/labeler_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,130 +18,292 @@ package k8s
 
 import (
 	"context"
-	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/NVIDIA/topograph/pkg/topology"
 	"github.com/NVIDIA/topograph/pkg/translate"
 )
 
-type testLabeler struct {
-	data map[string]map[string]string
+type recordingReconciler struct {
+	calls int
+	plans nodeLabelPlans
 }
 
-func (l *testLabeler) AddNodeLabels(_ context.Context, nodeName string, labels map[string]string) error {
-	if _, ok := l.data[nodeName]; ok {
-		return fmt.Errorf("duplicate entry for %s", nodeName)
-	}
-	l.data[nodeName] = labels
+func (r *recordingReconciler) reconcileNodeLabelPlans(_ context.Context, plans nodeLabelPlans) error {
+	r.calls++
+	r.plans = plans
 	return nil
 }
 
-func TestApplyNodeLabelsWithTree(t *testing.T) {
-	InitLabels(DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
-	root, _ := translate.GetTreeTestSet(true)
-	labeler := &testLabeler{data: make(map[string]map[string]string)}
-	data := map[string]map[string]string{
-		"Node201": {"network.topology.nvidia.com/leaf": "S2", "network.topology.nvidia.com/spine": "S1"},
-		"Node202": {"network.topology.nvidia.com/leaf": "S2", "network.topology.nvidia.com/spine": "S1"},
-		"Node205": {"network.topology.nvidia.com/leaf": "S2", "network.topology.nvidia.com/spine": "S1"},
-		"Node304": {"network.topology.nvidia.com/leaf": "xf946c4acef2d5939", "network.topology.nvidia.com/spine": "S1"},
-		"Node305": {"network.topology.nvidia.com/leaf": "xf946c4acef2d5939", "network.topology.nvidia.com/spine": "S1"},
-		"Node306": {"network.topology.nvidia.com/leaf": "xf946c4acef2d5939", "network.topology.nvidia.com/spine": "S1"},
-	}
-
-	err := NewTopologyLabeler().ApplyNodeLabels(context.TODO(), root, labeler)
+func TestBuildNodeLabelPlansWithTree(t *testing.T) {
+	setTestLabels(t, DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+	graph, _ := translate.GetTreeTestSet(true)
+	plans, err := newTopologyLabeler().buildNodeLabelPlans(graph)
 	require.NoError(t, err)
-	require.Equal(t, data, labeler.data)
+
+	want := map[string]map[string]string{
+		"Node201": {DefaultLabelLeaf: "S2", DefaultLabelSpine: "S1"},
+		"Node202": {DefaultLabelLeaf: "S2", DefaultLabelSpine: "S1"},
+		"Node205": {DefaultLabelLeaf: "S2", DefaultLabelSpine: "S1"},
+		"Node304": {DefaultLabelLeaf: "xf946c4acef2d5939", DefaultLabelSpine: "S1"},
+		"Node305": {DefaultLabelLeaf: "xf946c4acef2d5939", DefaultLabelSpine: "S1"},
+		"Node306": {DefaultLabelLeaf: "xf946c4acef2d5939", DefaultLabelSpine: "S1"},
+	}
+	require.Equal(t, want, desiredLabelsByNode(plans))
+	for nodeName := range want {
+		require.Equal(t, keySet(DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore), plans[nodeName].ManagedKeys)
+		require.Empty(t, plans[nodeName].acceleratorKey)
+	}
 }
 
-func TestApplyNodeLabelsWithBlock(t *testing.T) {
-	InitLabels(DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
-	root, _ := translate.GetBlockWithMultiIBTestSet()
-	labeler := &testLabeler{data: make(map[string]map[string]string)}
-	data := map[string]map[string]string{
-		"Node104": {
-			"network.topology.nvidia.com/accelerator": "B1",
-			"network.topology.nvidia.com/leaf":        "S2",
-			"network.topology.nvidia.com/spine":       "S1",
-			"network.topology.nvidia.com/core":        "IB2",
-		},
-		"Node105": {
-			"network.topology.nvidia.com/accelerator": "B1",
-			"network.topology.nvidia.com/leaf":        "S2",
-			"network.topology.nvidia.com/spine":       "S1",
-			"network.topology.nvidia.com/core":        "IB2",
-		},
-		"Node106": {
-			"network.topology.nvidia.com/accelerator": "B1",
-			"network.topology.nvidia.com/leaf":        "S2",
-			"network.topology.nvidia.com/spine":       "S1",
-			"network.topology.nvidia.com/core":        "IB2",
-		},
-		"Node201": {
-			"network.topology.nvidia.com/accelerator": "B2",
-			"network.topology.nvidia.com/leaf":        "S3",
-			"network.topology.nvidia.com/spine":       "S1",
-			"network.topology.nvidia.com/core":        "IB2",
-		},
-		"Node202": {
-			"network.topology.nvidia.com/accelerator": "B2",
-			"network.topology.nvidia.com/leaf":        "S3",
-			"network.topology.nvidia.com/spine":       "S1",
-			"network.topology.nvidia.com/core":        "IB2",
-		},
-		"Node205": {
-			"network.topology.nvidia.com/accelerator": "B2",
-			"network.topology.nvidia.com/leaf":        "S3",
-			"network.topology.nvidia.com/spine":       "S1",
-			"network.topology.nvidia.com/core":        "IB2",
-		},
-		"Node301": {
-			"network.topology.nvidia.com/accelerator": "B3",
-			"network.topology.nvidia.com/leaf":        "S5",
-			"network.topology.nvidia.com/spine":       "S4",
-			"network.topology.nvidia.com/core":        "IB1",
-		},
-		"Node302": {
-			"network.topology.nvidia.com/accelerator": "B3",
-			"network.topology.nvidia.com/leaf":        "S5",
-			"network.topology.nvidia.com/spine":       "S4",
-			"network.topology.nvidia.com/core":        "IB1",
-		},
-		"Node303": {
-			"network.topology.nvidia.com/accelerator": "B3",
-			"network.topology.nvidia.com/leaf":        "S5",
-			"network.topology.nvidia.com/spine":       "S4",
-			"network.topology.nvidia.com/core":        "IB1",
-		},
-		"Node401": {
-			"network.topology.nvidia.com/accelerator": "B4",
-			"network.topology.nvidia.com/leaf":        "S6",
-			"network.topology.nvidia.com/spine":       "S4",
-			"network.topology.nvidia.com/core":        "IB1",
-		},
-		"Node402": {
-			"network.topology.nvidia.com/accelerator": "B4",
-			"network.topology.nvidia.com/leaf":        "S6",
-			"network.topology.nvidia.com/spine":       "S4",
-			"network.topology.nvidia.com/core":        "IB1",
-		},
-		"Node403": {
-			"network.topology.nvidia.com/accelerator": "B4",
-			"network.topology.nvidia.com/leaf":        "S6",
-			"network.topology.nvidia.com/spine":       "S4",
-			"network.topology.nvidia.com/core":        "IB1",
-		},
+func TestBuildNodeLabelPlansWithBlock(t *testing.T) {
+	setTestLabels(t, DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+	graph, _ := translate.GetBlockWithMultiIBTestSet()
+	plans, err := newTopologyLabeler().buildNodeLabelPlans(graph)
+	require.NoError(t, err)
+
+	want := map[string]map[string]string{
+		"Node104": {DefaultLabelAccelerator: "B1", DefaultLabelLeaf: "S2", DefaultLabelSpine: "S1", DefaultLabelCore: "IB2"},
+		"Node105": {DefaultLabelAccelerator: "B1", DefaultLabelLeaf: "S2", DefaultLabelSpine: "S1", DefaultLabelCore: "IB2"},
+		"Node106": {DefaultLabelAccelerator: "B1", DefaultLabelLeaf: "S2", DefaultLabelSpine: "S1", DefaultLabelCore: "IB2"},
+		"Node201": {DefaultLabelAccelerator: "B2", DefaultLabelLeaf: "S3", DefaultLabelSpine: "S1", DefaultLabelCore: "IB2"},
+		"Node202": {DefaultLabelAccelerator: "B2", DefaultLabelLeaf: "S3", DefaultLabelSpine: "S1", DefaultLabelCore: "IB2"},
+		"Node205": {DefaultLabelAccelerator: "B2", DefaultLabelLeaf: "S3", DefaultLabelSpine: "S1", DefaultLabelCore: "IB2"},
+		"Node301": {DefaultLabelAccelerator: "B3", DefaultLabelLeaf: "S5", DefaultLabelSpine: "S4", DefaultLabelCore: "IB1"},
+		"Node302": {DefaultLabelAccelerator: "B3", DefaultLabelLeaf: "S5", DefaultLabelSpine: "S4", DefaultLabelCore: "IB1"},
+		"Node303": {DefaultLabelAccelerator: "B3", DefaultLabelLeaf: "S5", DefaultLabelSpine: "S4", DefaultLabelCore: "IB1"},
+		"Node401": {DefaultLabelAccelerator: "B4", DefaultLabelLeaf: "S6", DefaultLabelSpine: "S4", DefaultLabelCore: "IB1"},
+		"Node402": {DefaultLabelAccelerator: "B4", DefaultLabelLeaf: "S6", DefaultLabelSpine: "S4", DefaultLabelCore: "IB1"},
+		"Node403": {DefaultLabelAccelerator: "B4", DefaultLabelLeaf: "S6", DefaultLabelSpine: "S4", DefaultLabelCore: "IB1"},
+	}
+	require.Equal(t, want, desiredLabelsByNode(plans))
+	for nodeName := range want {
+		require.Equal(
+			t,
+			keySet(DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore),
+			plans[nodeName].ManagedKeys,
+		)
+		require.Equal(t, DefaultLabelAccelerator, plans[nodeName].acceleratorKey)
+	}
+}
+
+func TestBuildTierPlansByDepth(t *testing.T) {
+	setTestLabels(t, DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+	testCases := []struct {
+		name    string
+		tiers   []string
+		desired map[string]string
+	}{
+		{name: "one tier", tiers: []string{"leaf-a"}, desired: map[string]string{DefaultLabelLeaf: "leaf-a"}},
+		{name: "two tiers", tiers: []string{"leaf-a", "spine-a"}, desired: map[string]string{DefaultLabelLeaf: "leaf-a", DefaultLabelSpine: "spine-a"}},
+		{name: "three tiers", tiers: []string{"leaf-a", "spine-a", "core-a"}, desired: map[string]string{DefaultLabelLeaf: "leaf-a", DefaultLabelSpine: "spine-a", DefaultLabelCore: "core-a"}},
 	}
 
-	err := NewTopologyLabeler().ApplyNodeLabels(context.TODO(), root, labeler)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			plans, err := newTopologyLabeler().buildNodeLabelPlans(graphWithTiers(map[string][]string{"node-a": tc.tiers}))
+			require.NoError(t, err)
+			require.Equal(t, tc.desired, plans["node-a"].Desired)
+			require.Equal(t, keySet(DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore), plans["node-a"].ManagedKeys)
+		})
+	}
+}
+
+func TestBuildNodeLabelPlansAuthority(t *testing.T) {
+	setTestLabels(t, DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+	graph := graphWithTiers(map[string][]string{
+		"both":       {"leaf-b", "spine-b"},
+		"tiers-only": {"leaf-t"},
+	})
+	graph.Domains = domainsByNode(map[string]string{
+		"both":        "domain-b",
+		"domain-only": "domain-d",
+	})
+
+	plans, err := newTopologyLabeler().buildNodeLabelPlans(graph)
 	require.NoError(t, err)
-	require.Equal(t, data, labeler.data)
+	require.Equal(t, &nodeLabelPlan{
+		Desired: map[string]string{
+			DefaultLabelAccelerator: "domain-d",
+		},
+		ManagedKeys:    keySet(DefaultLabelAccelerator),
+		acceleratorKey: DefaultLabelAccelerator,
+	}, plans["domain-only"])
+	require.Equal(t, &nodeLabelPlan{
+		Desired: map[string]string{
+			DefaultLabelAccelerator: "domain-b",
+			DefaultLabelLeaf:        "leaf-b",
+			DefaultLabelSpine:       "spine-b",
+		},
+		ManagedKeys:    keySet(DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore),
+		acceleratorKey: DefaultLabelAccelerator,
+	}, plans["both"])
+	require.Equal(t, &nodeLabelPlan{
+		Desired: map[string]string{
+			DefaultLabelLeaf: "leaf-t",
+		},
+		ManagedKeys: keySet(DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore),
+	}, plans["tiers-only"])
+	require.NotContains(t, plans, "outside")
+}
+
+func TestBuildNodeLabelPlansWithEmptyTiersAndDomains(t *testing.T) {
+	setTestLabels(t, DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+	graph := &topology.Graph{
+		Tiers:   &topology.Vertex{Vertices: map[string]*topology.Vertex{}},
+		Domains: domainsByNode(map[string]string{"node-a": "domain-a"}),
+	}
+
+	plans, err := newTopologyLabeler().buildNodeLabelPlans(graph)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{DefaultLabelAccelerator: "domain-a"}, plans["node-a"].Desired)
+	require.Equal(t, keySet(DefaultLabelAccelerator), plans["node-a"].ManagedKeys)
+}
+
+func TestBuildNodeLabelPlansEmptyGraph(t *testing.T) {
+	setTestLabels(t, DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+	for _, graph := range []*topology.Graph{
+		nil,
+		{},
+		{Tiers: &topology.Vertex{Vertices: map[string]*topology.Vertex{}}},
+	} {
+		plans, err := newTopologyLabeler().buildNodeLabelPlans(graph)
+		require.NoError(t, err)
+		require.Empty(t, plans)
+	}
+}
+
+func TestBuildNodeLabelPlansCustomAndEmptyKeys(t *testing.T) {
+	setTestLabels(t, "custom.example/accelerator", "custom.example/leaf", "", "  ")
+	graph := graphWithTiers(map[string][]string{"node-a": {"leaf-a", "spine-a", "core-a"}})
+	graph.Domains = domainsByNode(map[string]string{"node-a": "domain-a"})
+
+	plans, err := newTopologyLabeler().buildNodeLabelPlans(graph)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{
+		"custom.example/accelerator": "domain-a",
+		"custom.example/leaf":        "leaf-a",
+	}, plans["node-a"].Desired)
+	require.Equal(t, keySet("custom.example/accelerator", "custom.example/leaf"), plans["node-a"].ManagedKeys)
+}
+
+func TestBuildNodeLabelPlansDeduplicatesKeys(t *testing.T) {
+	setTestLabels(t, "custom.example/shared", "custom.example/shared", DefaultLabelSpine, DefaultLabelCore)
+	graph := graphWithTiers(map[string][]string{"node-a": {"same", "spine-a"}})
+	graph.Domains = domainsByNode(map[string]string{"node-a": "same"})
+
+	plans, err := newTopologyLabeler().buildNodeLabelPlans(graph)
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{
+		"custom.example/shared": "same",
+		DefaultLabelSpine:       "spine-a",
+	}, plans["node-a"].Desired)
+	require.Equal(t, keySet("custom.example/shared", DefaultLabelSpine, DefaultLabelCore), plans["node-a"].ManagedKeys)
+}
+
+func TestBuildNodeLabelPlansRejectsConflictingKeys(t *testing.T) {
+	setTestLabels(t, "custom.example/shared", "custom.example/shared", DefaultLabelSpine, DefaultLabelCore)
+	graph := graphWithTiers(map[string][]string{"node-a": {"leaf-a"}})
+	graph.Domains = domainsByNode(map[string]string{"node-a": "domain-a"})
+
+	_, err := newTopologyLabeler().buildNodeLabelPlans(graph)
+	require.EqualError(
+		t,
+		err,
+		`conflicting desired values "domain-a" and "leaf-a" for label "custom.example/shared" on node "node-a"`,
+	)
+}
+
+func TestBuildNodeLabelPlansRejectsMultipleDomainsBeforeReconcile(t *testing.T) {
+	setTestLabels(t, DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+	graph := &topology.Graph{Domains: topology.DomainMap{
+		"domain-a": {"node-a": &topology.HostInfo{HostName: "node-a"}},
+		"domain-b": {"node-a": &topology.HostInfo{HostName: "node-a"}},
+	}}
+	reconciler := &recordingReconciler{}
+
+	err := newTopologyLabeler().applyNodeLabels(context.Background(), graph, reconciler)
+	require.EqualError(t, err, "multiple accelerator labels domain-a, domain-b for node node-a")
+	require.Zero(t, reconciler.calls)
+}
+
+func TestBuildNodeLabelPlansRejectsNilVertexBeforeReconcile(t *testing.T) {
+	setTestLabels(t, DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+	graph := &topology.Graph{Tiers: &topology.Vertex{Vertices: map[string]*topology.Vertex{"bad": nil}}}
+	reconciler := &recordingReconciler{}
+
+	err := newTopologyLabeler().applyNodeLabels(context.Background(), graph, reconciler)
+	require.EqualError(t, err, `topology vertex "" contains a nil child`)
+	require.Zero(t, reconciler.calls)
+}
+
+func TestBuildNodeLabelPlansHashesLongValues(t *testing.T) {
+	setTestLabels(t, DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+	longDomain := strings.Repeat("domain", 20)
+	plans, err := newTopologyLabeler().buildNodeLabelPlans(&topology.Graph{
+		Domains: domainsByNode(map[string]string{"node-a": longDomain}),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "x98512e5ff9824935", plans["node-a"].Desired[DefaultLabelAccelerator])
 }
 
 func TestInitLabels(t *testing.T) {
-	InitLabels("a", "b", "c", "d")
-	require.Equal(t, []string{"b", "c", "d"}, switchNetworkHierarchy)
+	setTestLabels(t, "a", "b", "c", "d")
 	require.Equal(t, "a", labelAccelerator)
+	require.Equal(t, "b", labelLeaf)
+	require.Equal(t, "c", labelSpine)
+	require.Equal(t, "d", labelCore)
+}
+
+func setTestLabels(t *testing.T, accelerator, leaf, spine, core string) {
+	t.Helper()
+	InitLabels(accelerator, leaf, spine, core)
+	t.Cleanup(func() {
+		InitLabels(DefaultLabelAccelerator, DefaultLabelLeaf, DefaultLabelSpine, DefaultLabelCore)
+	})
+}
+
+func keySet(keys ...string) labelKeySet {
+	set := make(labelKeySet)
+	for _, key := range keys {
+		set[key] = struct{}{}
+	}
+	return set
+}
+
+func desiredLabelsByNode(plans nodeLabelPlans) map[string]map[string]string {
+	desired := make(map[string]map[string]string, len(plans))
+	for nodeName, plan := range plans {
+		desired[nodeName] = plan.Desired
+	}
+	return desired
+}
+
+func domainsByNode(domains map[string]string) topology.DomainMap {
+	domainMap := topology.NewDomainMap()
+	for nodeName, domain := range domains {
+		domainMap.AddHost(domain, nodeName, nodeName)
+	}
+	return domainMap
+}
+
+func graphWithTiers(tiersByNode map[string][]string) *topology.Graph {
+	root := &topology.Vertex{Vertices: make(map[string]*topology.Vertex)}
+	for nodeName, tiers := range tiersByNode {
+		parent := root
+		for i := len(tiers) - 1; i >= 0; i-- {
+			tierID := tiers[i]
+			vertex, ok := parent.Vertices[tierID]
+			if !ok {
+				vertex = &topology.Vertex{ID: tierID, Vertices: make(map[string]*topology.Vertex)}
+				parent.Vertices[tierID] = vertex
+			}
+			parent = vertex
+		}
+		parent.Vertices[nodeName] = &topology.Vertex{Name: nodeName, ID: nodeName}
+	}
+	return &topology.Graph{Tiers: root}
 }


### PR DESCRIPTION
## Description

Reconcile Kubernetes Node topology labels from a complete per-node plan so stale higher-tier labels are removed when a discovered network path becomes shallower.

The Kubernetes engine now:

- builds and validates all desired labels and authoritative managed keys before accessing the Kubernetes API;
- performs one logical, selector-filtered and paginated Node List, then updates only nodes whose managed labels changed;
- uses the List resourceVersion for the first Update and performs a per-node GET only after an Update conflict;
- leaves nodes outside the current graph untouched and preserves all non-managed Node data;
- retains the existing `nvidia.com/gpu.clique` protection, including custom label-key collisions.

This reduces a stable reconciliation from per-node GET and Update calls to the List page count plus one Update per changed node.

Validation completed:

- `go test -race ./pkg/engines/k8s/...`
- `make fmt`
- `make vet`
- `make lint`
- `make test`
- `make qualify`

## Checklist
- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).
