### PR TITLE
refactor(models): use annotations for simulation topology metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **BREAKING:** Simulation models now define accelerator topology through inherited `switches[].annotations` and `blocks[].annotations` using `accelerator.topology.test/domain` and optional `accelerator.topology.test/sub-domain`, instead of the `network.topology.nvidia.com/accelerator` model label.
 - The Slurm topology-update trigger script now accepts AWS, GCP, OCI, Nebius, NetQ, Nscale, Lambda, and bare-metal InfiniBand providers.
 - **BREAKING:** Fabric topology now uses variable, closest-first tiers labeled `network.topology.nvidia.com/tier-N`; `InstanceTopology.FabricTiers` and graph conversion support arbitrary fabric depth. Accelerator topology remains a single `AcceleratorID`/`Graph.Domains` dimension labeled `network.topology.nvidia.com/accelerator`. The fixed `leaf`, `spine`, and `core` keys and process-wide Helm/CLI label overrides are replaced by optional `fabricLabels` and `acceleratorLabel` parameters on the `k8s` engine.
 - Simulation model node names are now treated as hostnames; the model-backed test provider generates their instance IDs with an `i-` prefix.
@@ -33,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `kwok-nodes` now prevents model-provided metadata from overriding its required KWOK selector and model-derived `topograph.nvidia.com/instance` and `topograph.nvidia.com/region` annotations.
 - Slinky dynamic-node reconciliation now reuses listed Node annotations, skips unchanged nodes without a per-node GET, and patches only changed topology annotations, substantially reducing Kubernetes client-side throttling on large clusters.
 - Corrected DRA provider guidance to document its Slinky-only block-topology scope, dependency on pre-existing `nvidia.com/gpu.clique` labels, and inability to guide placement across NVLink partitions without backend-fabric topology.
 - The NFD engine now rejects an empty generated object set when cleanup is enabled, preserving the last published topology instead of deleting every Topograph-managed NFD object after an empty provider result or over-narrow node selection.

--- a/cmd/kwok-nodes/main_test.go
+++ b/cmd/kwok-nodes/main_test.go
@@ -29,4 +29,5 @@ func TestMainInternalWritesManifest(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, string(data), "kind: List")
 	require.Contains(t, string(data), "name: i21")
+	require.Contains(t, string(data), "accelerator.topology.test/domain: nvl2")
 }

--- a/demos/dra-slinky/demo.sh
+++ b/demos/dra-slinky/demo.sh
@@ -19,9 +19,15 @@ step "delete_cluster"
 
 step "./scripts/create-test-cluster.sh -m ./tests/models/large.yaml"
 
+step "kubectl --context \"$KUBE_CONTEXT\" get node"
+
 step "./demos/dra-slinky/update-labels.sh"
 
+step "kubectl --context \"$KUBE_CONTEXT\" get node srv4101 -o yaml | yq '.metadata.labels'"
+
 step "./demos/dra-slinky/deploy-slinky.sh"
+
+step "kubectl --context \"$KUBE_CONTEXT\" -n slurm get cm slurm-config-extra -o yaml"
 
 step "deploy_topograph demos/dra-slinky/values.dra-slinky.kwok.yaml"
 

--- a/demos/dra-slinky/update-labels.sh
+++ b/demos/dra-slinky/update-labels.sh
@@ -11,11 +11,9 @@ kubectl --context "$KUBE_CONTEXT" get nodes -l kwok.x-k8s.io/node=fake \
     -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' |
 while read -r node; do
     value=$(kubectl --context "$KUBE_CONTEXT" get node "$node" \
-        -o jsonpath='{.metadata.labels.network\.topology\.nvidia\.com/accelerator}')
+        -o jsonpath='{.metadata.annotations.accelerator\.topology\.test/domain}')
     if [ -n "$value" ]; then
         kubectl --context "$KUBE_CONTEXT" label node "$node" \
             "nvidia.com/gpu.clique=$value" "kubernetes.io/os=linux" --overwrite
-        kubectl --context "$KUBE_CONTEXT" label node "$node" \
-            network.topology.nvidia.com/accelerator-
     fi
 done

--- a/demos/test-k8s/demo.sh
+++ b/demos/test-k8s/demo.sh
@@ -19,7 +19,12 @@ step "delete_cluster"
 
 step "./scripts/create-test-cluster.sh -m ./tests/models/medium.yaml"
 
+step "kubectl --context \"$KUBE_CONTEXT\" get node"
+
+step "kubectl --context \"$KUBE_CONTEXT\" get node 1202 -o yaml | yq '.metadata.labels'"
+
 step "deploy_topograph demos/test-k8s/values.k8s.kwok.yaml"
 
 sleep 5
-step "kubectl --context \"$KUBE_CONTEXT\" describe no 1301 | head -15"
+step "kubectl --context \"$KUBE_CONTEXT\" get node 1202 -o yaml | yq '.metadata.labels'"
+

--- a/demos/test-nfd/demo.sh
+++ b/demos/test-nfd/demo.sh
@@ -19,10 +19,12 @@ step "delete_cluster"
 
 step "./scripts/create-test-cluster.sh -m ./tests/models/medium.yaml"
 
-step "kubectl --context \"$KUBE_CONTEXT\" label node \"\$(kubectl --context \"$KUBE_CONTEXT\" get nodes -l node-role.kubernetes.io/control-plane -o jsonpath='{.items[0].metadata.name}')\" nfd-enabled=true"
+step "kubectl --context \"$KUBE_CONTEXT\" get node"
 
 step "demos/test-nfd/deploy-nfd.sh"
 
 step "deploy_topograph demos/test-nfd/values.nfd.kwok.yaml"
 
 step "kubectl --context \"$KUBE_CONTEXT\" -n node-feature-discovery get nodefeaturegroups"
+
+step "kubectl --context \"$KUBE_CONTEXT\" -n node-feature-discovery get nodefeaturegroups -l topograph.nvidia.com/group-type=fabric-tier-1 -o yaml"

--- a/demos/test-nfd/deploy-nfd.sh
+++ b/demos/test-nfd/deploy-nfd.sh
@@ -7,6 +7,12 @@ set -e
 
 KUBE_CONTEXT="${KUBE_CONTEXT:-kind-topograph}"
 
+CONTROL_PLANE_LABEL="node-role.kubernetes.io/control-plane"
+
+control_plane_node=$(kubectl --context "$KUBE_CONTEXT" get nodes -l "$CONTROL_PLANE_LABEL" -o jsonpath='{.items[0].metadata.name}')
+
+kubectl --context "$KUBE_CONTEXT" label node "$control_plane_node" nfd-enabled=true
+
 helm repo add --force-update nfd https://kubernetes-sigs.github.io/node-feature-discovery/charts
 
 helm repo update

--- a/demos/utils.sh
+++ b/demos/utils.sh
@@ -13,7 +13,7 @@ step() {
     local reply
 
     echo
-    echo "\$ $command"
+    printf '\033[33m$ %s\033[0m\n' "$command"
     if read -rp "Run? [y/N] " reply; then
         case "$reply" in
             [yY]|[yY][eE][sS])
@@ -28,6 +28,8 @@ delete_cluster() {
 }
 
 deploy_topograph() {
+    helm uninstall topograph --kube-context "$KUBE_CONTEXT" --namespace topograph 2>/dev/null || true
+
     helm upgrade --install topograph charts/topograph \
         --kube-context "$KUBE_CONTEXT" \
         --namespace topograph --create-namespace --values "$1" --wait

--- a/docs/modeling.md
+++ b/docs/modeling.md
@@ -6,7 +6,7 @@ A model describes the same canonical topology that real providers eventually pro
 
 - A variable-depth switch tree, used for Slurm `topology/tree` output and Kubernetes `network.topology.nvidia.com/tier-N` labels
 - Node membership in one accelerator domain, used for block topology and the optional `network.topology.nvidia.com/accelerator` label
-- Optional per-node labels used by provider simulations
+- Optional per-node labels and provider-specific annotations used by provider simulations
 
 Model loading lives in `pkg/models`. Model fixtures live under `tests/models/`.
 
@@ -60,7 +60,8 @@ The utility uses the model-derived instance-to-hostname mapping, so model hostna
 - `topograph.nvidia.com/instance: i-1101`
 - `topograph.nvidia.com/region: <derived-region-or-none>`
 - `kwok.x-k8s.io/node=fake` as both a label and annotation
-- Model-derived labels such as `topology.kubernetes.io/region`, `topology.kubernetes.io/zone`, and `network.topology.nvidia.com/accelerator`
+- Model-derived labels such as `topology.kubernetes.io/region` and `topology.kubernetes.io/zone`
+- Model-derived annotations such as `accelerator.topology.test/domain`
 
 Generated Kubernetes node names come from model hostnames and are normalized to valid lowercase DNS names. For example, model hostname `I21` becomes Kubernetes node `i21`, while its generated instance ID `i-I21` is stored in `topograph.nvidia.com/instance`.
 
@@ -129,7 +130,7 @@ switches:
   ...
 ```
 
-`switches` is a map and `blocks` is a list. `blocks[].nodes` is where model files declare compute node names; it creates the node records, applies block labels, and optionally attaches those nodes to a leaf switch through `blocks[].switch`. `switches` may be omitted for block-only models.
+`switches` is a map and `blocks` is a list. `blocks[].nodes` is where model files declare compute node names; it creates the node records, applies block labels and annotations, and optionally attaches those nodes to a leaf switch through `blocks[].switch`. `switches` may be omitted for block-only models.
 
 ## Switches
 
@@ -138,6 +139,7 @@ The `switches` map describes the network hierarchy. Each key is the switch ID. E
 | Field | Description |
 |---|---|
 | `labels` | Labels inherited by descendant nodes. Common keys are `topology.kubernetes.io/region` and `topology.kubernetes.io/zone`. |
+| `annotations` | Provider-specific simulation metadata inherited by descendant nodes. Use `accelerator.topology.test/domain` for accelerator-domain membership and, where supported, `accelerator.topology.test/sub-domain` for a nested accelerator grouping. |
 | `switches` | Child switch IDs. |
 
 Example:
@@ -158,7 +160,7 @@ Switch rules:
 
 - A switch can have at most one parent switch.
 - Empty leaf switches may be omitted from the `switches` map. A child switch named in a parent's `switches` list is created automatically when it has no top-level definition.
-- A switch that defines labels or child switches must have a top-level entry.
+- A switch that defines labels, annotations, or child switches must have a top-level entry.
 - If a block names a switch with `blocks[].switch`, that block's `nodes` are attached to the switch before switch validation runs.
 
 ## Blocks
@@ -169,7 +171,8 @@ The `blocks` list describes sets of compute instances with similar hardware and 
 |---|---|
 | `switch` | Optional leaf switch ID. When set, this block's `nodes` are attached to that switch. |
 | `nodes` | Required non-empty list of hostnames in this block. Compact ranges are supported. The model-backed test provider generates each instance ID by prefixing the hostname with `i-`. |
-| `labels` | Optional labels applied to nodes generated from this block. For example, `network.topology.nvidia.com/accelerator` can identify an NVLink / accelerator domain. |
+| `labels` | Optional node labels applied to nodes generated from this block. |
+| `annotations` | Optional provider-specific simulation metadata applied to nodes generated from this block. Use `accelerator.topology.test/domain` to identify an accelerator domain. |
 
 Example:
 
@@ -177,8 +180,8 @@ Example:
 blocks:
 - switch: leaf1
   nodes: ["n[1-2]"]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl1
+  annotations:
+    accelerator.topology.test/domain: nvl1
 ```
 
 Block rules:
@@ -217,6 +220,7 @@ After YAML parsing, Topograph completes the model before simulation uses it:
 - Nodes are created from `blocks[].nodes`.
 - Node `NetLayers` is derived from the switch path from leaf to root.
 - Node labels are built by merging labels from the switch path and block labels.
+- Node annotations are built by merging annotations from the switch path and block annotations.
 - `Instances` is derived from node names and grouped by `labels.topology.kubernetes.io/region`; nodes without a region use `none`.
 
 These derived fields are not written in YAML.
@@ -235,36 +239,36 @@ switches:
 blocks:
 - switch: leaf
   nodes: ["n[1-2]"]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl1
+  annotations:
+    accelerator.topology.test/domain: nvl1
 - switch: leaf
   nodes: [n3]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl2
+  annotations:
+    accelerator.topology.test/domain: nvl2
 ```
 
 After loading:
 
 - `n1`, `n2`, and `n3` are hostnames mapped from instance IDs `i-n1`, `i-n2`, and `i-n3`
-- `n1` and `n2` belong to the first block and have `network.topology.nvidia.com/accelerator: nvl1` label
-- `n3` belongs to the second block and has `network.topology.nvidia.com/accelerator: nvl2` label
+- `n1` and `n2` belong to the first block and have the `accelerator.topology.test/domain: nvl1` annotation
+- `n3` belongs to the second block and has the `accelerator.topology.test/domain: nvl2` annotation
 - All three nodes have network layers `[leaf, core]`
 
 ### Blocks Without Switches
 
-This model omits `switches`. Nodes are still created, block labels are still applied, and generated instances have no network layers.
+This model omits `switches`. Nodes are still created, block metadata is still applied, and generated instances have no network layers.
 
 ```yaml
 blocks:
 - nodes: ["n[1-2]"]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl1
+  annotations:
+    accelerator.topology.test/domain: nvl1
 ```
 
 After loading:
 
 - `n1` and `n2` belong to the first block
-- `n1` and `n2` have `network.topology.nvidia.com/accelerator: nvl1` label
+- `n1` and `n2` have the `accelerator.topology.test/domain: nvl1` annotation
 - `n1` and `n2` have no network layers
 
 ## Simulating the API

--- a/internal/kwok/nodes.go
+++ b/internal/kwok/nodes.go
@@ -58,7 +58,6 @@ func NodesFromModel(model *models.Model, capacity Capacity) ([]*corev1.Node, err
 		return nil, err
 	}
 
-	instanceInfo := newInstanceInfo(model.Instances)
 	hostNames := make([]string, 0, len(model.Nodes))
 	for hostName := range model.Nodes {
 		hostNames = append(hostNames, hostName)
@@ -69,29 +68,21 @@ func NodesFromModel(model *models.Model, capacity Capacity) ([]*corev1.Node, err
 	seenNodeNames := make(map[string]string, len(hostNames))
 	for _, hostName := range hostNames {
 		instance := model.Nodes[hostName]
-		info := instanceInfo[hostName]
-		if info.instanceID == "" {
-			return nil, fmt.Errorf("model hostname %q has no instance ID mapping", hostName)
-		}
 		nodeName := kubernetesNodeName(hostName)
 		if seenHostName, ok := seenNodeNames[nodeName]; ok {
 			return nil, fmt.Errorf("model hostnames %q and %q resolve to duplicate Kubernetes node name %q", seenHostName, hostName, nodeName)
 		}
 		seenNodeNames[nodeName] = hostName
-		if info.region == "" {
-			info.region = "none"
-		}
 
-		labels := map[string]string{
-			NodeSelectorKey: NodeSelectorValue,
-		}
+		labels := make(map[string]string, len(instance.Labels)+1)
 		maps.Copy(labels, instance.Labels)
+		labels[NodeSelectorKey] = NodeSelectorValue
 
-		annotations := map[string]string{
-			NodeSelectorKey:          NodeSelectorValue,
-			topology.KeyNodeInstance: info.instanceID,
-			topology.KeyNodeRegion:   info.region,
-		}
+		annotations := make(map[string]string, len(instance.Annotations)+3)
+		maps.Copy(annotations, instance.Annotations)
+		annotations[NodeSelectorKey] = NodeSelectorValue
+		annotations[topology.KeyNodeInstance] = models.InstanceID(hostName)
+		annotations[topology.KeyNodeRegion] = instance.Labels[models.LabelTopologyRegion]
 
 		nodes = append(nodes, &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
@@ -190,24 +181,6 @@ func setResource(resources corev1.ResourceList, name corev1.ResourceName, value 
 	}
 	resources[name] = quantity
 	return nil
-}
-
-type nodeInfo struct {
-	instanceID string
-	region     string
-}
-
-func newInstanceInfo(instances []topology.ComputeInstances) map[string]nodeInfo {
-	info := make(map[string]nodeInfo)
-	for _, ci := range instances {
-		for instanceID, hostName := range ci.Instances {
-			info[hostName] = nodeInfo{
-				instanceID: instanceID,
-				region:     ci.Region,
-			}
-		}
-	}
-	return info
 }
 
 func kubernetesNodeName(name string) string {

--- a/internal/kwok/nodes_test.go
+++ b/internal/kwok/nodes_test.go
@@ -33,13 +33,14 @@ func TestNodesFromModel(t *testing.T) {
 	node := nodes[0]
 	require.Equal(t, "i21", node.Name)
 	require.Equal(t, map[string]string{
-		NodeSelectorKey:                 NodeSelectorValue,
-		topology.KeyTopologyAccelerator: "nvl2",
+		NodeSelectorKey:            NodeSelectorValue,
+		models.LabelTopologyRegion: "none",
 	}, node.Labels)
 	require.Equal(t, map[string]string{
-		NodeSelectorKey:          NodeSelectorValue,
-		topology.KeyNodeInstance: "i-I21",
-		topology.KeyNodeRegion:   "none",
+		NodeSelectorKey:                    NodeSelectorValue,
+		topology.KeyNodeInstance:           "i-I21",
+		topology.KeyNodeRegion:             "none",
+		"accelerator.topology.test/domain": "nvl2",
 	}, node.Annotations)
 	require.Equal(t, "kwok://i21", node.Spec.ProviderID)
 	require.Equal(t, resource.MustParse("8"), node.Status.Capacity[corev1.ResourceCPU])
@@ -50,7 +51,7 @@ func TestNodesFromModel(t *testing.T) {
 	require.Equal(t, node.Status.Capacity, node.Status.Allocatable)
 }
 
-func TestNodesFromModelUsesDerivedRegionAndLabels(t *testing.T) {
+func TestNodesFromModelUsesDerivedMetadata(t *testing.T) {
 	model, err := models.NewModelFromFile("../../tests/models/medium.yaml")
 	require.NoError(t, err)
 
@@ -69,7 +70,31 @@ func TestNodesFromModelUsesDerivedRegionAndLabels(t *testing.T) {
 	require.Equal(t, "us-west", node.Annotations[topology.KeyNodeRegion])
 	require.Equal(t, "us-west", node.Labels[models.LabelTopologyRegion])
 	require.Equal(t, "zone2", node.Labels[models.LabelTopologyZone])
-	require.Equal(t, "nvl3", node.Labels[topology.KeyTopologyAccelerator])
+	require.Equal(t, "nvl3", node.Annotations["accelerator.topology.test/domain"])
+}
+
+func TestNodesFromModelKeepsRequiredMetadata(t *testing.T) {
+	model, err := models.NewModelFromFile("../../tests/models/small-tree.yaml")
+	require.NoError(t, err)
+
+	instance := model.Nodes["I21"]
+	instance.Labels[NodeSelectorKey] = "overridden"
+	instance.Labels["custom-label"] = "value"
+	instance.Annotations[NodeSelectorKey] = "overridden"
+	instance.Annotations[topology.KeyNodeInstance] = "overridden"
+	instance.Annotations[topology.KeyNodeRegion] = "overridden"
+	instance.Annotations["custom-annotation"] = "value"
+
+	nodes, err := NodesFromModel(model, DefaultCapacity())
+	require.NoError(t, err)
+
+	node := nodes[0]
+	require.Equal(t, NodeSelectorValue, node.Labels[NodeSelectorKey])
+	require.Equal(t, "value", node.Labels["custom-label"])
+	require.Equal(t, NodeSelectorValue, node.Annotations[NodeSelectorKey])
+	require.Equal(t, "i-I21", node.Annotations[topology.KeyNodeInstance])
+	require.Equal(t, "none", node.Annotations[topology.KeyNodeRegion])
+	require.Equal(t, "value", node.Annotations["custom-annotation"])
 }
 
 func TestMarshalNodeManifest(t *testing.T) {
@@ -86,6 +111,7 @@ func TestMarshalNodeManifest(t *testing.T) {
 	require.Contains(t, manifest, "kind: List")
 	require.Contains(t, manifest, "name: i21")
 	require.Contains(t, manifest, "topograph.nvidia.com/instance: i-I21")
+	require.Contains(t, manifest, "accelerator.topology.test/domain: nvl2")
 }
 
 func TestCapacityRejectsInvalidQuantities(t *testing.T) {

--- a/pkg/models/model.go
+++ b/pkg/models/model.go
@@ -18,6 +18,7 @@ package models
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"sort"
@@ -30,29 +31,51 @@ import (
 )
 
 const (
-	LabelTopologyRegion = "topology.kubernetes.io/region"
-	LabelTopologyZone   = "topology.kubernetes.io/zone"
+	LabelTopologyRegion            = "topology.kubernetes.io/region"
+	LabelTopologyZone              = "topology.kubernetes.io/zone"
+	defaultRegion                  = "none"
+	annotationAcceleratorDomain    = "accelerator.topology.test/domain"
+	annotationAcceleratorSubDomain = "accelerator.topology.test/sub-domain"
 )
 
 // Switch is a switch vertex in a simulation model YAML tree (tests/models).
 type Switch struct {
-	Name     string            `yaml:"name,omitempty"`
-	Labels   map[string]string `yaml:"labels"`
-	Switches []string          `yaml:"switches"`
-	Nodes    []string          `yaml:"-"`
+	Name        string            `yaml:"name,omitempty"`
+	Labels      map[string]string `yaml:"labels"`
+	Annotations map[string]string `yaml:"annotations"`
+	Switches    []string          `yaml:"switches"`
+	Nodes       []string          `yaml:"-"`
 }
 
 // CapacityBlock is the blocks entry shape in simulation model YAML.
 type CapacityBlock struct {
-	Switch string            `yaml:"switch"`
-	Nodes  []string          `yaml:"nodes"`
-	Labels map[string]string `yaml:"labels"`
+	Switch      string            `yaml:"switch"`
+	Nodes       []string          `yaml:"nodes"`
+	Labels      map[string]string `yaml:"labels"`
+	Annotations map[string]string `yaml:"annotations"`
+}
+
+// Node is a compute instance in a simulation model. Annotations hold
+// provider-specific test inputs and are not exported as topology labels.
+type Node struct {
+	topology.Instance
+	Annotations map[string]string `yaml:"annotations"`
+}
+
+// AcceleratorDomain returns the simulated accelerator-domain identifier.
+func (node *Node) AcceleratorDomain() string {
+	return node.Annotations[annotationAcceleratorDomain]
+}
+
+// AcceleratorSubDomain returns the simulated accelerator sub-domain identifier.
+func (node *Node) AcceleratorSubDomain() string {
+	return node.Annotations[annotationAcceleratorSubDomain]
 }
 
 type Model struct {
-	Switches       map[string]*Switch            `yaml:"switches"`
-	Nodes          map[string]*topology.Instance `yaml:"-"`
-	CapacityBlocks []CapacityBlock               `yaml:"blocks"`
+	Switches       map[string]*Switch `yaml:"switches"`
+	Nodes          map[string]*Node   `yaml:"-"`
+	CapacityBlocks []CapacityBlock    `yaml:"blocks"`
 
 	// derived
 	Instances []topology.ComputeInstances `yaml:"-"`
@@ -181,15 +204,17 @@ func (m *Model) derive() error {
 	for hostName, node := range m.Nodes {
 		var netLayers []string
 		var labels map[string]string
+		var annotations map[string]string
 
 		if sw, ok := maps.switchByNode[hostName]; ok {
-			netLayers, labels, err = getNetworkLayers(sw, maps.parentBySwitch)
+			netLayers, labels, annotations, err = getNetworkLayers(sw, maps.parentBySwitch)
 			if err != nil {
 				return err
 			}
 		}
 
-		node.Labels = mergeLabels(labels, node.Labels)
+		node.Labels = withDefaultRegion(mergeMaps(labels, node.Labels))
+		node.Annotations = mergeMaps(annotations, node.Annotations)
 		node.NetLayers = netLayers
 		addInstanceRegion(regions, node.Labels, hostName)
 	}
@@ -217,14 +242,17 @@ func (m *Model) completeCapacityBlocks() error {
 		m.CapacityBlocks[capacityBlockIndex] = capacityBlock
 		for _, name := range capacityBlock.Nodes {
 			if m.Nodes == nil {
-				m.Nodes = make(map[string]*topology.Instance)
+				m.Nodes = make(map[string]*Node)
 			}
 			if _, ok := m.Nodes[name]; ok {
 				return fmt.Errorf("node %q belongs to more than one capacity block", name)
 			}
-			m.Nodes[name] = &topology.Instance{
-				ID:     name,
-				Labels: cloneStringMap(capacityBlock.Labels),
+			m.Nodes[name] = &Node{
+				Instance: topology.Instance{
+					ID:     name,
+					Labels: cloneStringMap(capacityBlock.Labels),
+				},
+				Annotations: cloneStringMap(capacityBlock.Annotations),
 			}
 		}
 	}
@@ -241,44 +269,44 @@ func appendUnique(values []string, value string) []string {
 	return append(values, value)
 }
 
-func setMapValue(values map[string]string, key, value string) map[string]string {
-	if values == nil {
-		values = make(map[string]string)
-	}
-	values[key] = value
-	return values
-}
-
 func cloneStringMap(values map[string]string) map[string]string {
 	if len(values) == 0 {
 		return nil
 	}
-	clone := make(map[string]string, len(values))
-	for k, v := range values {
-		clone[k] = v
-	}
-	return clone
+	return maps.Clone(values)
 }
 
-func mergeLabels(base, overlay map[string]string) map[string]string {
-	labels := cloneStringMap(base)
-	for k, v := range overlay {
-		labels = setMapValue(labels, k, v)
+// mergeMaps copies overlay into base, with overlay values taking precedence.
+func mergeMaps(base, overlay map[string]string) map[string]string {
+	if len(overlay) == 0 {
+		return base
 	}
+	if base == nil {
+		base = make(map[string]string, len(overlay))
+	}
+	maps.Copy(base, overlay)
+	return base
+}
+
+func withDefaultRegion(labels map[string]string) map[string]string {
+	if labels[LabelTopologyRegion] != "" {
+		return labels
+	}
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	labels[LabelTopologyRegion] = defaultRegion
 	return labels
 }
 
 func addInstanceRegion(regions map[string]map[string]string, labels map[string]string, hostName string) {
 	region := labels[LabelTopologyRegion]
-	if region == "" {
-		region = "none"
-	}
 	r, ok := regions[region]
 	if !ok {
 		r = make(map[string]string)
 		regions[region] = r
 	}
-	r[getInstanceID(hostName)] = hostName
+	r[InstanceID(hostName)] = hostName
 }
 
 func (m *Model) setInstances(regions map[string]map[string]string) {
@@ -297,7 +325,7 @@ func (m *Model) setInstances(regions map[string]map[string]string) {
 	}
 }
 
-func getNetworkLayers(sw *Switch, swmap map[string]*Switch) ([]string, map[string]string, error) {
+func getNetworkLayers(sw *Switch, swmap map[string]*Switch) ([]string, map[string]string, map[string]string, error) {
 	visited := make(map[string]struct{})
 	layers := []string{}
 	path := []*Switch{}
@@ -306,7 +334,7 @@ func getNetworkLayers(sw *Switch, swmap map[string]*Switch) ([]string, map[strin
 		name := sw.Name
 		// check for circular switch topology
 		if _, ok := visited[name]; ok {
-			return nil, nil, fmt.Errorf("circular dependency detected in topology for switch %q", name)
+			return nil, nil, nil, fmt.Errorf("circular dependency detected in topology for switch %q", name)
 		}
 		visited[name] = struct{}{}
 		layers = append(layers, name)
@@ -314,10 +342,12 @@ func getNetworkLayers(sw *Switch, swmap map[string]*Switch) ([]string, map[strin
 		parent, ok := swmap[name]
 		if !ok {
 			labels := map[string]string(nil)
+			annotations := map[string]string(nil)
 			for i := len(path) - 1; i >= 0; i-- {
-				labels = mergeLabels(labels, path[i].Labels)
+				labels = mergeMaps(labels, path[i].Labels)
+				annotations = mergeMaps(annotations, path[i].Annotations)
 			}
-			return layers, labels, nil
+			return layers, labels, annotations, nil
 		}
 		sw = parent
 	}
@@ -331,12 +361,12 @@ func (model *Model) ToGraph(instances []topology.ComputeInstances) (*topology.Gr
 	domainMap := topology.NewDomainMap()
 
 	for hostName := range model.Nodes {
-		instance2node[getInstanceID(hostName)] = hostName
+		instance2node[InstanceID(hostName)] = hostName
 	}
 
 	// Create all the vertices for each node.
 	for hostName := range model.Nodes {
-		instanceID := getInstanceID(hostName)
+		instanceID := InstanceID(hostName)
 		nodeVertexMap[hostName] = &topology.Vertex{
 			ID:   instanceID,
 			Name: instance2node[instanceID],
@@ -351,8 +381,8 @@ func (model *Model) ToGraph(instances []topology.ComputeInstances) (*topology.Gr
 
 	// Initializes accelerator-network membership.
 	for hostName, instance := range model.Nodes {
-		if domain := instance.AcceleratorID(); domain != "" {
-			instanceID := getInstanceID(hostName)
+		if domain := instance.AcceleratorDomain(); domain != "" {
+			instanceID := InstanceID(hostName)
 			domainMap.AddHost(domain, instanceID, instance2node[instanceID])
 		}
 	}
@@ -392,7 +422,7 @@ func (model *Model) graphInstanceMap(computeInstances []topology.ComputeInstance
 	instances := make(map[string]topology.Instance)
 
 	for hostName, inst := range model.Nodes {
-		instanceID := getInstanceID(hostName)
+		instanceID := InstanceID(hostName)
 		if len(wanted) != 0 {
 			if _, ok := wanted[instanceID]; !ok {
 				continue
@@ -430,6 +460,7 @@ func requestedInstanceIDs(computeInstances []topology.ComputeInstances) map[stri
 	return ids
 }
 
-func getInstanceID(hostName string) string {
+// InstanceID returns the simulated instance ID for a model hostname.
+func InstanceID(hostName string) string {
 	return fmt.Sprintf("i-%s", hostName)
 }

--- a/pkg/models/model_test.go
+++ b/pkg/models/model_test.go
@@ -25,11 +25,11 @@ import (
 	"github.com/NVIDIA/topograph/pkg/translate"
 )
 
-func acceleratorDomainLabels(domain string) map[string]string {
+func acceleratorDomainAnnotations(domain string) map[string]string {
 	if domain == "" {
 		return nil
 	}
-	return map[string]string{topology.KeyTopologyAccelerator: domain}
+	return map[string]string{annotationAcceleratorDomain: domain}
 }
 
 func TestNewModelFromFileMedium(t *testing.T) {
@@ -43,35 +43,37 @@ func TestNewModelFromFileMedium(t *testing.T) {
 	require.Equal(t, []string{"1101", "1102"}, cfg.Switches["sw11"].Nodes)
 	require.Equal(t, []CapacityBlock{
 		{
-			Switch: "sw11",
-			Nodes:  []string{"1101", "1102"},
-			Labels: acceleratorDomainLabels("nvl1"),
+			Switch:      "sw11",
+			Nodes:       []string{"1101", "1102"},
+			Annotations: acceleratorDomainAnnotations("nvl1"),
 		},
 		{
-			Switch: "sw12",
-			Nodes:  []string{"1201", "1202"},
-			Labels: acceleratorDomainLabels("nvl2"),
+			Switch:      "sw12",
+			Nodes:       []string{"1201", "1202"},
+			Annotations: acceleratorDomainAnnotations("nvl2"),
 		},
 		{
-			Switch: "sw13",
-			Nodes:  []string{"1301", "1302"},
-			Labels: acceleratorDomainLabels("nvl3"),
+			Switch:      "sw13",
+			Nodes:       []string{"1301", "1302"},
+			Annotations: acceleratorDomainAnnotations("nvl3"),
 		},
 		{
-			Switch: "sw14",
-			Nodes:  []string{"1401", "1402"},
-			Labels: acceleratorDomainLabels("nvl4"),
+			Switch:      "sw14",
+			Nodes:       []string{"1401", "1402"},
+			Annotations: acceleratorDomainAnnotations("nvl4"),
 		},
 	}, cfg.CapacityBlocks)
 
-	require.Equal(t, &topology.Instance{
-		ID: "1101",
-		Labels: map[string]string{
-			LabelTopologyRegion:             "us-west",
-			LabelTopologyZone:               "zone1",
-			topology.KeyTopologyAccelerator: "nvl1",
+	require.Equal(t, &Node{
+		Instance: topology.Instance{
+			ID: "1101",
+			Labels: map[string]string{
+				LabelTopologyRegion: "us-west",
+				LabelTopologyZone:   "zone1",
+			},
+			NetLayers: []string{"sw11", "sw21", "sw3"},
 		},
-		NetLayers: []string{"sw11", "sw21", "sw3"},
+		Annotations: acceleratorDomainAnnotations("nvl1"),
 	}, cfg.Nodes["1101"])
 
 	require.Equal(t, []topology.ComputeInstances{
@@ -99,14 +101,16 @@ func TestNewModelFromFileNVL72(t *testing.T) {
 	require.Len(t, cfg.CapacityBlocks, 4)
 	require.Len(t, cfg.Nodes, 72)
 
-	require.Equal(t, &topology.Instance{
-		ID: "node2215",
-		Labels: map[string]string{
-			LabelTopologyRegion:             "us-east",
-			LabelTopologyZone:               "zone1",
-			topology.KeyTopologyAccelerator: "nvl-2-2",
+	require.Equal(t, &Node{
+		Instance: topology.Instance{
+			ID: "node2215",
+			Labels: map[string]string{
+				LabelTopologyRegion: "us-east",
+				LabelTopologyZone:   "zone1",
+			},
+			NetLayers: []string{"leaf-2-2", "spine-2", "core"},
 		},
-		NetLayers: []string{"leaf-2-2", "spine-2", "core"},
+		Annotations: acceleratorDomainAnnotations("nvl-2-2"),
 	}, cfg.Nodes["node2215"])
 }
 
@@ -126,12 +130,12 @@ switches:
 blocks:
 - switch: leaf
   nodes: ["n[1-2]"]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl1
+  annotations:
+    accelerator.topology.test/domain: nvl1
 - switch: leaf
   nodes: [n3]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl2
+  annotations:
+    accelerator.topology.test/domain: nvl2
 `,
 			model: &Model{
 				Switches: map[string]*Switch{
@@ -141,33 +145,42 @@ blocks:
 					},
 					"leaf": {Name: "leaf", Nodes: []string{"n1", "n2", "n3"}},
 				},
-				Nodes: map[string]*topology.Instance{
+				Nodes: map[string]*Node{
 					"n1": {
-						ID:        "n1",
-						NetLayers: []string{"leaf", "core"},
-						Labels:    acceleratorDomainLabels("nvl1"),
+						Instance: topology.Instance{
+							ID:        "n1",
+							Labels:    map[string]string{LabelTopologyRegion: "none"},
+							NetLayers: []string{"leaf", "core"},
+						},
+						Annotations: acceleratorDomainAnnotations("nvl1"),
 					},
 					"n2": {
-						ID:        "n2",
-						NetLayers: []string{"leaf", "core"},
-						Labels:    acceleratorDomainLabels("nvl1"),
+						Instance: topology.Instance{
+							ID:        "n2",
+							Labels:    map[string]string{LabelTopologyRegion: "none"},
+							NetLayers: []string{"leaf", "core"},
+						},
+						Annotations: acceleratorDomainAnnotations("nvl1"),
 					},
 					"n3": {
-						ID:        "n3",
-						NetLayers: []string{"leaf", "core"},
-						Labels:    acceleratorDomainLabels("nvl2"),
+						Instance: topology.Instance{
+							ID:        "n3",
+							Labels:    map[string]string{LabelTopologyRegion: "none"},
+							NetLayers: []string{"leaf", "core"},
+						},
+						Annotations: acceleratorDomainAnnotations("nvl2"),
 					},
 				},
 				CapacityBlocks: []CapacityBlock{
 					{
-						Switch: "leaf",
-						Nodes:  []string{"n1", "n2"},
-						Labels: acceleratorDomainLabels("nvl1"),
+						Switch:      "leaf",
+						Nodes:       []string{"n1", "n2"},
+						Annotations: acceleratorDomainAnnotations("nvl1"),
 					},
 					{
-						Switch: "leaf",
-						Nodes:  []string{"n3"},
-						Labels: acceleratorDomainLabels("nvl2"),
+						Switch:      "leaf",
+						Nodes:       []string{"n3"},
+						Annotations: acceleratorDomainAnnotations("nvl2"),
 					},
 				},
 				Instances: []topology.ComputeInstances{
@@ -183,24 +196,30 @@ blocks:
 			cfg: `
 blocks:
 - nodes: ["n[1-2]"]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl1
+  annotations:
+    accelerator.topology.test/domain: nvl1
 `,
 			model: &Model{
-				Nodes: map[string]*topology.Instance{
+				Nodes: map[string]*Node{
 					"n1": {
-						ID:     "n1",
-						Labels: acceleratorDomainLabels("nvl1"),
+						Instance: topology.Instance{
+							ID:     "n1",
+							Labels: map[string]string{LabelTopologyRegion: "none"},
+						},
+						Annotations: acceleratorDomainAnnotations("nvl1"),
 					},
 					"n2": {
-						ID:     "n2",
-						Labels: acceleratorDomainLabels("nvl1"),
+						Instance: topology.Instance{
+							ID:     "n2",
+							Labels: map[string]string{LabelTopologyRegion: "none"},
+						},
+						Annotations: acceleratorDomainAnnotations("nvl1"),
 					},
 				},
 				CapacityBlocks: []CapacityBlock{
 					{
-						Nodes:  []string{"n1", "n2"},
-						Labels: acceleratorDomainLabels("nvl1"),
+						Nodes:       []string{"n1", "n2"},
+						Annotations: acceleratorDomainAnnotations("nvl1"),
 					},
 				},
 				Instances: []topology.ComputeInstances{
@@ -216,8 +235,8 @@ blocks:
 			cfg: `
 blocks:
 - nodes: [n1]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl1
+  annotations:
+    accelerator.topology.test/domain: nvl1
 - labels: {}
 `,
 			err: `capacity block at index 1 must declare at least one node`,
@@ -264,23 +283,32 @@ blocks:
 	}
 }
 
-func TestSwitchAndBlockLabelsMerge(t *testing.T) {
+func TestSwitchAndBlockMetadataMerge(t *testing.T) {
 	cfg := `
 switches:
   core:
     labels:
       topology.kubernetes.io/region: region1
       inherited: core
+    annotations:
+      core-annotation: core-value
+      inherited: core
     switches: [leaf]
   leaf:
     labels:
       topology.kubernetes.io/zone: zone1
+      inherited: leaf
+    annotations:
+      leaf-annotation: leaf-value
       inherited: leaf
 blocks:
 - switch: leaf
   nodes: [n1]
   labels:
     block-label: block-value
+    inherited: block
+  annotations:
+    block-annotation: block-value
     inherited: block
 `
 
@@ -293,6 +321,12 @@ blocks:
 		"inherited":         "block",
 		"block-label":       "block-value",
 	}, model.Nodes["n1"].Labels)
+	require.Equal(t, map[string]string{
+		"core-annotation":  "core-value",
+		"leaf-annotation":  "leaf-value",
+		"block-annotation": "block-value",
+		"inherited":        "block",
+	}, model.Nodes["n1"].Annotations)
 	require.Equal(t, []topology.ComputeInstances{
 		{
 			Region:    "region1",
@@ -308,8 +342,8 @@ switches:
 blocks:
 - switch: leaf
   nodes: [instance-1]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl1
+  annotations:
+    accelerator.topology.test/domain: nvl1
 `), "inline")
 	require.NoError(t, err)
 
@@ -325,6 +359,9 @@ blocks:
 		InstanceID: "i-instance-1",
 		HostName:   "instance-1",
 	}, graph.Domains["nvl1"]["instance-1"])
+	require.Equal(t, map[string]string{
+		LabelTopologyRegion: "none",
+	}, graph.Instances["i-instance-1"].Labels)
 }
 
 func TestToGraphKeepsModelHostNames(t *testing.T) {

--- a/pkg/providers/aws/provider_sim.go
+++ b/pkg/providers/aws/provider_sim.go
@@ -104,7 +104,7 @@ func (client *simClient) DescribeInstanceTopology(ctx context.Context, params *e
 				for j := len(node.NetLayers) - 1; j >= 0; j-- {
 					netLayers = append(netLayers, node.NetLayers[j])
 				}
-				domainID := node.Labels[topology.KeyTopologyAccelerator]
+				domainID := node.AcceleratorDomain()
 				instTopo := types.InstanceTopology{
 					InstanceId:       &instanceId,
 					AvailabilityZone: &az,

--- a/pkg/providers/aws/provider_sim_test.go
+++ b/pkg/providers/aws/provider_sim_test.go
@@ -46,12 +46,12 @@ switches:
 blocks:
 - switch: tor1
   nodes: [n11,n12]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl1
+  annotations:
+    accelerator.topology.test/domain: nvl1
 - switch: tor2
   nodes: [n21,n22]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl2
+  annotations:
+    accelerator.topology.test/domain: nvl2
 `
 
 	largeClusterModel = `
@@ -67,12 +67,12 @@ switches:
 blocks:
 - switch: tor1
   nodes: ["n[100-199]"]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl1
+  annotations:
+    accelerator.topology.test/domain: nvl1
 - switch: tor2
   nodes: ["n[200-299]"]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl2
+  annotations:
+    accelerator.topology.test/domain: nvl2
 `
 )
 
@@ -109,8 +109,8 @@ switches:
 blocks:
 - switch: tor
   nodes: [n11,n12]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl1
+  annotations:
+    accelerator.topology.test/domain: nvl1
 `,
 		},
 		{
@@ -147,8 +147,8 @@ switches:
 blocks:
 - switch: tor
   nodes: [n11]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl1
+  annotations:
+    accelerator.topology.test/domain: nvl1
 `,
 			region:    "region",
 			intervals: []interval{{11, 11}},

--- a/pkg/providers/dsx/provider_sim.go
+++ b/pkg/providers/dsx/provider_sim.go
@@ -61,7 +61,7 @@ func (client *simClient) GetTopology(ctx context.Context, _ string, nodeIDs []st
 				if !exists {
 					continue
 				}
-				swInfo.Nodes = append(swInfo.Nodes, NodeInfo{NodeID: nodeName, AcceleratedNetworkID: node.Labels[topology.KeyTopologyAccelerator]})
+				swInfo.Nodes = append(swInfo.Nodes, NodeInfo{NodeID: nodeName, AcceleratedNetworkID: node.AcceleratorDomain()})
 			}
 		} else {
 			//If it is not a leaf switch, add the child switches to the switch info

--- a/pkg/providers/dsx/provider_sim_test.go
+++ b/pkg/providers/dsx/provider_sim_test.go
@@ -34,12 +34,12 @@ switches:
 blocks:
 - switch: leaf1
   nodes: [n11,n12]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl1
+  annotations:
+    accelerator.topology.test/domain: nvl1
 - switch: leaf2
   nodes: [n21,n22]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl2
+  annotations:
+    accelerator.topology.test/domain: nvl2
 `
 
 	largeClusterModel = `
@@ -55,12 +55,12 @@ switches:
 blocks:
 - switch: leaf1
   nodes: ["n[100-164]"]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl1
+  annotations:
+    accelerator.topology.test/domain: nvl1
 - switch: leaf2
   nodes: ["n[200-264]"]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl2
+  annotations:
+    accelerator.topology.test/domain: nvl2
 `
 
 	singleNodeModel = `
@@ -71,8 +71,8 @@ switches:
 blocks:
 - switch: leaf
   nodes: [n1]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl1
+  annotations:
+    accelerator.topology.test/domain: nvl1
 `
 )
 

--- a/pkg/providers/gcp/provider_sim_test.go
+++ b/pkg/providers/gcp/provider_sim_test.go
@@ -41,8 +41,8 @@ switches:
 blocks:
 - switch: tor
   nodes: ["11"]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl1
+  annotations:
+    accelerator.topology.test/domain: nvl1
 `
 
 	clusterModel = `
@@ -56,12 +56,12 @@ switches:
 blocks:
 - switch: tor1
   nodes: ["11","12"]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl1
+  annotations:
+    accelerator.topology.test/domain: nvl1
 - switch: tor2
   nodes: ["21","22"]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl2
+  annotations:
+    accelerator.topology.test/domain: nvl2
 `
 )
 
@@ -124,8 +124,8 @@ switches:
 blocks:
 - switch: tor
   nodes: [n11]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl1
+  annotations:
+    accelerator.topology.test/domain: nvl1
 `,
 			instances: []topology.ComputeInstances{
 				{

--- a/pkg/providers/lambdai/provider_sim.go
+++ b/pkg/providers/lambdai/provider_sim.go
@@ -65,7 +65,7 @@ func (c *simClient) InstanceList(ctx context.Context, req *InstanceListRequest) 
 			NetworkPath: netPath,
 			//TODO: check whether the below mapping is correct
 			NVLink: &NVLinkInfo{
-				DomainID: node.Labels[topology.KeyTopologyAccelerator],
+				DomainID: node.AcceleratorDomain(),
 				CliqueID: "simulation",
 			},
 		}

--- a/pkg/providers/lambdai/provider_sim_test.go
+++ b/pkg/providers/lambdai/provider_sim_test.go
@@ -32,12 +32,12 @@ switches:
 blocks:
 - switch: tor1
   nodes: [n11,n12]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl1
+  annotations:
+    accelerator.topology.test/domain: nvl1
 - switch: tor2
   nodes: [n21,n22]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl2
+  annotations:
+    accelerator.topology.test/domain: nvl2
 `
 )
 

--- a/pkg/providers/nebius/provider_sim.go
+++ b/pkg/providers/nebius/provider_sim.go
@@ -60,7 +60,7 @@ func (c *simClient) GetComputeInstanceList(ctx context.Context, req *compute.Lis
 		node := c.model.Nodes[c.instanceIDs[indx]]
 		instance := &compute.Instance{
 			Spec: &compute.InstanceSpec{
-				NvlInstanceGroupId: node.Labels[topology.KeyTopologyAccelerator],
+				NvlInstanceGroupId: node.AcceleratorDomain(),
 			},
 			Status: &compute.InstanceStatus{},
 		}

--- a/pkg/providers/nebius/provider_sim_test.go
+++ b/pkg/providers/nebius/provider_sim_test.go
@@ -31,8 +31,8 @@ switches:
 blocks:
 - switch: tor
   nodes: ["11"]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl1
+  annotations:
+    accelerator.topology.test/domain: nvl1
 `
 
 	clusterModel = `
@@ -46,12 +46,12 @@ switches:
 blocks:
 - switch: tor1
   nodes: ["11","12"]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl1
+  annotations:
+    accelerator.topology.test/domain: nvl1
 - switch: tor2
   nodes: ["21","22"]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl2
+  annotations:
+    accelerator.topology.test/domain: nvl2
 `
 )
 

--- a/pkg/providers/nscale/provider_sim.go
+++ b/pkg/providers/nscale/provider_sim.go
@@ -56,7 +56,7 @@ func (c *simClient) Topology(ctx context.Context, _ string, pageSize, offset int
 			ID:          node.ID,
 			NetworkPath: path,
 		}
-		domainID := node.Labels[topology.KeyTopologyAccelerator]
+		domainID := node.AcceleratorDomain()
 		if domainID != "" {
 			instance.BlockID = &domainID
 		}

--- a/pkg/providers/nscale/provider_sim_test.go
+++ b/pkg/providers/nscale/provider_sim_test.go
@@ -30,12 +30,12 @@ switches:
 blocks:
 - switch: tor1
   nodes: [n11,n12]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl1
+  annotations:
+    accelerator.topology.test/domain: nvl1
 - switch: tor2
   nodes: [n21,n22]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl2
+  annotations:
+    accelerator.topology.test/domain: nvl2
 `
 )
 

--- a/pkg/providers/oci/provider_sim.go
+++ b/pkg/providers/oci/provider_sim.go
@@ -35,8 +35,6 @@ import (
 const (
 	NAME_SIM = "oci-sim"
 
-	labelTopologyRack = "test.topology/rack"
-
 	errNone = iota
 	errClientFactory
 	errListAvailabilityDomains
@@ -105,7 +103,7 @@ func (c *simClient) ListComputeHosts(ctx context.Context, req core.ListComputeHo
 				host.HpcIslandId = ptr.String(node.NetLayers[i])
 			}
 		}
-		domainID := node.Labels[topology.KeyTopologyAccelerator]
+		domainID := node.AcceleratorDomain()
 		if domainID != "" {
 			host.GpuMemoryFabricId = &domainID
 		}
@@ -147,11 +145,11 @@ func (c *simClient) GetComputeHost(ctx context.Context, req core.GetComputeHostR
 			host.HpcIslandId = ptr.String(node.NetLayers[i])
 		}
 	}
-	domainID := node.Labels[topology.KeyTopologyAccelerator]
+	domainID := node.AcceleratorDomain()
 	if domainID != "" {
 		host.GpuMemoryFabricId = &domainID
 	}
-	if rack, ok := node.Labels[labelTopologyRack]; ok {
+	if rack := node.AcceleratorSubDomain(); rack != "" {
 		host.AdditionalData = map[string]any{
 			"locationDetails": map[string]any{
 				"rack": rack,

--- a/pkg/providers/oci/provider_sim_test.go
+++ b/pkg/providers/oci/provider_sim_test.go
@@ -45,12 +45,12 @@ switches:
 blocks:
 - switch: tor1
   nodes: [n11,n12]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl1
+  annotations:
+    accelerator.topology.test/domain: nvl1
 - switch: tor2
   nodes: [n21,n22]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl2
+  annotations:
+    accelerator.topology.test/domain: nvl2
 `
 )
 

--- a/pkg/server/http_server_test.go
+++ b/pkg/server/http_server_test.go
@@ -191,7 +191,7 @@ BlockSizes=8,16,32
 }
 `
 
-	// graph engine returns compact JSON from instance labels embedded in the topology graph
+	// graph engine returns compact JSON from instances embedded in the topology graph
 	graphPayload = `
 {
   "provider": {
@@ -218,23 +218,23 @@ BlockSizes=8,16,32
   "instances": [
     {
       "id": "i-I21",
+      "labels": {
+        "topology.kubernetes.io/region": "none"
+      },
       "network_layers": [
         "S2",
         "S1"
-      ],
-      "labels": {
-        "network.topology.nvidia.com/accelerator": "nvl2"
-      }
+      ]
     },
     {
       "id": "i-I22",
+      "labels": {
+        "topology.kubernetes.io/region": "none"
+      },
       "network_layers": [
         "S2",
         "S1"
-      ],
-      "labels": {
-        "network.topology.nvidia.com/accelerator": "nvl2"
-      }
+      ]
     }
   ]
 }`

--- a/tests/models/dual-accelerator.yaml
+++ b/tests/models/dual-accelerator.yaml
@@ -70,72 +70,72 @@ blocks:
 - switch: leaf-1-1
   nodes:
   - "srv11[01-08]"
-  labels:
-    network.topology.nvidia.com/accelerator: nvl-1
-    test.topology/rack: "rack01"
+  annotations:
+    accelerator.topology.test/domain: nvl-1
+    accelerator.topology.test/sub-domain: "rack01"
 - switch: leaf-1-2
   nodes:
   - "srv12[01-08]"
-  labels:
-    network.topology.nvidia.com/accelerator: nvl-1
-    test.topology/rack: "rack02"
+  annotations:
+    accelerator.topology.test/domain: nvl-1
+    accelerator.topology.test/sub-domain: "rack02"
 - switch: leaf-2-1
   nodes:
   - "srv21[01-08]"
-  labels:
-    network.topology.nvidia.com/accelerator: nvl-1
-    test.topology/rack: "rack03"
+  annotations:
+    accelerator.topology.test/domain: nvl-1
+    accelerator.topology.test/sub-domain: "rack03"
 - switch: leaf-2-2
   nodes:
   - "srv22[01-08]"
-  labels:
-    network.topology.nvidia.com/accelerator: nvl-1
-    test.topology/rack: "rack04"
+  annotations:
+    accelerator.topology.test/domain: nvl-1
+    accelerator.topology.test/sub-domain: "rack04"
 - switch: leaf-3-1
   nodes:
   - "srv31[01-08]"
-  labels:
-    network.topology.nvidia.com/accelerator: nvl-1
-    test.topology/rack: "rack05"
+  annotations:
+    accelerator.topology.test/domain: nvl-1
+    accelerator.topology.test/sub-domain: "rack05"
 - switch: leaf-3-2
   nodes:
   - "srv32[01-08]"
-  labels:
-    network.topology.nvidia.com/accelerator: nvl-1
-    test.topology/rack: "rack06"
+  annotations:
+    accelerator.topology.test/domain: nvl-1
+    accelerator.topology.test/sub-domain: "rack06"
 - switch: leaf-4-1
   nodes:
   - "srv41[01-08]"
-  labels:
-    network.topology.nvidia.com/accelerator: nvl-2
-    test.topology/rack: "rack07"
+  annotations:
+    accelerator.topology.test/domain: nvl-2
+    accelerator.topology.test/sub-domain: "rack07"
 - switch: leaf-4-2
   nodes:
   - "srv42[01-08]"
-  labels:
-    network.topology.nvidia.com/accelerator: nvl-2
-    test.topology/rack: "rack08"
+  annotations:
+    accelerator.topology.test/domain: nvl-2
+    accelerator.topology.test/sub-domain: "rack08"
 - switch: leaf-5-1
   nodes:
   - "srv51[01-08]"
-  labels:
-    network.topology.nvidia.com/accelerator: nvl-2
-    test.topology/rack: "rack09"
+  annotations:
+    accelerator.topology.test/domain: nvl-2
+    accelerator.topology.test/sub-domain: "rack09"
 - switch: leaf-5-2
   nodes:
   - "srv52[01-08]"
-  labels:
-    network.topology.nvidia.com/accelerator: nvl-2
-    test.topology/rack: "rack10"
+  annotations:
+    accelerator.topology.test/domain: nvl-2
+    accelerator.topology.test/sub-domain: "rack10"
 - switch: leaf-6-1
   nodes:
   - "srv61[01-08]"
-  labels:
-    network.topology.nvidia.com/accelerator: nvl-2
-    test.topology/rack: "rack11"
+  annotations:
+    accelerator.topology.test/domain: nvl-2
+    accelerator.topology.test/sub-domain: "rack11"
 - switch: leaf-6-2
   nodes:
   - "srv62[01-08]"
-  labels:
-    network.topology.nvidia.com/accelerator: nvl-2
-    test.topology/rack: "rack12"
+  annotations:
+    accelerator.topology.test/domain: nvl-2
+    accelerator.topology.test/sub-domain: "rack12"

--- a/tests/models/large.yaml
+++ b/tests/models/large.yaml
@@ -68,60 +68,60 @@ blocks:
 - switch: leaf-1-1
   nodes:
   - "srv11[01-08]"
-  labels:
-    network.topology.nvidia.com/accelerator: nvl-1-1
+  annotations:
+    accelerator.topology.test/domain: nvl-1-1
 - switch: leaf-1-2
   nodes:
   - "srv12[01-08]"
-  labels:
-    network.topology.nvidia.com/accelerator: nvl-1-2
+  annotations:
+    accelerator.topology.test/domain: nvl-1-2
 - switch: leaf-2-1
   nodes:
   - "srv21[01-08]"
-  labels:
-    network.topology.nvidia.com/accelerator: nvl-2-1
+  annotations:
+    accelerator.topology.test/domain: nvl-2-1
 - switch: leaf-2-2
   nodes:
   - "srv22[01-08]"
-  labels:
-    network.topology.nvidia.com/accelerator: nvl-2-2
+  annotations:
+    accelerator.topology.test/domain: nvl-2-2
 - switch: leaf-3-1
   nodes:
   - "srv31[01-08]"
-  labels:
-    network.topology.nvidia.com/accelerator: nvl-3-1
+  annotations:
+    accelerator.topology.test/domain: nvl-3-1
 - switch: leaf-3-2
   nodes:
   - "srv32[01-08]"
-  labels:
-    network.topology.nvidia.com/accelerator: nvl-3-2
+  annotations:
+    accelerator.topology.test/domain: nvl-3-2
 - switch: leaf-4-1
   nodes:
   - "srv41[01-08]"
-  labels:
-    network.topology.nvidia.com/accelerator: nvl-4-1
+  annotations:
+    accelerator.topology.test/domain: nvl-4-1
 - switch: leaf-4-2
   nodes:
   - "srv42[01-08]"
-  labels:
-    network.topology.nvidia.com/accelerator: nvl-4-2
+  annotations:
+    accelerator.topology.test/domain: nvl-4-2
 - switch: leaf-5-1
   nodes:
   - "srv51[01-08]"
-  labels:
-    network.topology.nvidia.com/accelerator: nvl-5-1
+  annotations:
+    accelerator.topology.test/domain: nvl-5-1
 - switch: leaf-5-2
   nodes:
   - "srv52[01-08]"
-  labels:
-    network.topology.nvidia.com/accelerator: nvl-5-2
+  annotations:
+    accelerator.topology.test/domain: nvl-5-2
 - switch: leaf-6-1
   nodes:
   - "srv61[01-08]"
-  labels:
-    network.topology.nvidia.com/accelerator: nvl-6-1
+  annotations:
+    accelerator.topology.test/domain: nvl-6-1
 - switch: leaf-6-2
   nodes:
   - "srv62[01-08]"
-  labels:
-    network.topology.nvidia.com/accelerator: nvl-6-2
+  annotations:
+    accelerator.topology.test/domain: nvl-6-2

--- a/tests/models/medium.yaml
+++ b/tests/models/medium.yaml
@@ -40,20 +40,20 @@ blocks:
 - switch: sw11
   nodes:
   - "[1101-1102]"
-  labels:
-    network.topology.nvidia.com/accelerator: nvl1
+  annotations:
+    accelerator.topology.test/domain: nvl1
 - switch: sw12
   nodes:
   - "[1201-1202]"
-  labels:
-    network.topology.nvidia.com/accelerator: nvl2
+  annotations:
+    accelerator.topology.test/domain: nvl2
 - switch: sw13
   nodes:
   - "[1301-1302]"
-  labels:
-    network.topology.nvidia.com/accelerator: nvl3
+  annotations:
+    accelerator.topology.test/domain: nvl3
 - switch: sw14
   nodes:
   - "[1401-1402]"
-  labels:
-    network.topology.nvidia.com/accelerator: nvl4
+  annotations:
+    accelerator.topology.test/domain: nvl4

--- a/tests/models/nvl72.yaml
+++ b/tests/models/nvl72.yaml
@@ -40,20 +40,20 @@ blocks:
 - switch: leaf-1-1
   nodes:
   - node[1101-1118]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl-1-1
+  annotations:
+    accelerator.topology.test/domain: nvl-1-1
 - switch: leaf-1-2
   nodes:
   - node[1201-1218]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl-1-2
+  annotations:
+    accelerator.topology.test/domain: nvl-1-2
 - switch: leaf-2-1
   nodes:
   - node[2101-2118]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl-2-1
+  annotations:
+    accelerator.topology.test/domain: nvl-2-1
 - switch: leaf-2-2
   nodes:
   - node[2201-2218]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl-2-2
+  annotations:
+    accelerator.topology.test/domain: nvl-2-2

--- a/tests/models/small-tree.yaml
+++ b/tests/models/small-tree.yaml
@@ -20,9 +20,9 @@ switches:
 blocks:
 - switch: S2
   nodes: ["I[21-22]", "I25"]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl2
+  annotations:
+    accelerator.topology.test/domain: nvl2
 - switch: S3
   nodes: ["I[34-36]"]
-  labels:
-    network.topology.nvidia.com/accelerator: nvl3
+  annotations:
+    accelerator.topology.test/domain: nvl3


### PR DESCRIPTION
## Description
Move accelerator domain and sub-domain data from node labels to
simulation-specific annotations. Update simulated providers and the DRA
Slinky demo to consume the annotations and create required labels.
