### PR TITLE
fix(slurm): update topology trigger provider list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- The Slurm topology-update trigger script now accepts AWS, GCP, OCI, Nebius, NetQ, Nscale, Lambda, and bare-metal InfiniBand providers.
 - **BREAKING:** Fabric topology now uses variable, closest-first tiers labeled `network.topology.nvidia.com/tier-N`; `InstanceTopology.FabricTiers` and graph conversion support arbitrary fabric depth. Accelerator topology remains a single `AcceleratorID`/`Graph.Domains` dimension labeled `network.topology.nvidia.com/accelerator`. The fixed `leaf`, `spine`, and `core` keys and process-wide Helm/CLI label overrides are replaced by optional `fabricLabels` and `acceleratorLabel` parameters on the `k8s` engine.
 - Simulation model node names are now treated as hostnames; the model-backed test provider generates their instance IDs with an `i-` prefix.
 - The node-observer and node-data-broker are now rendered directly by the main Topograph Helm chart instead of local subcharts. Their existing `node-observer.*` and `node-data-broker.*` values paths are unchanged.

--- a/docs/engines/slurm.md
+++ b/docs/engines/slurm.md
@@ -53,7 +53,7 @@ curl -s -X POST -H "Content-Type: application/json" -d @payload.json http://loca
 We provide `scripts/create-topology-update-script.sh` in the repository, which performs the steps outlined above: it creates the topology update script and registers it with the strigger.
 
 The script accepts the following parameters:
-- **provider name** (aws, oci, gcp, nebius, nscale, netq, infiniband-bm)
+- **provider name** (`aws`, `gcp`, `oci`, `nebius`, `netq`, `nscale`, `lambdai`, or `infiniband-bm`)
 - **path to the generated topology update script**
 - **path to the topology.conf file**
 

--- a/scripts/create-topology-update-script.sh
+++ b/scripts/create-topology-update-script.sh
@@ -14,6 +14,7 @@ fi
 SCRIPT_PATH="update-topology-config.sh"
 PROVIDER=""
 TOPOLOGY_CONFIG_PATH=""
+SUPPORTED_PROVIDERS=(aws gcp oci nebius netq nscale lambdai infiniband-bm)
 if [[ ! -z "$SLURM_CONF" ]]; then 
   TOPOLOGY_CONFIG_PATH="$(dirname $SLURM_CONF)/topology.conf"
 fi
@@ -30,8 +31,8 @@ Options:
     Default: $SCRIPT_PATH
   -c <path to the topology config>
     Default: $TOPOLOGY_CONFIG_PATH
-  -p <CSP provider>
-    Options: aws, oci, gcp, azure
+  -p <provider>
+    Options: ${SUPPORTED_PROVIDERS[*]}
   -h
     Print this message
 EOF
@@ -73,21 +74,19 @@ if [[ -z "$PROVIDER" ]]; then
   exit 1
 fi
 
-case $PROVIDER in
-  "aws")
-    ;;
-  "oci")
-    ;;
-  "gcp")
-    ;;
-  "azure")
-    ;;
-  *)
-    echo "unsupported provider $PROVIDER"
-    usage
-    exit 1
-    ;;
-esac
+provider_supported=false
+for supported_provider in "${SUPPORTED_PROVIDERS[@]}"; do
+  if [[ "$PROVIDER" == "$supported_provider" ]]; then
+    provider_supported=true
+    break
+  fi
+done
+
+if [[ "$provider_supported" != true ]]; then
+  echo "unsupported provider $PROVIDER"
+  usage
+  exit 1
+fi
 
 echo "Creating $SCRIPT_PATH to update topology config $TOPOLOGY_CONFIG_PATH"
 echo ""


### PR DESCRIPTION
## Description
Updates scripts/create-topology-update-script.sh to validate the currently supported Slurm provider names.
closes #413 
