### PR TITLE
fix(slinky): reduce Kubernetes API throttling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- DRA provider and Slinky engine `kubeQPS` and `kubeBurst` parameters for tuning their independent Kubernetes client rate limits on large clusters.
 - Slurm and Slinky block topology configurations can set `blockName.nodeNameRegexp` and `blockName.format` to derive unique block names from site-specific node naming conventions.
 - Simulation model files may omit empty leaf-switch definitions; the model loader now creates leaf switches referenced by the parent switch hierarchy.
 - `govulncheck` job in the Go CI workflow for symbol-level vulnerability scanning on pull requests.
@@ -32,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Slinky dynamic-node reconciliation now reuses listed Node annotations, skips unchanged nodes without a per-node GET, and patches only changed topology annotations, substantially reducing Kubernetes client-side throttling on large clusters.
 - Corrected DRA provider guidance to document its Slinky-only block-topology scope, dependency on pre-existing `nvidia.com/gpu.clique` labels, and inability to guide placement across NVLink partitions without backend-fabric topology.
 - The NFD engine now rejects an empty generated object set when cleanup is enabled, preserving the last published topology instead of deleting every Topograph-managed NFD object after an empty provider result or over-narrow node selection.
 - The NFD engine now groups nodes with `nvidia.com/gpu.clique` by that authoritative accelerator value instead of omitting their accelerator attribute.
@@ -54,7 +56,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Scoped the NFD engine's `NodeFeature` and `NodeFeatureGroup` permissions to the deployment-level `nfdNamespace` instead of granting them cluster-wide. Helm configures the same namespace at runtime through `NFD_NAMESPACE`; the namespace is no longer a request-level engine parameter, and the engine rejects a missing or blank environment variable.
 
-- Removed unused RBAC verbs from the Topograph API server and node-data-broker ClusterRoles (least-privilege): API server `pods` rule dropped `get` (list-only), `daemonsets` rule dropped `list` (get-only), and the Slinky `configmaps` rule dropped `list`; node-data-broker `nodes` rule dropped `list` (get/update), and the InfiniBand `daemonsets`/`pods` rules dropped `list`/`get` respectively (get-only, list-only).
+- Removed unused RBAC verbs from the Topograph API server and node-data-broker ClusterRoles (least-privilege): API server `pods` rule dropped `get` (list-only), `daemonsets` rule dropped `list` (get-only), Slinky receives Node `patch` without Node `update`, and the Slinky `configmaps` rule dropped `list`; node-data-broker `nodes` rule dropped `list` (get/update), and the InfiniBand `daemonsets`/`pods` rules dropped `list`/`get` respectively (get-only, list-only).
 
 - node-observer ClusterRole no longer grants unused `get`; `nodes` list/watch now gated on `trigger.nodeSelector`.
 ### Migration (Helm — hardened security context)

--- a/charts/topograph/templates/rbac.yaml
+++ b/charts/topograph/templates/rbac.yaml
@@ -40,7 +40,17 @@ rules:
 {{- end }}
 - apiGroups: [""]
   resources: [nodes]
-  verbs: [get,list,update]
+  verbs: [get,list]
+{{- if eq .Values.engine.name "k8s" }}
+- apiGroups: [""]
+  resources: [nodes]
+  verbs: [update]
+{{- end }}
+{{- if eq .Values.engine.name "slinky" }}
+- apiGroups: [""]
+  resources: [nodes]
+  verbs: [patch]
+{{- end }}
 - apiGroups: [apps]
   resources: [daemonsets]
   verbs: [get]

--- a/charts/topograph/tests/__snapshot__/render_snapshot_test.yaml.snap
+++ b/charts/topograph/tests/__snapshot__/render_snapshot_test.yaml.snap
@@ -398,6 +398,11 @@ renders default values.yaml:
         verbs:
           - get
           - list
+      - apiGroups:
+          - ""
+        resources:
+          - nodes
+        verbs:
           - update
       - apiGroups:
           - apps
@@ -963,6 +968,11 @@ renders values.k8s.gateway-api-example.yaml:
         verbs:
           - get
           - list
+      - apiGroups:
+          - ""
+        resources:
+          - nodes
+        verbs:
           - update
       - apiGroups:
           - apps
@@ -1538,6 +1548,11 @@ renders values.k8s.gcp-federated-workload-identity-example.yaml:
         verbs:
           - get
           - list
+      - apiGroups:
+          - ""
+        resources:
+          - nodes
+        verbs:
           - update
       - apiGroups:
           - apps
@@ -2101,6 +2116,11 @@ renders values.k8s.gcp-service-account-example.yaml:
         verbs:
           - get
           - list
+      - apiGroups:
+          - ""
+        resources:
+          - nodes
+        verbs:
           - update
       - apiGroups:
           - apps
@@ -2672,6 +2692,11 @@ renders values.k8s.ib-example.yaml:
         verbs:
           - get
           - list
+      - apiGroups:
+          - ""
+        resources:
+          - nodes
+        verbs:
           - update
       - apiGroups:
           - apps
@@ -3239,7 +3264,12 @@ renders values.slinky.block-example.yaml:
         verbs:
           - get
           - list
-          - update
+      - apiGroups:
+          - ""
+        resources:
+          - nodes
+        verbs:
+          - patch
       - apiGroups:
           - apps
         resources:
@@ -3831,7 +3861,12 @@ renders values.slinky.partition-example.yaml:
         verbs:
           - get
           - list
-          - update
+      - apiGroups:
+          - ""
+        resources:
+          - nodes
+        verbs:
+          - patch
       - apiGroups:
           - apps
         resources:
@@ -4398,7 +4433,12 @@ renders values.slinky.tree-example.yaml:
         verbs:
           - get
           - list
-          - update
+      - apiGroups:
+          - ""
+        resources:
+          - nodes
+        verbs:
+          - patch
       - apiGroups:
           - apps
         resources:

--- a/charts/topograph/tests/rbac_test.yaml
+++ b/charts/topograph/tests/rbac_test.yaml
@@ -63,7 +63,13 @@ tests:
           content:
             apiGroups: [""]
             resources: [nodes]
-            verbs: [get, list, update]
+            verbs: [get, list]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [update]
       - contains:
           path: rules
           content:
@@ -136,6 +142,56 @@ tests:
             apiGroups: [""]
             resources: [configmaps]
             verbs: [create, get, list, update]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [patch]
+
+  - it: does not grant node patch access to non-slinky engines
+    set:
+      engine:
+        name: k8s
+    documentIndex: 0
+    asserts:
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [patch]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [update]
+
+  - it: does not grant node update access to the slinky engine
+    set:
+      engine:
+        name: slinky
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [get, list]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [patch]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [update]
 
   - it: does not render NFD namespace RBAC for an explicit non-NFD engine
     set:

--- a/charts/topograph/values.yaml
+++ b/charts/topograph/values.yaml
@@ -10,6 +10,10 @@ provider:
   #   # accelerator-domain source instead of running nvidia-smi through the
   #   # GPU Operator device-plugin DaemonSet.
   #   useGpuCliqueLabel: true
+  #   # DRA provider Kubernetes client rate limits. Leave unset to use the
+  #   # client-go defaults (5 QPS and burst 10).
+  #   kubeQPS: 50
+  #   kubeBurst: 100
 
 engine:
   # name: "k8s", "nfd", "slinky", "slurm" or "graph"
@@ -18,6 +22,11 @@ engine:
   #   # For slinky topology/block output, use the GPU Operator's existing
   #   # Kubernetes node label as the block-domain source.
   #   useGpuCliqueLabel: true
+  #   # Slinky engine Kubernetes client rate limits. Raise these only when
+  #   # large dynamic-node reconciliations still experience client throttling.
+  #   # Leave unset to use the client-go defaults (5 QPS and burst 10).
+  #   kubeQPS: 50
+  #   kubeBurst: 100
 
 # Namespace where NFD master runs. The nfd engine creates NodeFeature and
 # NodeFeatureGroup resources here, and its Role/RoleBinding are scoped here.

--- a/demos/dra-slinky/values.dra-slinky.kwok.yaml
+++ b/demos/dra-slinky/values.dra-slinky.kwok.yaml
@@ -21,6 +21,8 @@ engine:
     topologyConfigPath: topology.conf
     topologyConfigmapName: slurm-config-extra
     useDynamicNodes: true
+    kubeQPS: 50
+    kubeBurst: 100
 
 config:
   requestAggregationDelay: 2s

--- a/docs/api.md
+++ b/docs/api.md
@@ -73,6 +73,8 @@ Topograph exposes three endpoints for interacting with the service. Below are th
     - **creds**: (optional) A key-value map with provider-specific parameters for authentication.
     - **params**: (optional) A key-value map with provider-specific parameters. The `test` provider uses these parameters for response simulation; for complete behavior and examples, see [Test Mode and Test Provider](./providers/test.md).
       - **useGpuCliqueLabel**: (optional) Used in: [`infiniband-k8s`]. If `true`, reads the GPU Operator's `nvidia.com/gpu.clique` node label as the accelerator-domain source instead of using the `topograph.nvidia.com/cluster-id` node annotation.
+      - **kubeQPS**: (optional) Used in: [`dra`]. A positive number overriding the provider Kubernetes client's default request rate of 5 QPS.
+      - **kubeBurst**: (optional) Used in: [`dra`]. A positive integer overriding the provider Kubernetes client's default burst capacity of 10.
   - **engine**: (optional) Selects the topology output and provides any engine-specific parameters.
     - **name**: (optional) A string specifying the topology output, either `slurm`, `k8s`, `nfd`, `slinky`, or `graph`. This parameter will override the engine set in the topograph config.
     - **params**: (optional) A key-value map with engine-specific parameters.
@@ -99,6 +101,8 @@ Topograph exposes three endpoints for interacting with the service. Below are th
       - **topologyConfigmapName**: Used in: [`slinky`]. The required name of the ConfigMap containing the topology config.
       - **useDynamicNodes**: (optional) Used in: [`slinky`]. If `true`, Kubernetes nodes matched by the Node Selector will be annotated with the topology spec.
       - **useGpuCliqueLabel**: (optional) Used in: [`slinky`]. If `true`, `topology/block` domains are built from the GPU Operator's `nvidia.com/gpu.clique` node label instead of provider accelerator-domain data.
+      - **kubeQPS**: (optional) Used in: [`slinky`]. A positive number overriding the engine Kubernetes client's default request rate of 5 QPS.
+      - **kubeBurst**: (optional) Used in: [`slinky`]. A positive integer overriding the engine Kubernetes client's default burst capacity of 10.
       - **configUpdateMode**: (optional) Used in: [`slinky`]. By default, the full topology YAML is written in the Slurm ConfigMap. `skeleton-only` overrides to include switches or blocks only (no node lines); `none` skips updating the topology key in the ConfigMap.
   - **nodes**: (optional) Supplies the cluster nodes used for topology generation as an array of regions mapping instance IDs to node names.
 

--- a/docs/engines/slinky.md
+++ b/docs/engines/slinky.md
@@ -40,8 +40,8 @@ engine:
     blockName:                               # (Optional) Derive block names from node names
       nodeNameRegexp: 'd([0-9]{2})-r([0-9]{2})'
       format: 'domain${1}_rack${2}'
-  topologyConfigmapName: slurm-config        # Name of the ConfigMap containing the topology config
-  topologyConfigPath: topology.conf          # Key in the ConfigMap for the topology config
+    topologyConfigmapName: slurm-config      # Name of the ConfigMap containing the topology config
+    topologyConfigPath: topology.conf        # Key in the ConfigMap for the topology config
 ```
 
 ### Per-partition topologies
@@ -108,6 +108,33 @@ engine:
 ```
 
 If `useGpuCliqueLabel` is enabled for a block topology and no matching nodes have the `nvidia.com/gpu.clique` label plus the Topograph instance annotation, topology generation fails with a `502` error instead of falling back to provider accelerator domains.
+
+### Kubernetes API rate limiting
+
+The Slinky engine uses client-go's default Kubernetes client limits of 5 QPS
+and a burst of 10 unless `kubeQPS` or `kubeBurst` is set. Dynamic-node
+reconciliation compares each desired topology annotation with the Node objects
+returned by the cluster-wide list, skips nodes that are already current, and
+patches only changed annotations. This avoids a separate Node GET for every
+node during steady-state reconciliation.
+
+Large reconciliations that legitimately change many nodes can still exceed the
+default client-side limit. Increase the limits conservatively and monitor API
+server latency and throttling:
+
+```yaml
+engine:
+  name: slinky
+  params:
+    kubeQPS: 50
+    kubeBurst: 100
+```
+
+These settings apply only to the Slinky engine client. Kubernetes-backed
+providers use separate clients and, where supported, separate provider
+parameters. Increasing the limits reduces client-side waiting but does not
+reduce API-server load; narrow `nodeSelector` and `podSelector` values remain
+the preferred first mitigation.
 
 ## ConfigMap Annotations
 

--- a/docs/providers/dra.md
+++ b/docs/providers/dra.md
@@ -52,6 +52,8 @@ If no nodes with matching labels are found, Topograph returns a `502` error with
 | Parameter | Type | Required | Description |
 |---|---|---|---|
 | `nodeSelector` | `map[string]string` | No | Label selector to filter which nodes participate in topology discovery |
+| `kubeQPS` | `number` | No | Kubernetes client request rate. Values greater than zero override the client-go default of 5 QPS. |
+| `kubeBurst` | `integer` | No | Kubernetes client burst capacity. Values greater than zero override the client-go default of 10. |
 
 ## Configuration
 
@@ -60,6 +62,12 @@ engine through the chart's `provider` and `engine` values. Set the optional
 `nodeSelector` under `provider.params`. The chart manages the Topograph
 configuration and topology request payload; they do not need to be supplied
 separately.
+
+The DRA provider performs one filtered Node list per topology generation, so
+raising `kubeQPS` or `kubeBurst` is rarely necessary. These provider settings
+are independent from the Slinky engine settings of the same names. Tune the
+Slinky settings first when dynamic-node reconciliation is the source of
+client-side throttling.
 
 No credentials are required. The provider uses the in-cluster service account
 automatically. See the [Slinky engine documentation](../engines/slinky.md#configuration)

--- a/pkg/engines/slinky/engine.go
+++ b/pkg/engines/slinky/engine.go
@@ -19,6 +19,7 @@ package slinky
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"maps"
 	"net/http"
@@ -30,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
@@ -95,6 +97,11 @@ type Params struct {
 	ConfigUpdateMode string `mapstructure:"configUpdateMode,omitempty"`
 	// Topologies specifies per-partition topology configuration
 	Topologies map[string]*Topology `mapstructure:"topologies,omitempty"`
+	// KubeQPS overrides the client-go default QPS for Kubernetes API calls (default: 5).
+	// Increase on large clusters where per-node annotation updates saturate the rate limiter.
+	KubeQPS float32 `mapstructure:"kubeQPS"`
+	// KubeBurst overrides the client-go default burst for Kubernetes API calls (default: 10).
+	KubeBurst int `mapstructure:"kubeBurst"`
 
 	// derived fields
 	podListOpt  *metav1.ListOptions
@@ -126,6 +133,13 @@ func Loader(_ context.Context, params engines.Config) (engines.Engine, *httperr.
 		return nil, httperr.NewError(http.StatusBadGateway, err.Error())
 	}
 
+	if p.KubeQPS > 0 {
+		config.QPS = p.KubeQPS
+	}
+	if p.KubeBurst > 0 {
+		config.Burst = p.KubeBurst
+	}
+
 	client, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, httperr.NewError(http.StatusBadGateway, err.Error())
@@ -142,6 +156,12 @@ func getParameters(params engines.Config) (*Params, error) {
 	p := &Params{}
 	if err := config.Decode(params, p); err != nil {
 		return nil, err
+	}
+	if p.KubeQPS < 0 {
+		return nil, fmt.Errorf("kubeQPS must be greater than or equal to zero")
+	}
+	if p.KubeBurst < 0 {
+		return nil, fmt.Errorf("kubeBurst must be greater than or equal to zero")
 	}
 
 	// Validate config update mode
@@ -665,47 +685,40 @@ func (eng *SlinkyEngine) performReconciliation(ctx context.Context, nt *translat
 }
 
 func (eng *SlinkyEngine) updateNodeAnnotation(ctx context.Context, node *corev1.Node, slurmName string, nt *translate.NetworkTopology, topologies []*translate.TopologyUnit) *httperr.Error {
-
-	// Get the topology desiredSpec for the node based on the desired topologies
 	desiredSpec, httpErr := nt.GetNodeTopologySpec(slurmName, topologies)
 	if httpErr != nil {
 		return httperr.NewError(http.StatusBadGateway, fmt.Sprintf("failed to get topology spec for node %s: %v", slurmName, httpErr))
 	}
 
-	//If the topology spec is empty, no topology information is available for the node from the provider.
-	//In this case, we can skip the annotation update to avoid unnecessary node reconfiguration by Slinky.
 	if desiredSpec == "" {
 		klog.V(4).Infof("Node %s (SLURM name: %s) received no topology spec from the provider, skipping annotation update", node.Name, slurmName)
 		return nil
 	}
 
-	//Get the node object again to ensure we have the latest resource version for update
-	nodeObj, err := eng.client.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
-	if err != nil {
-		return httperr.NewError(http.StatusBadGateway, fmt.Sprintf("failed to get node %s: %v", node.Name, err))
-	}
-
-	// Update the topology annotation on the node
-	if nodeObj.Annotations == nil {
-		nodeObj.Annotations = make(map[string]string)
-	}
-
-	//Get the current topology spec annotation on the node and compare with the desired spec. If they are the same, skip the update to avoid unnecessary node reconfiguration by Slinky.
-	currentSpec, exists := nodeObj.Annotations[topology.KeySlinkyTopologySpec]
-	if exists && currentSpec == desiredSpec {
+	// Use the annotation value from the already-fetched node (from the cluster List) to
+	// avoid an extra Get per node. If the annotation is already correct, skip the Patch.
+	if node.Annotations[topology.KeySlinkyTopologySpec] == desiredSpec {
 		klog.V(4).Infof("Node %s (SLURM name: %s) topology spec is up to date, skipping annotation update", node.Name, slurmName)
 		return nil
 	}
 
-	klog.Infof("Updating node %s (SLURM name: %s) topology spec annotation. Current spec: %q, New spec: %q", node.Name, slurmName, currentSpec, desiredSpec)
+	klog.Infof("Updating node %s (SLURM name: %s) topology spec annotation. Current spec: %q, New spec: %q",
+		node.Name, slurmName, node.Annotations[topology.KeySlinkyTopologySpec], desiredSpec)
 
-	//Set the new topology spec annotation on the node. This will trigger Slinky to reconfigure the node according to the new topology.
-	nodeObj.Annotations[topology.KeySlinkyTopologySpec] = desiredSpec
-
-	// Update the node object in Kubernetes
-	_, err = eng.client.CoreV1().Nodes().Update(ctx, nodeObj, metav1.UpdateOptions{})
+	patchData, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{
+			"annotations": map[string]string{
+				topology.KeySlinkyTopologySpec: desiredSpec,
+			},
+		},
+	})
 	if err != nil {
-		return httperr.NewError(http.StatusBadGateway, fmt.Sprintf("failed to update node annotation: %v", err))
+		return httperr.NewError(http.StatusInternalServerError, fmt.Sprintf("failed to marshal patch for node %s: %v", node.Name, err))
+	}
+
+	_, err = eng.client.CoreV1().Nodes().Patch(ctx, node.Name, types.StrategicMergePatchType, patchData, metav1.PatchOptions{})
+	if err != nil {
+		return httperr.NewError(http.StatusBadGateway, fmt.Sprintf("failed to patch node annotation: %v", err))
 	}
 
 	return nil

--- a/pkg/engines/slinky/engine_test.go
+++ b/pkg/engines/slinky/engine_test.go
@@ -240,6 +240,48 @@ func TestGetParameters(t *testing.T) {
 				podListOpt:        &metav1.ListOptions{LabelSelector: "key=value"},
 			},
 		},
+		{
+			name: "Case 11: kubeQPS and kubeBurst",
+			params: map[string]any{
+				topology.KeyNamespace:         "namespace",
+				topology.KeyPodSelector:       podSelector,
+				topology.KeyTopoConfigPath:    "path",
+				topology.KeyTopoConfigmapName: "name",
+				"kubeQPS":                     float32(50),
+				"kubeBurst":                   100,
+			},
+			ret: &Params{
+				Namespace:     "namespace",
+				PodSelector:   labelSelector,
+				ConfigPath:    "path",
+				ConfigMapName: "name",
+				KubeQPS:       50,
+				KubeBurst:     100,
+				podListOpt:    &metav1.ListOptions{LabelSelector: "key=value"},
+			},
+		},
+		{
+			name: "Case 12: negative kubeQPS",
+			params: map[string]any{
+				topology.KeyNamespace:         "namespace",
+				topology.KeyPodSelector:       podSelector,
+				topology.KeyTopoConfigPath:    "path",
+				topology.KeyTopoConfigmapName: "name",
+				"kubeQPS":                     -1,
+			},
+			err: "kubeQPS must be greater than or equal to zero",
+		},
+		{
+			name: "Case 13: negative kubeBurst",
+			params: map[string]any{
+				topology.KeyNamespace:         "namespace",
+				topology.KeyPodSelector:       podSelector,
+				topology.KeyTopoConfigPath:    "path",
+				topology.KeyTopoConfigmapName: "name",
+				"kubeBurst":                   -1,
+			},
+			err: "kubeBurst must be greater than or equal to zero",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1262,6 +1304,22 @@ func TestGenerateDynamicNodesOutput(t *testing.T) {
 			expectError:    true,
 			errorMsg:       "failed to get config map",
 		},
+		{
+			name: "error patching node",
+			k8sClient: func(slurmNames []string, createConfigMap bool) *fake.Clientset {
+				client := fakeSuccessClient(slurmNames, createConfigMap)
+				client.PrependReactor("patch", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, errors.NewInternalError(fmt.Errorf("failed to patch node"))
+				})
+				return client
+			},
+			createConfigMap: true,
+			topologyFile:    "medium.yaml",
+			topologyConfig:  []string{topology.TopologyTree},
+			slurmName:       []string{"1101", "1402"},
+			expectError:     true,
+			errorMsg:        "failed to patch node annotation",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1307,6 +1365,9 @@ func TestGenerateDynamicNodesOutput(t *testing.T) {
 			}
 			require.Nil(t, httpErr)
 
+			require.Equal(t, 0, countClientActions(client.Actions(), "get", "nodes"))
+			require.Equal(t, len(tc.expectTopologySpec), countClientActions(client.Actions(), "patch", "nodes"))
+
 			cm, err := client.CoreV1().ConfigMaps(params.Namespace).Get(context.Background(), params.ConfigMapName, metav1.GetOptions{})
 			require.NoError(t, err)
 			require.Equal(t, tc.expectTopologyYaml, cm.Data[params.ConfigPath])
@@ -1318,8 +1379,26 @@ func TestGenerateDynamicNodesOutput(t *testing.T) {
 				require.Equal(t, []byte("OK\n"), result)
 			}
 
+			// A second reconciliation over unchanged nodes must use the existing
+			// List result and issue no per-node Get or Patch requests.
+			client.ClearActions()
+			result, httpErr = engine.GenerateOutput(context.Background(), topo, nil)
+			require.Nil(t, httpErr)
+			require.Equal(t, []byte("OK\n"), result)
+			require.Equal(t, 0, countClientActions(client.Actions(), "get", "nodes"))
+			require.Equal(t, 0, countClientActions(client.Actions(), "patch", "nodes"))
 		})
 	}
+}
+
+func countClientActions(actions []k8stesting.Action, verb, resource string) int {
+	count := 0
+	for _, action := range actions {
+		if action.GetVerb() == verb && action.GetResource().Resource == resource {
+			count++
+		}
+	}
+	return count
 }
 
 func TestResolveTopologies(t *testing.T) {

--- a/pkg/providers/dra/provider.go
+++ b/pkg/providers/dra/provider.go
@@ -38,6 +38,10 @@ type Provider struct {
 type Params struct {
 	// NodeSelector (optional) specifies nodes participating in the topology
 	NodeSelector map[string]string `mapstructure:"nodeSelector"`
+	// KubeQPS overrides the client-go default QPS for Kubernetes API calls (default: 5).
+	KubeQPS float32 `mapstructure:"kubeQPS"`
+	// KubeBurst overrides the client-go default burst for Kubernetes API calls (default: 10).
+	KubeBurst int `mapstructure:"kubeBurst"`
 
 	// derived fields
 	nodeListOpt *metav1.ListOptions
@@ -58,6 +62,13 @@ func Loader(ctx context.Context, config providers.Config) (providers.Provider, *
 		return nil, httperr.NewError(http.StatusBadGateway, err.Error())
 	}
 
+	if p.KubeQPS > 0 {
+		cfg.QPS = p.KubeQPS
+	}
+	if p.KubeBurst > 0 {
+		cfg.Burst = p.KubeBurst
+	}
+
 	client, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		return nil, httperr.NewError(http.StatusBadGateway, err.Error())
@@ -74,6 +85,12 @@ func getParameters(params map[string]any) (*Params, error) {
 	p := &Params{}
 	if err := config.Decode(params, p); err != nil {
 		return nil, err
+	}
+	if p.KubeQPS < 0 {
+		return nil, fmt.Errorf("kubeQPS must be greater than or equal to zero")
+	}
+	if p.KubeBurst < 0 {
+		return nil, fmt.Errorf("kubeBurst must be greater than or equal to zero")
 	}
 
 	if len(p.NodeSelector) != 0 {

--- a/pkg/providers/dra/provider_test.go
+++ b/pkg/providers/dra/provider_test.go
@@ -43,6 +43,27 @@ func TestGetParameters(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Case 4: kubeQPS and kubeBurst",
+			params: map[string]any{
+				"kubeQPS":   float32(50),
+				"kubeBurst": 100,
+			},
+			ret: &Params{
+				KubeQPS:   50,
+				KubeBurst: 100,
+			},
+		},
+		{
+			name:   "Case 5: negative kubeQPS",
+			params: map[string]any{"kubeQPS": -1},
+			err:    "kubeQPS must be greater than or equal to zero",
+		},
+		{
+			name:   "Case 6: negative kubeBurst",
+			params: map[string]any{"kubeBurst": -1},
+			err:    "kubeBurst must be greater than or equal to zero",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Description

Reduce Kubernetes API client-side throttling when running the Slinky engine
with dynamic nodes, particularly on large DRA-backed clusters.

Previously, every reconciliation performed an additional Node GET for each
participating node before updating its topology annotation. This caused API
request volume to scale with cluster size even when annotations were already
current.

This change:

- Reuses Node annotations from the existing cluster-wide LIST.
- Skips unchanged nodes without additional API calls.
- Uses a targeted PATCH for changed topology annotations.
- Adds Slinky Node PATCH RBAC permissions.
- Adds configurable `kubeQPS` and `kubeBurst` parameters for the Slinky engine and DRA provider.
- Rejects negative rate-limit values.
- Adds tests covering API action counts, unchanged reconciliation, PATCH failures, and Helm RBAC.
- Updates Helm values, API documentation, provider/engine documentation, snapshots, and the changelog.

closes #423
