### PR TITLE
feat(slinky): stable block IDs via blockHostnameRegex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - OCI labels missing from `docker/metadata-action` on the Topograph container image: `org.opencontainers.image.documentation`, `authors`, and `vendor` ([#377](https://github.com/NVIDIA/topograph/pull/377)).
 - Helm chart metadata: `home`, `icon`, `maintainers`, `keywords`, and Artifact Hub annotations ([#377](https://github.com/NVIDIA/topograph/pull/377)).
+- **Slinky engine**: `blockHostnameRegex` engine parameter and per-partition topology field. When set, physical block IDs are derived from a decimal capture in each node's hostname (`block<digits>`), keeping NVRx-compatible block names stable across pod-scale events. Every selected physical Kubernetes node contributes to the block inventory whether or not it has a Ready slurmd pod, and blocks with no live members are emitted as empty declarations so retained node annotations remain valid. See [`docs/engines/slinky.md`](docs/engines/slinky.md) for the full contract, including validation rules and non-goals.
+- **Node observer**: Kubernetes Node updates now trigger topology regeneration when block-relevant metadata changes (`topograph.nvidia.com/instance`, `topograph.nvidia.com/region`, `topograph.nvidia.com/cluster-id`, `nvidia.com/gpu.clique`, or the node name). Status-only updates are ignored to keep the trailing-delay queue quiet.
 
 ### Fixed
 
 - Helm node-observer now targets the rendered Topograph Service fullname in `generateTopologyUrl`.
+- **Slinky engine**: block topology names no longer shift positionally when slurmd pods scale. Previously, removing every pod in a block could cause other blocks to be renumbered as their positional index shifted (`block2 -> block1`), breaking NVRx and any consumer that depended on stable `block<number>` names. With `blockHostnameRegex` configured, block names are derived from a stable regex capture over hostnames and no longer depend on the Ready-pod ordering.
+- **Slinky engine**: `blockHostnameRegex` set only on a per-partition topology no longer falls back to positional block IDs. `translate.NewNetworkTopology` now derives an effective cluster-wide regex from either the top-level `blockHostnameRegex` or a consistent per-partition value, and rejects configs where multiple non-empty values disagree.
+- **Slinky engine**: per-partition block topology no longer emits `block_sizes: [0]` when `blockHostnameRegex` is configured and `blockSizes` is left unset. Empty stable-ID declarations are skipped when the base block size is auto-derived from live domains.
+- **Slinky engine**: per-partition block topology now falls back to flat when regex is configured but there is no physical inventory to declare, rather than emitting an empty `blocks: []` block topology unit.
 
 ## [0.5.0] - 2026-06-30
 

--- a/charts/topograph/values.schema.json
+++ b/charts/topograph/values.schema.json
@@ -53,7 +53,7 @@
             },
             "params": {
               "type": "object",
-              "description": "Engine-specific parameters. For slinky, useGpuCliqueLabel=true reads nvidia.com/gpu.clique as the topology/block domain source."
+              "description": "Engine-specific parameters. For slinky, useGpuCliqueLabel=true reads nvidia.com/gpu.clique as the topology/block domain source. For slinky topology/block, blockHostnameRegex extracts a decimal capture from each node's hostname (e.g., 'd(\\d+)-T\\d+' captures '002' from 'nvl72d002-T01') and emits it as the block name; this stabilizes block IDs across pod-scale events for NVRx compatibility."
             }
           },
           "required": ["name"]

--- a/charts/topograph/values.slinky.block-example.yaml
+++ b/charts/topograph/values.slinky.block-example.yaml
@@ -21,6 +21,12 @@ global:
       plugin: topology/block
       blockSizes: [4]
       # useGpuCliqueLabel: true
+      # blockHostnameRegex extracts a decimal capture from each node's
+      # hostname and uses it as the emitted block name (e.g., "block002").
+      # Required for NVRx-compatible naming: block IDs stay stable across
+      # pod-scale events instead of shifting positionally. See
+      # docs/engines/slinky.md for the full contract.
+      # blockHostnameRegex: 'd(\d+)-T\d+'
       topologyConfigPath: topology.conf
       topologyConfigmapName: slurm-config
       useDynamicNodes: false

--- a/docs/engines/slinky.md
+++ b/docs/engines/slinky.md
@@ -100,6 +100,74 @@ global:
 
 If `useGpuCliqueLabel` is enabled for a block topology and no matching nodes have the `nvidia.com/gpu.clique` label plus the Topograph instance annotation, topology generation fails with a `502` error instead of falling back to provider accelerator domains.
 
+### Stable block names with `blockHostnameRegex` (NVRx compatibility)
+
+For NVRx and any other consumer that expects `block<number>` names to remain the same across pod-scale events, set `blockHostnameRegex` on the block topology. The regex extracts a decimal capture from each node's hostname and uses those digits as the emitted block name (`block<digits>`), preserving leading zeros.
+
+```yaml
+global:
+  engine:
+    name: slinky
+    params:
+      namespace: ns-slinky
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/component: compute
+      plugin: topology/block
+      blockSizes: [1]
+      topologyConfigmapName: slurm-config
+      topologyConfigPath: topology.conf
+      blockHostnameRegex: 'd(\d+)-T\d+'   # captures "002" from "nvl72d002-T01"
+```
+
+The same field can be set per partition (with an identical value across partitions and, if provided, the cluster-wide value):
+
+```yaml
+global:
+  engineParams:
+    topologies:
+      gpu-block:
+        plugin: topology/block
+        blockSizes: [4]
+        podSelector:
+          matchLabels:
+            app.kubernetes.io/component: compute
+        blockHostnameRegex: 'd(\d+)-T\d+'
+```
+
+Contract enforced by the engine:
+
+- Applies only to `topology/block`; setting `blockHostnameRegex` on `topology/tree` or `topology/flat` is rejected at load time.
+- The regex must compile and contain exactly one non-optional capture group.
+- The captured value on every selected hostname must be a non-empty decimal string. Non-numeric or empty captures are rejected.
+- All hosts in a physical block must produce the same captured index (validated per domain).
+- Different physical blocks must not produce the same captured index (duplicate emitted block ID is rejected).
+- `configUpdateMode: none` is rejected because Topograph cannot guarantee that the externally managed topology config declares the same block names the annotations reference.
+- If a physical block would need to be split across multiple base blocks (`blockSizes[0]` smaller than the block's host count), generation fails with an actionable error rather than emitting suffixed IDs.
+
+Which hostname the regex is applied to:
+
+- For a Kubernetes node with a `Ready` slurmd pod, the regex runs against the pod's SLURM node name (from the `slurm.node.name` label, falling back to `pod.spec.hostname`). This is the same name that later appears in the emitted `topology.conf`.
+- For a Kubernetes node without a `Ready` slurmd pod (physical inventory only), the regex runs against the Kubernetes node name so the block can still be declared before any pod runs.
+- If your Kubernetes node names and SLURM node names use different formats, keep the capture group derived from the shared physical suffix (e.g. `d(\d+)-T\d+`) so both hostname sources produce the same captured index. Otherwise nodes with no live pod would land in a different block than nodes with a live pod.
+
+Regex authoring tips:
+
+- Anchor the pattern when the digit suffix is fixed-width or the hostname format is known: `^nvl72d(\d+)-T\d+$` is safer than `d(\d+)-T\d+` because it rejects incidental matches on unrelated hostnames instead of silently grouping them into a block. The engine does not anchor for you.
+- Non-matching hostnames are skipped with a `V(4)` log line, not treated as errors. If every node fails to match, generation returns a `502` with the regex value; verify the regex against the actual SLURM/Kubernetes node names.
+
+Guarantees the regex provides:
+
+- Physical blocks (identified by regex capture) keep their emitted `block<digits>` name across pod scale events. Removing every pod in a block leaves the block declared with zero hosts; when the pods return the block name is unchanged.
+- Every physical block selected by the engine's node/pod selectors is declared in the topology, whether or not it currently has a Ready slurmd pod. Blocks with no live members are emitted as empty `BlockName=block<digits>` lines so retained `topology.slinky.slurm.net/spec` annotations keep resolving to a valid block.
+- Adding or removing a physical block does not renumber any other block: only the affected block's declaration changes.
+- Padding slots introduced by `blockSizes` alignment use the distinct `block-pad-<n>` prefix so they never collide with physical block IDs.
+
+Non-goals of this fix:
+
+- Long-lived stability across arbitrary physical hardware changes. If the underlying hostname pattern itself changes (rename, redeployment with a different regex source), block names may change. The regex is the identity source; keep it consistent for the lifetime of the cluster.
+- Persistent block-ID allocation. Topograph does not remember previous captures. Two nodes with the same captured index remain in the same block; if a physical block is decommissioned its digits are no longer emitted.
+
 ## ConfigMap Annotations
 
 Slinky automatically adds metadata annotations to managed ConfigMaps for improved observability:

--- a/pkg/engines/slinky/engine.go
+++ b/pkg/engines/slinky/engine.go
@@ -172,6 +172,36 @@ func getParameters(params engines.Config) (*Params, error) {
 		}
 	}
 
+	// blockHostnameRegex requires Topograph to own topology.conf.
+	if p.ConfigUpdateMode == ConfigUpdateModeNone {
+		if p.BlockHostnameRegex != "" {
+			return nil, fmt.Errorf("blockHostnameRegex is incompatible with configUpdateMode %q", ConfigUpdateModeNone)
+		}
+		for name, t := range p.Topologies {
+			if t != nil && t.BlockHostnameRegex != "" {
+				return nil, fmt.Errorf("topology %q: blockHostnameRegex is incompatible with configUpdateMode %q",
+					name, ConfigUpdateModeNone)
+			}
+		}
+	}
+
+	// A single regex regroups the full physical inventory, so all non-empty
+	// values must agree.
+	effective := p.BlockHostnameRegex
+	for name, t := range p.Topologies {
+		if t == nil || t.BlockHostnameRegex == "" {
+			continue
+		}
+		if effective == "" {
+			effective = t.BlockHostnameRegex
+			continue
+		}
+		if t.BlockHostnameRegex != effective {
+			return nil, fmt.Errorf("topology %q: blockHostnameRegex %q conflicts with cluster-wide or another partition value %q",
+				name, t.BlockHostnameRegex, effective)
+		}
+	}
+
 	return p, nil
 }
 
@@ -310,6 +340,95 @@ func withGPUCliqueDomains(graph *topology.Graph, clusterNodes *clusterNodes) (*t
 	return graph, nil
 }
 
+// hostnameForBlockRegex returns the string that the block hostname regex
+// matches: the SLURM node name for Ready nodes, otherwise the K8s node name so
+// pod-less nodes can still be assigned a physical block.
+func hostnameForBlockRegex(nodeName string, nodeMap map[string]string) string {
+	if slurmName, ok := nodeMap[nodeName]; ok && slurmName != "" {
+		return slurmName
+	}
+	return nodeName
+}
+
+// withHostnameRegexDomains rebuilds graph.Domains by grouping physical nodes
+// via a hostname regex; captured digits form the DomainMap key so translate
+// emits stable `block<digits>` names. Nodes without a Ready slurmd pod are
+// recorded via EnsureDomain so their block remains declared.
+func withHostnameRegexDomains(graph *topology.Graph, clusterNodes *clusterNodes, rawRegex string) (*topology.Graph, *httperr.Error) {
+	matcher, err := translate.CompileBlockHostnameRegex(rawRegex)
+	if err != nil {
+		return nil, httperr.NewError(http.StatusBadRequest, err.Error())
+	}
+	if matcher == nil {
+		return nil, httperr.NewError(http.StatusInternalServerError,
+			"withHostnameRegexDomains called with empty blockHostnameRegex")
+	}
+
+	domains := topology.NewDomainMap()
+
+	// Skip non-matching hostnames; only fail when no node matched at all.
+	for _, node := range clusterNodes.nodes.Items {
+		hostname := hostnameForBlockRegex(node.Name, clusterNodes.nodeMap)
+		digits, ok, err := matcher.MatchDigits(hostname)
+		if err != nil {
+			klog.Warningf("blockHostnameRegex=%q: %v; skipping node %s",
+				rawRegex, err, node.Name)
+			continue
+		}
+		if !ok {
+			klog.V(4).Infof("blockHostnameRegex=%q did not match hostname %q for node %s, skipping",
+				rawRegex, hostname, node.Name)
+			continue
+		}
+
+		slurmName, live := clusterNodes.nodeMap[node.Name]
+		if !live || slurmName == "" {
+			domains.EnsureDomain(digits)
+			klog.V(4).Infof("Physical inventory node %s in block %s (no Ready pod)", node.Name, digits)
+			continue
+		}
+
+		instance := node.Annotations[topology.KeyNodeInstance]
+		if instance == "" {
+			instance = node.Name
+		}
+		domains.AddHost(digits, instance, slurmName)
+	}
+
+	if len(domains) == 0 {
+		return nil, httperr.NewError(http.StatusBadGateway,
+			fmt.Sprintf("blockHostnameRegex=%q matched no nodes; check the selector and regex", rawRegex))
+	}
+
+	if graph == nil {
+		graph = &topology.Graph{}
+	} else {
+		cloned := *graph
+		graph = &cloned
+	}
+	graph.Domains = domains
+
+	return graph, nil
+}
+
+// resolveHostnameRegex returns the effective blockHostnameRegex, preferring
+// the engine-level value and falling back to any per-partition value.
+// Conflicts are rejected in getParameters.
+func (p *Params) resolveHostnameRegex() string {
+	if p == nil {
+		return ""
+	}
+	if p.BlockHostnameRegex != "" {
+		return p.BlockHostnameRegex
+	}
+	for _, t := range p.Topologies {
+		if t != nil && t.BlockHostnameRegex != "" {
+			return t.BlockHostnameRegex
+		}
+	}
+	return ""
+}
+
 func usesBlockTopology(cfg *translate.Config) bool {
 	if cfg == nil {
 		return false
@@ -375,12 +494,23 @@ func (eng *SlinkyEngine) GenerateOutput(ctx context.Context, graph *topology.Gra
 		return clusterNodeData, httpErr
 	}
 
+	// gpu.clique and blockHostnameRegex are mutually exclusive re-groupings of
+	// the provider graph's Domains map; gpu.clique wins when both are set.
 	if p.UseGPUCliqueLabel && usesBlockTopology(cfg) {
 		clusterNodeData, httpErr := loadClusterNodes()
 		if httpErr != nil {
 			return nil, httpErr
 		}
 		graph, httpErr = withGPUCliqueDomains(graph, clusterNodeData)
+		if httpErr != nil {
+			return nil, httpErr
+		}
+	} else if regex := p.resolveHostnameRegex(); regex != "" && usesBlockTopology(cfg) {
+		clusterNodeData, httpErr := loadClusterNodes()
+		if httpErr != nil {
+			return nil, httpErr
+		}
+		graph, httpErr = withHostnameRegexDomains(graph, clusterNodeData, regex)
 		if httpErr != nil {
 			return nil, httpErr
 		}

--- a/pkg/engines/slinky/engine_test.go
+++ b/pkg/engines/slinky/engine_test.go
@@ -516,6 +516,65 @@ func makeReadySlurmdPod(name, nodeName, slurmName string) *corev1.Pod {
 	}
 }
 
+// createPhysicalNodes creates K8s nodes with a KeyNodeInstance annotation so
+// they appear as physical inventory to the Slinky engine.
+func createPhysicalNodes(t *testing.T, ctx context.Context, client *fake.Clientset, names []string) {
+	t.Helper()
+	for i, name := range names {
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        name,
+				Annotations: map[string]string{topology.KeyNodeInstance: fmt.Sprintf("i-%d", i)},
+			},
+		}
+		_, err := client.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+}
+
+// reconcileReadySlurmdPods deletes any slurmd pods whose node is not in
+// k8sNodes and creates Ready slurmd pods for those that are, so subsequent
+// engine calls observe exactly the requested Ready set.
+func reconcileReadySlurmdPods(t *testing.T, ctx context.Context, client *fake.Clientset, namespace string, k8sNodes []string) {
+	t.Helper()
+	want := make(map[string]bool, len(k8sNodes))
+	for _, name := range k8sNodes {
+		want[name] = true
+	}
+
+	existing, err := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+
+	have := make(map[string]bool, len(existing.Items))
+	for _, pod := range existing.Items {
+		nodeName := pod.Spec.NodeName
+		if want[nodeName] {
+			have[nodeName] = true
+			continue
+		}
+		require.NoError(t, client.CoreV1().Pods(namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}))
+	}
+
+	for _, k8sName := range k8sNodes {
+		if have[k8sName] {
+			continue
+		}
+		pod := makeReadySlurmdPod("pod-"+k8sName, k8sName, k8sName)
+		_, err := client.CoreV1().Pods(namespace).Create(ctx, pod, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+}
+
+// readConfigMapKey returns the raw string stored at key inside the given
+// ConfigMap. Used by tests that assert on the topology config emitted by
+// GenerateOutput.
+func readConfigMapKey(t *testing.T, ctx context.Context, client *fake.Clientset, namespace, name, key string) string {
+	t.Helper()
+	cm, err := client.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+	require.NoError(t, err)
+	return cm.Data[key]
+}
+
 func TestResolveSlurmNodeName(t *testing.T) {
 	testCases := []struct {
 		name string
@@ -1185,4 +1244,474 @@ func TestGetParametersTopologyValidation(t *testing.T) {
 			require.ErrorContains(t, err, `cannot set both nodes and podSelector`)
 		})
 	}
+}
+
+// TestGetParametersBlockHostnameRegexValidation verifies parameter-time
+// validation for blockHostnameRegex: it must be compatible with the config
+// update mode and must not disagree between engine-level and per-partition
+// settings.
+func TestGetParametersBlockHostnameRegexValidation(t *testing.T) {
+	baseParams := func(extras map[string]any) map[string]any {
+		p := map[string]any{
+			topology.KeyNamespace:         "test-ns",
+			topology.KeyPodSelector:       map[string]any{"matchLabels": map[string]string{"app": "slurm"}},
+			topology.KeyTopoConfigPath:    "topology.conf",
+			topology.KeyTopoConfigmapName: "slurm-config",
+		}
+		for k, v := range extras {
+			p[k] = v
+		}
+		return p
+	}
+
+	t.Run("regex with configUpdateMode none is rejected", func(t *testing.T) {
+		params := baseParams(map[string]any{
+			"blockHostnameRegex": `d(\d+)-T\d+`,
+			"configUpdateMode":   "none",
+		})
+		_, err := getParameters(params)
+		require.ErrorContains(t, err, `blockHostnameRegex is incompatible with configUpdateMode "none"`)
+	})
+
+	t.Run("per-partition regex with configUpdateMode none is rejected", func(t *testing.T) {
+		params := baseParams(map[string]any{
+			"configUpdateMode": "none",
+			"topologies": map[string]any{
+				"gpu-block": map[string]any{
+					"plugin":             topology.TopologyBlock,
+					"nodes":              []string{"n1"},
+					"blockHostnameRegex": `d(\d+)-T\d+`,
+				},
+			},
+		})
+		_, err := getParameters(params)
+		require.ErrorContains(t, err, `blockHostnameRegex is incompatible with configUpdateMode "none"`)
+	})
+
+	t.Run("conflicting per-partition regex is rejected", func(t *testing.T) {
+		params := baseParams(map[string]any{
+			"topologies": map[string]any{
+				"a": map[string]any{
+					"plugin":             topology.TopologyBlock,
+					"nodes":              []string{"n1"},
+					"blockHostnameRegex": `d(\d+)-T\d+`,
+				},
+				"b": map[string]any{
+					"plugin":             topology.TopologyBlock,
+					"nodes":              []string{"n2"},
+					"blockHostnameRegex": `nvl(\d+)`,
+				},
+			},
+		})
+		_, err := getParameters(params)
+		require.ErrorContains(t, err, `conflicts with cluster-wide or another partition value`)
+	})
+
+	t.Run("matching engine and partition regex is accepted", func(t *testing.T) {
+		params := baseParams(map[string]any{
+			"blockHostnameRegex": `d(\d+)-T\d+`,
+			"topologies": map[string]any{
+				"gpu-block": map[string]any{
+					"plugin":             topology.TopologyBlock,
+					"nodes":              []string{"n1"},
+					"blockHostnameRegex": `d(\d+)-T\d+`,
+				},
+			},
+		})
+		p, err := getParameters(params)
+		require.NoError(t, err)
+		require.Equal(t, `d(\d+)-T\d+`, p.BlockHostnameRegex)
+	})
+}
+
+// TestWithHostnameRegexDomainsPhysicalInventory verifies that
+// withHostnameRegexDomains includes every selected physical Kubernetes node,
+// whether or not it has a Ready slurmd pod. Live nodes contribute host entries
+// keyed by their SLURM name; nodes without a Ready pod ensure the block
+// remains declared with zero live hosts so its ID stays reserved.
+func TestWithHostnameRegexDomainsPhysicalInventory(t *testing.T) {
+	ctx := context.Background()
+	client := fake.NewSimpleClientset()
+
+	nodes := []*corev1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "nvl72d001-T01",
+				Annotations: map[string]string{topology.KeyNodeInstance: "instance-0"},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "nvl72d002-T01",
+				Annotations: map[string]string{topology.KeyNodeInstance: "instance-1"},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				// No Ready pod for this physical node: still contributes an
+				// empty block declaration so retained topology annotations
+				// stay valid.
+				Name:        "nvl72d003-T01",
+				Annotations: map[string]string{topology.KeyNodeInstance: "instance-2"},
+			},
+		},
+	}
+	for _, node := range nodes {
+		_, err := client.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+	for _, pod := range []*corev1.Pod{
+		makeReadySlurmdPod("pod-0", "nvl72d001-T01", "nvl72d001-T01"),
+		makeReadySlurmdPod("pod-1", "nvl72d002-T01", "nvl72d002-T01"),
+	} {
+		_, err := client.CoreV1().Pods("test-ns").Create(ctx, pod, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	eng := &SlinkyEngine{
+		client: client,
+		params: &Params{
+			Namespace:   "test-ns",
+			podListOpt:  &metav1.ListOptions{LabelSelector: "app=slinky"},
+			nodeListOpt: &metav1.ListOptions{},
+		},
+	}
+	clusterNodes, httpErr := eng.getClusterNodes(ctx)
+	require.Nil(t, httpErr)
+
+	got, httpErr := withHostnameRegexDomains(&topology.Graph{}, clusterNodes, `d(\d+)-T\d+`)
+	require.Nil(t, httpErr)
+	require.NotNil(t, got)
+
+	// Every physical block is declared. Blocks 001 and 002 hold their Ready
+	// pod's SLURM name; block 003 exists with zero hosts.
+	require.Contains(t, got.Domains, "001")
+	require.Contains(t, got.Domains, "002")
+	require.Contains(t, got.Domains, "003")
+
+	require.Len(t, got.Domains["001"], 1)
+	require.Contains(t, got.Domains["001"], "nvl72d001-T01")
+	require.Len(t, got.Domains["002"], 1)
+	require.Contains(t, got.Domains["002"], "nvl72d002-T01")
+	require.Len(t, got.Domains["003"], 0, "block 003 has no Ready pod and must be empty")
+}
+
+// TestWithHostnameRegexDomainsRejectsInvalidRegex verifies validation.
+// Regex-level errors (syntax, capture count) fail up front; per-hostname
+// data errors are logged and skipped, only failing hard when no node matches.
+func TestWithHostnameRegexDomainsRejectsInvalidRegex(t *testing.T) {
+	baseNodes := &corev1.NodeList{
+		Items: []corev1.Node{
+			{ObjectMeta: metav1.ObjectMeta{Name: "nvl72d001-T01"}},
+		},
+	}
+	cn := &clusterNodes{nodes: baseNodes, nodeMap: map[string]string{}}
+
+	t.Run("invalid regex", func(t *testing.T) {
+		_, err := withHostnameRegexDomains(&topology.Graph{}, cn, `d(\d+`)
+		require.NotNil(t, err)
+		require.Contains(t, err.Error(), "invalid blockHostnameRegex")
+	})
+	t.Run("multiple capture groups", func(t *testing.T) {
+		_, err := withHostnameRegexDomains(&topology.Graph{}, cn, `d(\d+)-T(\d+)`)
+		require.NotNil(t, err)
+		require.Contains(t, err.Error(), "exactly one capture group")
+	})
+	t.Run("non-matching hostname is skipped", func(t *testing.T) {
+		_, err := withHostnameRegexDomains(&topology.Graph{}, cn, `sn(\d+)`)
+		require.NotNil(t, err)
+		require.Contains(t, err.Error(), "matched no nodes")
+	})
+	t.Run("non-decimal capture is skipped", func(t *testing.T) {
+		_, err := withHostnameRegexDomains(&topology.Graph{}, cn, `nvl72d(\d+-T)\d+`)
+		require.NotNil(t, err)
+		require.Contains(t, err.Error(), "matched no nodes")
+	})
+	t.Run("partial match succeeds", func(t *testing.T) {
+		mixed := &corev1.NodeList{
+			Items: []corev1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "nvl72d001-T01"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "unrelated-node"}},
+			},
+		}
+		graph, err := withHostnameRegexDomains(&topology.Graph{}, &clusterNodes{
+			nodes: mixed, nodeMap: map[string]string{"nvl72d001-T01": "nvl72d001-T01"},
+		}, `d(\d+)-T\d+`)
+		require.Nil(t, err)
+		require.NotNil(t, graph)
+		require.Contains(t, graph.Domains, "001")
+	})
+}
+
+// TestGenerateOutputPodScaleStability verifies the pod-scale fix end-to-end
+// against a single shared client and engine across pod add/remove
+// transitions, so each phase asserts against the ConfigMap left by the
+// previous generation.
+func TestGenerateOutputPodScaleStability(t *testing.T) {
+	ctx := context.Background()
+	client := fake.NewSimpleClientset()
+
+	physical := []string{"nvl72d001-T01", "nvl72d002-T01", "nvl72d003-T01"}
+	createPhysicalNodes(t, ctx, client, physical)
+
+	eng := &SlinkyEngine{
+		client: client,
+		params: &Params{
+			BaseParams: slurm.BaseParams{
+				Plugin:             topology.TopologyBlock,
+				BlockSizes:         []int{1},
+				BlockHostnameRegex: `d(\d+)-T\d+`,
+			},
+			Namespace:       "test-ns",
+			ConfigMapName:   "slurm-config",
+			ConfigPath:      "topology.conf",
+			UseDynamicNodes: true,
+			podListOpt:      &metav1.ListOptions{LabelSelector: "app=slinky"},
+			nodeListOpt:     &metav1.ListOptions{},
+		},
+	}
+	readTopology := func() string {
+		return readConfigMapKey(t, ctx, client, "test-ns", "slurm-config", "topology.conf")
+	}
+
+	// Initial state: all three pods Ready.
+	reconcileReadySlurmdPods(t, ctx, client, "test-ns", physical)
+	result, httpErr := eng.GenerateOutput(ctx, &topology.Graph{Domains: topology.NewDomainMap()}, nil)
+	require.Nil(t, httpErr)
+	require.Equal(t, []byte("OK\n"), result)
+
+	initial := readTopology()
+	require.Contains(t, initial, "BlockName=block001 Nodes=nvl72d001-T01")
+	require.Contains(t, initial, "BlockName=block002 Nodes=nvl72d002-T01")
+	require.Contains(t, initial, "BlockName=block003 Nodes=nvl72d003-T01")
+
+	// Pod scale: remove the pod backing block 002. Block 002 stays declared,
+	// blocks 001/003 keep their IDs, no renumbering occurs.
+	reconcileReadySlurmdPods(t, ctx, client, "test-ns", []string{"nvl72d001-T01", "nvl72d003-T01"})
+	_, httpErr = eng.GenerateOutput(ctx, &topology.Graph{Domains: topology.NewDomainMap()}, nil)
+	require.Nil(t, httpErr)
+
+	afterScale := readTopology()
+	require.Contains(t, afterScale, "BlockName=block001 Nodes=nvl72d001-T01")
+	require.Contains(t, afterScale, "BlockName=block002\n", "block002 should stay declared but empty when its pod leaves")
+	require.NotContains(t, afterScale, "BlockName=block002 Nodes=", "block002 must not point to a different physical block after pod removal")
+	require.Contains(t, afterScale, "BlockName=block003 Nodes=nvl72d003-T01",
+		"block003 must not be renamed to block002 when block002's pod leaves")
+
+	// Pod returns: ConfigMap must match the initial byte string exactly.
+	reconcileReadySlurmdPods(t, ctx, client, "test-ns", physical)
+	_, httpErr = eng.GenerateOutput(ctx, &topology.Graph{Domains: topology.NewDomainMap()}, nil)
+	require.Nil(t, httpErr)
+	require.Equal(t, initial, readTopology(),
+		"topology.conf must return to the exact initial state when the missing pod returns")
+}
+
+// TestGenerateOutputSkeletonOnlyWithRegex verifies skeleton-only mode
+// preserves stable block IDs and declares every physical block with no
+// Nodes= line.
+func TestGenerateOutputSkeletonOnlyWithRegex(t *testing.T) {
+	ctx := context.Background()
+	client := fake.NewSimpleClientset()
+
+	physical := []string{"nvl72d001-T01", "nvl72d002-T01", "nvl72d003-T01"}
+	createPhysicalNodes(t, ctx, client, physical)
+	reconcileReadySlurmdPods(t, ctx, client, "test-ns", physical)
+
+	eng := &SlinkyEngine{
+		client: client,
+		params: &Params{
+			BaseParams: slurm.BaseParams{
+				Plugin:             topology.TopologyBlock,
+				BlockSizes:         []int{1},
+				BlockHostnameRegex: `d(\d+)-T\d+`,
+			},
+			Namespace:        "test-ns",
+			ConfigMapName:    "slurm-config",
+			ConfigPath:       "topology.conf",
+			ConfigUpdateMode: ConfigUpdateModeSkeletonOnly,
+			UseDynamicNodes:  true,
+			podListOpt:       &metav1.ListOptions{LabelSelector: "app=slinky"},
+			nodeListOpt:      &metav1.ListOptions{},
+		},
+	}
+
+	_, httpErr := eng.GenerateOutput(ctx, &topology.Graph{Domains: topology.NewDomainMap()}, nil)
+	require.Nil(t, httpErr)
+
+	cm, err := client.CoreV1().ConfigMaps("test-ns").Get(ctx, "slurm-config", metav1.GetOptions{})
+	require.NoError(t, err)
+	got := cm.Data["topology.conf"]
+
+	for _, id := range []string{"block001", "block002", "block003"} {
+		require.Contains(t, got, "BlockName="+id+"\n",
+			"skeleton-only + regex must declare %s without a Nodes= line", id)
+	}
+	require.NotContains(t, got, " Nodes=",
+		"skeleton-only output must not contain Nodes= entries: %s", got)
+}
+
+// TestGenerateOutputRejectsSplitInStableIDMode verifies the plan's
+// "one captured index identifies one emitted physical base block" contract:
+// if blockSizes[0] is smaller than a physical block's host count, generation
+// fails with an actionable error rather than emitting suffixed IDs.
+func TestGenerateOutputRejectsSplitInStableIDMode(t *testing.T) {
+	ctx := context.Background()
+	client := fake.NewSimpleClientset()
+
+	// Two physical nodes share the same captured index (both are in block 001).
+	// blockSizes[0]=1 would require splitting them into two base blocks.
+	physical := []string{"nvl72d001-T01", "nvl72d001-T02"}
+	createPhysicalNodes(t, ctx, client, physical)
+	reconcileReadySlurmdPods(t, ctx, client, "test-ns", physical)
+
+	eng := &SlinkyEngine{
+		client: client,
+		params: &Params{
+			BaseParams: slurm.BaseParams{
+				Plugin:             topology.TopologyBlock,
+				BlockSizes:         []int{1, 2},
+				BlockHostnameRegex: `d(\d+)-T\d+`,
+			},
+			Namespace:       "test-ns",
+			ConfigMapName:   "slurm-config",
+			ConfigPath:      "topology.conf",
+			UseDynamicNodes: true,
+			podListOpt:      &metav1.ListOptions{LabelSelector: "app=slinky"},
+			nodeListOpt:     &metav1.ListOptions{},
+		},
+	}
+	_, httpErr := eng.GenerateOutput(ctx, &topology.Graph{Domains: topology.NewDomainMap()}, nil)
+	require.NotNil(t, httpErr)
+	require.Contains(t, httpErr.Error(), "would be split")
+}
+
+// TestWithHostnameRegexDomainsPrefersSlurmNameForLiveNodes pins the
+// documented hostname-source contract: live nodes are grouped by the digit
+// captured from the SLURM name (the string that appears in topology.conf);
+// nodes without a Ready pod fall back to the Kubernetes node name.
+func TestWithHostnameRegexDomainsPrefersSlurmNameForLiveNodes(t *testing.T) {
+	ctx := context.Background()
+	client := fake.NewSimpleClientset()
+
+	// K8s node "worker-42" hosts a Ready slurmd pod whose SLURM name is
+	// "nvl72d001-T01". The regex captures "001" from the SLURM name and
+	// "42" from the K8s name. Ready node must group into block 001.
+	live := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "worker-42",
+			Annotations: map[string]string{topology.KeyNodeInstance: "i-live"},
+		},
+	}
+	_, err := client.CoreV1().Nodes().Create(ctx, live, metav1.CreateOptions{})
+	require.NoError(t, err)
+	// Non-Ready node without a slurmd pod. Its K8s name yields digits "99".
+	nonReady := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "worker-99",
+		},
+	}
+	_, err = client.CoreV1().Nodes().Create(ctx, nonReady, metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = client.CoreV1().Pods("test-ns").Create(ctx,
+		makeReadySlurmdPod("pod-live", "worker-42", "nvl72d001-T01"), metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	eng := &SlinkyEngine{
+		client: client,
+		params: &Params{
+			Namespace:   "test-ns",
+			podListOpt:  &metav1.ListOptions{LabelSelector: "app=slinky"},
+			nodeListOpt: &metav1.ListOptions{},
+		},
+	}
+	cn, httpErr := eng.getClusterNodes(ctx)
+	require.Nil(t, httpErr)
+
+	// Regex matches decimal digits after either "d" or "worker-".
+	got, httpErr := withHostnameRegexDomains(&topology.Graph{}, cn, `(?:d|worker-)(\d+)`)
+	require.Nil(t, httpErr)
+	require.NotNil(t, got)
+
+	// Live node routed by SLURM-name capture "001".
+	require.Contains(t, got.Domains, "001")
+	require.Contains(t, got.Domains["001"], "nvl72d001-T01",
+		"live node must group by SLURM-name capture, not K8s-name capture")
+
+	// Non-Ready node routed by K8s-name capture "99".
+	require.Contains(t, got.Domains, "99")
+	require.Empty(t, got.Domains["99"], "non-Ready node must contribute an empty declaration")
+
+	// The live node's K8s-name capture "42" must not create a spurious block.
+	require.NotContains(t, got.Domains, "42",
+		"live node's K8s-name capture must not create a separate block")
+}
+
+// TestGenerateOutputPodScaleStabilityPerPartition mirrors
+// TestGenerateOutputPodScaleStability but exercises the per-partition code
+// path (getBlockTopologyUnit / blockNameForPartition) instead of the
+// cluster-wide toBlockTopology path. Both C1 (blockInfo.id propagation with
+// empty BlockSizes) and M1 (empty block declaration for zero-live-pod
+// blocks) live in the per-partition path.
+func TestGenerateOutputPodScaleStabilityPerPartition(t *testing.T) {
+	ctx := context.Background()
+	client := fake.NewSimpleClientset()
+
+	physical := []string{"nvl72d001-T01", "nvl72d002-T01", "nvl72d003-T01"}
+	createPhysicalNodes(t, ctx, client, physical)
+
+	eng := &SlinkyEngine{
+		client: client,
+		params: &Params{
+			Namespace:     "test-ns",
+			ConfigMapName: "slurm-config",
+			ConfigPath:    "topology.conf",
+			Topologies: map[string]*Topology{
+				"gpu-block": {
+					Topology: slurm.Topology{
+						Plugin:             topology.TopologyBlock,
+						BlockSizes:         []int{1},
+						BlockHostnameRegex: `d(\d+)-T\d+`,
+						Nodes:              physical,
+					},
+				},
+			},
+			UseDynamicNodes: true,
+			podListOpt:      &metav1.ListOptions{LabelSelector: "app=slinky"},
+			nodeListOpt:     &metav1.ListOptions{},
+		},
+	}
+	readTopology := func() string {
+		return readConfigMapKey(t, ctx, client, "test-ns", "slurm-config", "topology.conf")
+	}
+
+	reconcileReadySlurmdPods(t, ctx, client, "test-ns", physical)
+	_, httpErr := eng.GenerateOutput(ctx, &topology.Graph{Domains: topology.NewDomainMap()}, nil)
+	require.Nil(t, httpErr)
+	initial := readTopology()
+	require.Contains(t, initial, "block: block001")
+	require.Contains(t, initial, "block: block002")
+	require.Contains(t, initial, "block: block003")
+	require.Contains(t, initial, "nodes: nvl72d001-T01")
+	require.Contains(t, initial, "nodes: nvl72d003-T01")
+
+	// Remove block002's pod: the empty declaration must remain and no
+	// block gets renumbered.
+	reconcileReadySlurmdPods(t, ctx, client, "test-ns", []string{"nvl72d001-T01", "nvl72d003-T01"})
+	_, httpErr = eng.GenerateOutput(ctx, &topology.Graph{Domains: topology.NewDomainMap()}, nil)
+	require.Nil(t, httpErr)
+	afterScale := readTopology()
+	require.Contains(t, afterScale, "block: block001")
+	require.Contains(t, afterScale, "block: block002",
+		"block002 must remain declared even after its pod leaves")
+	require.Contains(t, afterScale, "block: block003",
+		"block003 must not be renamed to block002 when block002's pod leaves")
+	require.Contains(t, afterScale, "nodes: nvl72d001-T01")
+	require.Contains(t, afterScale, "nodes: nvl72d003-T01")
+
+	// Pod returns: config must return to the exact initial state.
+	reconcileReadySlurmdPods(t, ctx, client, "test-ns", physical)
+	_, httpErr = eng.GenerateOutput(ctx, &topology.Graph{Domains: topology.NewDomainMap()}, nil)
+	require.Nil(t, httpErr)
+	require.Equal(t, initial, readTopology(),
+		"per-partition topology must return to the exact initial state when the missing pod returns")
 }

--- a/pkg/engines/slurm/slurm.go
+++ b/pkg/engines/slurm/slurm.go
@@ -49,16 +49,18 @@ const NAME = "slurm"
 type SlurmEngine struct{}
 
 type BaseParams struct {
-	Plugin     string `mapstructure:"plugin"`
-	BlockSizes []int  `mapstructure:"blockSizes"`
+	Plugin             string `mapstructure:"plugin"`
+	BlockSizes         []int  `mapstructure:"blockSizes"`
+	BlockHostnameRegex string `mapstructure:"blockHostnameRegex"` // stable block IDs from a decimal hostname capture; topology/block only
 }
 
 type Topology struct {
-	Partition  string   `mapstructure:"partition"`
-	Plugin     string   `mapstructure:"plugin"`
-	BlockSizes []int    `mapstructure:"blockSizes"`
-	Nodes      []string `mapstructure:"nodes"`
-	Default    bool     `mapstructure:"clusterDefault"`
+	Partition          string   `mapstructure:"partition"`
+	Plugin             string   `mapstructure:"plugin"`
+	BlockSizes         []int    `mapstructure:"blockSizes"`
+	Nodes              []string `mapstructure:"nodes"`
+	Default            bool     `mapstructure:"clusterDefault"`
+	BlockHostnameRegex string   `mapstructure:"blockHostnameRegex"` // per-partition override for BaseParams.BlockHostnameRegex
 }
 
 type Params struct {
@@ -282,8 +284,9 @@ func GetTranslateConfig(ctx context.Context, params *BaseParams, topologies map[
 	}
 
 	cfg := &translate.Config{
-		Plugin:     params.Plugin,
-		BlockSizes: params.BlockSizes,
+		Plugin:             params.Plugin,
+		BlockSizes:         params.BlockSizes,
+		BlockHostnameRegex: params.BlockHostnameRegex,
 	}
 
 	// set per-partition topologies
@@ -293,10 +296,16 @@ func GetTranslateConfig(ctx context.Context, params *BaseParams, topologies map[
 			if err := validateBlockSizes(sect.BlockSizes); err != nil {
 				return nil, httperr.NewError(http.StatusBadRequest, fmt.Sprintf("topology %q: %v", topo, err))
 			}
+			// Inherit the cluster-wide regex when the partition does not override it.
+			partitionRegex := sect.BlockHostnameRegex
+			if partitionRegex == "" {
+				partitionRegex = params.BlockHostnameRegex
+			}
 			spec := &translate.TopologySpec{
-				Plugin:         sect.Plugin,
-				BlockSizes:     sect.BlockSizes,
-				ClusterDefault: sect.Default,
+				Plugin:             sect.Plugin,
+				BlockSizes:         sect.BlockSizes,
+				ClusterDefault:     sect.Default,
+				BlockHostnameRegex: partitionRegex,
 			}
 			klog.InfoS("Adding partition topology", "name", topo, "plugin", sect.Plugin, "default", sect.Default, "partition", sect.Partition)
 			if sect.Nodes != nil {

--- a/pkg/engines/slurm/slurm_test.go
+++ b/pkg/engines/slurm/slurm_test.go
@@ -343,6 +343,60 @@ func TestGetTranslateConfig(t *testing.T) {
 			},
 			err: `topology "topo": blockSizes[1]=6 must be a power-of-two multiple of blockSizes[0]=2`,
 		},
+		{
+			// Cluster-wide BlockHostnameRegex flows through to translate.Config
+			// so translate can derive stable NVRx-compatible block IDs.
+			name: "Case 9: cluster-wide blockHostnameRegex propagates",
+			params: &BaseParams{
+				Plugin:             topology.TopologyBlock,
+				BlockSizes:         []int{1},
+				BlockHostnameRegex: `d(\d+)-T\d+`,
+			},
+			cfg: &translate.Config{
+				Plugin:             topology.TopologyBlock,
+				BlockSizes:         []int{1},
+				BlockHostnameRegex: `d(\d+)-T\d+`,
+			},
+		},
+		{
+			// Per-partition BlockHostnameRegex propagates to each partition
+			// TopologySpec. When only the cluster-wide value is set, all
+			// partitions inherit it so consumers see one authoritative regex.
+			name: "Case 10: per-partition blockHostnameRegex inherits and overrides",
+			params: &BaseParams{
+				BlockHostnameRegex: `d(\d+)-T\d+`,
+			},
+			topologies: map[string]*Topology{
+				"inherit": {
+					Plugin:     topology.TopologyBlock,
+					BlockSizes: []int{1},
+					Nodes:      []string{"n1"},
+				},
+				"override": {
+					Plugin:             topology.TopologyBlock,
+					BlockSizes:         []int{1},
+					Nodes:              []string{"n2"},
+					BlockHostnameRegex: `nvl(\d+)`,
+				},
+			},
+			cfg: &translate.Config{
+				BlockHostnameRegex: `d(\d+)-T\d+`,
+				Topologies: map[string]*translate.TopologySpec{
+					"inherit": {
+						Plugin:             topology.TopologyBlock,
+						BlockSizes:         []int{1},
+						Nodes:              []string{"n1"},
+						BlockHostnameRegex: `d(\d+)-T\d+`,
+					},
+					"override": {
+						Plugin:             topology.TopologyBlock,
+						BlockSizes:         []int{1},
+						Nodes:              []string{"n2"},
+						BlockHostnameRegex: `nvl(\d+)`,
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/node_observer/status_informer.go
+++ b/pkg/node_observer/status_informer.go
@@ -20,7 +20,24 @@ import (
 	"github.com/NVIDIA/topograph/internal/httperr"
 	"github.com/NVIDIA/topograph/internal/httpreq"
 	"github.com/NVIDIA/topograph/internal/k8s"
+	"github.com/NVIDIA/topograph/pkg/topology"
 )
+
+// nodeTopologyLabels lists labels that participate in physical block
+// identification (grouping and mapping). Any change to these values should
+// trigger topology regeneration; unrelated label churn should be ignored to
+// keep the trailing-delay queue quiet.
+var nodeTopologyLabels = []string{
+	topology.KeyNvidiaGPUClique,
+}
+
+// nodeTopologyAnnotations lists annotations that participate in physical
+// block identification. See nodeTopologyLabels for the rationale.
+var nodeTopologyAnnotations = []string{
+	topology.KeyNodeInstance,
+	topology.KeyNodeRegion,
+	topology.KeyGpuClusterID,
+}
 
 type StatusInformer struct {
 	ctx           context.Context
@@ -161,7 +178,25 @@ func (s *StatusInformer) startNodeInformer() error {
 					s.sendRequest()
 				}
 			},
-			//UpdateFunc: func(_, obj any) {} // TODO: clarify the change in node that would require topology update
+			UpdateFunc: func(oldObj, newObj any) {
+				oldNode, ok := oldObj.(*corev1.Node)
+				if !ok {
+					return
+				}
+				newNode, ok := newObj.(*corev1.Node)
+				if !ok {
+					return
+				}
+				// Only re-request when metadata that influences physical
+				// block identity changed. Node status transitions (heartbeat,
+				// conditions) fire updates constantly; ignoring them prevents
+				// unnecessary regeneration and keeps stable block names stable.
+				if !nodeTopologyMetadataChanged(oldNode, newNode) {
+					return
+				}
+				klog.V(4).Infof("Informer updated node %s (topology metadata changed)", newNode.Name)
+				s.sendRequest()
+			},
 			DeleteFunc: func(obj any) {
 				switch v := obj.(type) {
 				case *corev1.Node:
@@ -182,6 +217,34 @@ func (s *StatusInformer) startNodeInformer() error {
 		s.nodeFactory.WaitForCacheSync(s.ctx.Done())
 	}
 	return nil
+}
+
+// nodeTopologyMetadataChanged reports whether the node fields that drive
+// physical block identification changed between old and new. It compares:
+//   - Node name (blockHostnameRegex source when no Ready pod is present)
+//   - Selected annotations that identify the physical block (see nodeTopologyAnnotations)
+//   - Selected labels used by domain grouping (see nodeTopologyLabels)
+//
+// Any other update (status transitions, addresses, capacity) is ignored so
+// the topology request queue is not flooded during normal cluster operation.
+func nodeTopologyMetadataChanged(oldNode, newNode *corev1.Node) bool {
+	if oldNode == nil || newNode == nil {
+		return true
+	}
+	if oldNode.Name != newNode.Name {
+		return true
+	}
+	for _, key := range nodeTopologyAnnotations {
+		if oldNode.Annotations[key] != newNode.Annotations[key] {
+			return true
+		}
+	}
+	for _, key := range nodeTopologyLabels {
+		if oldNode.Labels[key] != newNode.Labels[key] {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *StatusInformer) startAPIServerInformer() error {

--- a/pkg/node_observer/status_informer_test.go
+++ b/pkg/node_observer/status_informer_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/NVIDIA/topograph/internal/httperr"
 	"github.com/NVIDIA/topograph/internal/httpreq"
+	"github.com/NVIDIA/topograph/pkg/topology"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -256,4 +257,62 @@ func makeContainerStatus(name string, ready bool, restarts int32) corev1.Contain
 		status.State.Running = &corev1.ContainerStateRunning{}
 	}
 	return status
+}
+
+// TestNodeTopologyMetadataChanged verifies the filter that decides whether a
+// Kubernetes node Update event should trigger topology regeneration. It must:
+//   - Return true when relevant labels/annotations change (source of block ID).
+//   - Return false for irrelevant changes (status, unrelated labels).
+//   - Return true for a name change (regex source when no Ready pod exists).
+func TestNodeTopologyMetadataChanged(t *testing.T) {
+	base := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "nvl72d001-T01",
+			Labels: map[string]string{
+				topology.KeyNvidiaGPUClique: "clique-a",
+				"unrelated":                 "v1",
+			},
+			Annotations: map[string]string{
+				topology.KeyNodeInstance: "i-1",
+				topology.KeyNodeRegion:   "r-1",
+				topology.KeyGpuClusterID: "c-1",
+			},
+		},
+	}
+
+	unchanged := base.DeepCopy()
+	// Simulate a status/heartbeat update by changing an irrelevant label.
+	unchanged.Labels["unrelated"] = "v2"
+
+	nameChanged := base.DeepCopy()
+	nameChanged.Name = "nvl72d002-T01"
+
+	labelChanged := base.DeepCopy()
+	labelChanged.Labels[topology.KeyNvidiaGPUClique] = "clique-b"
+
+	annotationChanged := base.DeepCopy()
+	annotationChanged.Annotations[topology.KeyNodeInstance] = "i-2"
+
+	regionChanged := base.DeepCopy()
+	regionChanged.Annotations[topology.KeyNodeRegion] = "r-2"
+
+	testCases := []struct {
+		name string
+		old  *corev1.Node
+		new  *corev1.Node
+		want bool
+	}{
+		{"unrelated label change is ignored", base, unchanged, false},
+		{"node name change triggers", base, nameChanged, true},
+		{"gpu clique label change triggers", base, labelChanged, true},
+		{"instance annotation change triggers", base, annotationChanged, true},
+		{"region annotation change triggers", base, regionChanged, true},
+		{"nil old triggers", nil, base, true},
+		{"nil new triggers", base, nil, true},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, nodeTopologyMetadataChanged(tc.old, tc.new))
+		})
+	}
 }

--- a/pkg/topology/domain.go
+++ b/pkg/topology/domain.go
@@ -64,3 +64,17 @@ func (m DomainMap) AddHostInfo(hostInfo *HostInfo) {
 		m[hostInfo.Domain] = map[string]*HostInfo{hostInfo.HostName: hostInfo}
 	}
 }
+
+// EnsureDomain declares domain as a known physical block even when it has no
+// live Slurm hosts. Subsequent AddHost calls attach hosts to the existing
+// entry. Used to keep a block declared in Slurm's topology after all its pods
+// have left the underlying nodes, so retained node annotations remain valid.
+// Empty domain names are ignored to match AddHostInfo.
+func (m DomainMap) EnsureDomain(domain string) {
+	if domain == "" {
+		return
+	}
+	if _, ok := m[domain]; !ok {
+		m[domain] = map[string]*HostInfo{}
+	}
+}

--- a/pkg/topology/domain_test.go
+++ b/pkg/topology/domain_test.go
@@ -40,3 +40,25 @@ func TestDomainMapAddHost(t *testing.T) {
 		},
 	}, domainMap)
 }
+
+// TestDomainMapEnsureDomain verifies that EnsureDomain declares a domain with
+// no live hosts (so it survives iteration and can be emitted as an empty
+// block) and is idempotent when the domain already exists.
+func TestDomainMapEnsureDomain(t *testing.T) {
+	domainMap := NewDomainMap()
+	domainMap.EnsureDomain("empty")
+	require.Contains(t, domainMap, "empty")
+	require.Len(t, domainMap["empty"], 0)
+
+	// Adding a host under the same domain must not lose the initial declaration.
+	domainMap.AddHost("empty", "i1", "h1")
+	require.Len(t, domainMap["empty"], 1)
+
+	// EnsureDomain over an already-populated domain must not clear hosts.
+	domainMap.EnsureDomain("empty")
+	require.Len(t, domainMap["empty"], 1)
+
+	// Empty domain names are ignored (matching AddHostInfo).
+	domainMap.EnsureDomain("")
+	require.NotContains(t, domainMap, "")
+}

--- a/pkg/translate/block.go
+++ b/pkg/translate/block.go
@@ -16,13 +16,23 @@ import (
 	"github.com/NVIDIA/topograph/internal/httperr"
 )
 
+// findMinDomainSize returns the smallest non-empty block size, used as the
+// base BlockSizes entry when the user did not supply one. Empty blocks are
+// skipped so stable-ID declarations do not force BlockSizes=[0]. Returns 1
+// when no non-empty block exists.
 func findMinDomainSize(blocks []*blockInfo) int {
 	minDomainSize := -1
 	for _, block := range blocks {
 		blocklen := len(block.nodes)
+		if blocklen == 0 {
+			continue
+		}
 		if minDomainSize == -1 || minDomainSize > blocklen {
 			minDomainSize = blocklen
 		}
+	}
+	if minDomainSize == -1 {
+		return 1
 	}
 	return minDomainSize
 }
@@ -51,7 +61,10 @@ func getBlockSizes(blocks []*blockInfo, requestedBlockSizes []int) []int {
 }
 
 func (nt *NetworkTopology) toBlockTopology(wr io.Writer, skeletonOnly bool) *httperr.Error {
-	blocks := nt.complementBlocks(nt.blocks, nt.config.BlockSizes)
+	blocks, err := nt.complementBlocks(nt.blocks, nt.config.BlockSizes)
+	if err != nil {
+		return httperr.NewError(http.StatusBadRequest, err.Error())
+	}
 	// Refresh nodeInfo.blockID so GetNodeTopologySpec returns IDs that match the
 	// emitted topology file. complementBlocks may renumber blocks when it splits
 	// a domain across multiple base blocks, invalidating the IDs set by initBlocks.

--- a/pkg/translate/block_complement.go
+++ b/pkg/translate/block_complement.go
@@ -6,6 +6,9 @@
 package translate
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/NVIDIA/topograph/pkg/topology"
 	"k8s.io/klog/v2"
 )
@@ -49,48 +52,80 @@ func groupSizeFromDomains(domains topology.DomainMap, baseBlockSize, lastBlockSi
 // block count is then padded to a multiple of that groupSize so every accelerator
 // occupies complete aggregate groups within the tree. Aggregate nodes whose total leaf
 // count already satisfies blockSizes[last] or 2^n * blockSizes[last] are left unpadded.
-func (nt *NetworkTopology) complementBlocks(blocks []*blockInfo, blockSizes []int) []*blockInfo {
+//
+// In stable-ID mode, block IDs are preserved through padding and the function
+// fails if any physical block would be split across multiple base blocks: a
+// captured index must identify exactly one emitted base block.
+func (nt *NetworkTopology) complementBlocks(blocks []*blockInfo, blockSizes []int) ([]*blockInfo, error) {
 	if len(blockSizes) < 1 || nt.domains == nil {
-		return blocks
+		return blocks, nil
 	}
 
-	domains := domainsForBlocks(nt.domains, blocks)
+	domains := domainsForBlocks(nt.domains, blocks, nt.stableIDs)
 	if len(domains) == 0 {
-		return blocks
+		return blocks, nil
 	}
 
 	klog.Infof("Complementing %d blocks with %d domains into tree shape %v", len(blocks), len(domains), blockSizes)
 	byName := blocksByName(blocks)
 
-	actualTree := buildBlockTree(domains, blockSizes)
+	actualTree := buildBlockTree(domains, blockSizes, nt.stableIDs)
 	if actualTree == nil {
-		return blocks
+		return blocks, nil
 	}
 	allSlots := collectBaseBlockSlots(actualTree)
 
-	out := make([]*blockInfo, 0, len(allSlots))
-	for i, bb := range allSlots {
-		out = append(out, baseBlockToBlockInfo(bb, byName, i+1))
+	stableIDs := nt.stableIDs
+
+	if stableIDs {
+		// A split physical block would force non-unique IDs; reject it with
+		// an actionable message pointing at blockSizes[0].
+		for _, bb := range allSlots {
+			if strings.Contains(bb.id, "#") {
+				return nil, fmt.Errorf("blockHostnameRegex: physical block %q would be split into multiple base blocks (blockSizes[0]=%d is smaller than the block's host count); increase blockSizes[0] to fit each physical block",
+					bb.domain, blockSizes[0])
+			}
+		}
 	}
-	return out
+
+	padCtr := &paddingIDCounter{}
+	out := make([]*blockInfo, 0, len(allSlots))
+	seenIDs := make(map[string]bool, len(allSlots))
+	for i, bb := range allSlots {
+		info := baseBlockToBlockInfo(bb, byName, i+1, stableIDs, padCtr)
+		if stableIDs && info != nil {
+			if seenIDs[info.id] {
+				return nil, fmt.Errorf("blockHostnameRegex: duplicate block ID %q emitted; check that no two physical blocks share the same captured index", info.id)
+			}
+			seenIDs[info.id] = true
+		}
+		out = append(out, info)
+	}
+	return out, nil
 }
 
-// domainsForBlocks returns a subset of the cluster domain map containing only the
-// hosts that belong to the given partition-local blocks. For each block it intersects
-// the global domain with the block's own node list, so that nodes owned by another
-// partition in the same accelerator domain are never included.
-func domainsForBlocks(all topology.DomainMap, blocks []*blockInfo) topology.DomainMap {
+// domainsForBlocks returns a subset of the cluster domain map containing only
+// hosts owned by the given partition-local blocks. Nodes owned by another
+// partition in the same accelerator domain are excluded.
+//
+// preserveEmpty keeps hostless domains (from DomainMap.EnsureDomain) so
+// stable-ID mode can emit empty declarations for blocks without live pods.
+func domainsForBlocks(all topology.DomainMap, blocks []*blockInfo, preserveEmpty bool) topology.DomainMap {
 	if all == nil {
 		return nil
 	}
 	local := topology.NewDomainMap()
 	for _, b := range blocks {
-		if b == nil || b.name == "" {
+		domainKey := b.domainName()
+		if b == nil || domainKey == "" {
 			continue
 		}
-		hosts, ok := all[b.name]
+		hosts, ok := all[domainKey]
 		if !ok {
 			continue
+		}
+		if preserveEmpty {
+			local.EnsureDomain(domainKey)
 		}
 		// Restrict to nodes the partition actually owns; a domain may span multiple
 		// partitions and the global map holds all of them.
@@ -109,16 +144,16 @@ func domainsForBlocks(all topology.DomainMap, blocks []*blockInfo) topology.Doma
 	return local
 }
 
-// blocksByName builds an accelerator-ID → blockInfo index used by baseBlockToBlockInfo
-// to look up node lists when a block's leaves carry only an accelerator reference.
-// Nil entries and blocks without a name are skipped, matching the guard in domainsForBlocks.
+// blocksByName builds a domainName -> blockInfo index used by
+// baseBlockToBlockInfo when a leaf carries only a domain reference.
 func blocksByName(blocks []*blockInfo) map[string]*blockInfo {
 	m := make(map[string]*blockInfo, len(blocks))
 	for _, b := range blocks {
-		if b == nil || b.name == "" {
+		key := b.domainName()
+		if b == nil || key == "" {
 			continue
 		}
-		m[b.name] = b
+		m[key] = b
 	}
 	return m
 }

--- a/pkg/translate/block_complement_test.go
+++ b/pkg/translate/block_complement_test.go
@@ -142,7 +142,8 @@ func TestComplementKeepsSeparateAccelerators(t *testing.T) {
 		},
 	}
 
-	out := nt.complementBlocks(nt.blocks, []int{8, 16})
+	out, err := nt.complementBlocks(nt.blocks, []int{8, 16})
+	require.NoError(t, err)
 	require.Len(t, out, 2)
 	require.Equal(t, "B1", out[0].name)
 	require.Len(t, out[0].nodes, 3)
@@ -177,7 +178,8 @@ func TestComplementExcessHostsPerAccelerator(t *testing.T) {
 		}},
 	}
 
-	out := nt.complementBlocks(nt.blocks, []int{4, 8, 16})
+	out, err := nt.complementBlocks(nt.blocks, []int{4, 8, 16})
+	require.NoError(t, err)
 	// 3 base blocks (ceil(12/4)) padded to 4 (groupSize=4, ceil(3/4)*4=4).
 	require.Len(t, out, 4)
 	require.True(t, isEmptyBlock(out[3]), "out[3] should be the group-alignment padding block")
@@ -213,7 +215,8 @@ func TestComplementPartitionLocalDomainsOnly(t *testing.T) {
 		partitionBlocks = append(partitionBlocks, b)
 	}
 
-	out := nt.complementBlocks(partitionBlocks, []int{4, 8, 16})
+	out, err := nt.complementBlocks(partitionBlocks, []int{4, 8, 16})
+	require.NoError(t, err)
 	// 3 real domains padded to 4 to reach the 16-node lastBS boundary.
 	require.Len(t, out, 4)
 	require.Equal(t, "B1", out[0].name)
@@ -242,7 +245,8 @@ func TestDomainsForBlocksFilteredToPartitionNodes(t *testing.T) {
 		{name: "B1", nodes: []string{"n1", "n2", "n3"}},
 	}
 
-	out := nt.complementBlocks(partitionBlocks, []int{2, 4})
+	out, err := nt.complementBlocks(partitionBlocks, []int{2, 4})
+	require.NoError(t, err)
 	// groupSize=2 (maxAccelSize=3, 2^1×2=4≥3); B1 splits into 2 base blocks.
 	// len(packed)=2 ≠ len(input)=1 → complement applied.
 	require.Len(t, out, 2)
@@ -276,7 +280,8 @@ func TestComplementWithMissingDomain(t *testing.T) {
 		{id: "block001", name: "B1", nodes: []string{"n1", "n2"}},
 		{id: "block002", name: "B2", nodes: []string{"n3", "n4"}}, // no domain entry
 	}
-	out := nt.complementBlocks(input, []int{2, 4})
+	out, err := nt.complementBlocks(input, []int{2, 4})
+	require.NoError(t, err)
 	require.Len(t, out, 2)
 	require.Equal(t, "B1", out[0].name)
 	require.Equal(t, []string{"n1", "n2"}, out[0].nodes)

--- a/pkg/translate/block_hostname_regex.go
+++ b/pkg/translate/block_hostname_regex.go
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2025 NVIDIA CORPORATION
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package translate
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// BlockHostnameMatcher is a compiled blockHostnameRegex.
+type BlockHostnameMatcher struct {
+	raw string
+	re  *regexp.Regexp
+}
+
+// CompileBlockHostnameRegex compiles a blockHostnameRegex. Returns (nil, nil)
+// when raw is empty.
+func CompileBlockHostnameRegex(raw string) (*BlockHostnameMatcher, error) {
+	return compileBlockHostnameRegex(raw)
+}
+
+func compileBlockHostnameRegex(raw string) (*BlockHostnameMatcher, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	re, err := regexp.Compile(raw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid blockHostnameRegex %q: %v", raw, err)
+	}
+	if n := re.NumSubexp(); n != 1 {
+		return nil, fmt.Errorf("blockHostnameRegex %q must contain exactly one capture group, found %d", raw, n)
+	}
+	return &BlockHostnameMatcher{raw: raw, re: re}, nil
+}
+
+// blockRegexDigitsOnly matches non-empty decimal strings.
+var blockRegexDigitsOnly = regexp.MustCompile(`^[0-9]+$`)
+
+// MatchDigits returns the decimal capture from hostname. matched is false when
+// the regex does not match; err is non-nil only when the capture is non-decimal.
+func (r *BlockHostnameMatcher) MatchDigits(hostname string) (digits string, matched bool, err error) {
+	if r == nil || r.re == nil {
+		return "", false, nil
+	}
+	match := r.re.FindStringSubmatch(hostname)
+	if len(match) < 2 || match[1] == "" {
+		return "", false, nil
+	}
+	digits = match[1]
+	if !blockRegexDigitsOnly.MatchString(digits) {
+		return "", false, fmt.Errorf("hostname %q capture %q from blockHostnameRegex %q is not a decimal number",
+			hostname, digits, r.raw)
+	}
+	return digits, true, nil
+}
+
+// blockIDForDigits returns the Slurm block name for a decimal capture,
+// preserving leading zeros so "002" and "2" remain distinct.
+func blockIDForDigits(digits string) string {
+	return "block" + digits
+}
+
+// effectiveBlockHostnameRegex returns the effective cluster-wide value, falling
+// back to a unique non-empty per-partition value. Errors when multiple distinct
+// values are set.
+func (cfg *Config) effectiveBlockHostnameRegex() (string, error) {
+	chosen := cfg.BlockHostnameRegex
+	chosenSource := "cluster-wide"
+	for name, spec := range cfg.Topologies {
+		if spec == nil || spec.BlockHostnameRegex == "" {
+			continue
+		}
+		if chosen == "" {
+			chosen = spec.BlockHostnameRegex
+			chosenSource = fmt.Sprintf("partition %q", name)
+			continue
+		}
+		if spec.BlockHostnameRegex != chosen {
+			return "", fmt.Errorf("blockHostnameRegex mismatch: partition %q has %q but %s has %q",
+				name, spec.BlockHostnameRegex, chosenSource, chosen)
+		}
+	}
+	return chosen, nil
+}

--- a/pkg/translate/block_tree.go
+++ b/pkg/translate/block_tree.go
@@ -48,9 +48,17 @@ type aggregateBlockNode struct {
 
 func (*aggregateBlockNode) blockTreeNode() {}
 
-// splitIntoBaseBlocks splits a sorted host list into one or more base blocks of at
-// most baseBlockSize leaves each. Overflow blocks get a "#N" suffix on the ID.
-func splitIntoBaseBlocks(id string, hosts []*topology.HostInfo, baseBlockSize int) []*baseBlockNode {
+// splitIntoBaseBlocks splits a sorted host list into base blocks of at most
+// baseBlockSize leaves each; overflow blocks get a "#N" suffix on the ID.
+// When emitEmpty is true and hosts is empty, a single empty base block is
+// emitted so stable-ID mode can preserve the declaration.
+func splitIntoBaseBlocks(id string, hosts []*topology.HostInfo, baseBlockSize int, emitEmpty bool) []*baseBlockNode {
+	if len(hosts) == 0 {
+		if emitEmpty {
+			return []*baseBlockNode{newBaseBlock(id, nil, baseBlockSize)}
+		}
+		return nil
+	}
 	blocks := make([]*baseBlockNode, 0, (len(hosts)+baseBlockSize-1)/baseBlockSize)
 	for start := 0; start < len(hosts); start += baseBlockSize {
 		end := start + baseBlockSize
@@ -102,33 +110,69 @@ func isEmptyBlock(b *blockInfo) bool {
 	return b == nil || (len(b.name) == 0 && len(b.nodes) == 0)
 }
 
-// baseBlockToBlockInfo resolves a base block to a blockInfo using a priority fallback
-// chain, because not all blocks have live hosts attached to their leaves:
-//  1. Host names directly in leaves (live hosts — normal case)
-//  2. Domain IDs from leaves → byName lookup (placeholder hosts: Domain set, HostName empty)
-//  3. Domain ID as display name with no nodes (domain known, host list missing entirely)
-//  4. Empty blockInfo (tree slot was never filled)
-func baseBlockToBlockInfo(bb *baseBlockNode, byName map[string]*blockInfo, seq int) *blockInfo {
-	id := fmt.Sprintf("block%03d", seq)
+// baseBlockToBlockInfo resolves a base block to a blockInfo using a priority
+// fallback chain, since not all base blocks carry live hosts on their leaves:
+//  1. Host names directly in leaves (live hosts, the normal case).
+//  2. Domain IDs from leaves via byName lookup (placeholder hosts).
+//  3. Domain ID as display name with no nodes.
+//  4. Empty blockInfo (unfilled tree slot).
+//
+// See blockIDFor for how id is chosen. In stable-ID mode the display name is
+// dropped because the domain identifier equals the emitted block ID.
+func baseBlockToBlockInfo(bb *baseBlockNode, byName map[string]*blockInfo, seq int, stableIDs bool, padCtr *paddingIDCounter) *blockInfo {
 	domainID := bb.domainIdentifier()
 	nodes := hostNamesFromLeaves(bb.leaves)
+	id := blockIDFor(bb, seq, stableIDs, padCtr)
+	displayName := blockDisplayName(bb.id, domainID)
+	if stableIDs {
+		displayName = ""
+	}
 	if len(nodes) > 0 {
-		return &blockInfo{id: id, name: blockDisplayName(bb.id, domainID), nodes: nodes}
+		return &blockInfo{id: id, name: displayName, domain: domainID, nodes: nodes}
 	}
 	for _, domain := range domainIDsFromLeaves(bb.leaves) {
 		if b := byName[domain]; b != nil {
+			domainCopy := domain
 			return &blockInfo{
-				id:    id,
-				name:  blockDisplayName(bb.id, domain),
-				nodes: append([]string(nil), b.nodes...),
+				id:     id,
+				name:   displayName,
+				domain: domainCopy,
+				nodes:  append([]string(nil), b.nodes...),
 			}
 		}
 	}
 	if domainID != "" {
-		return &blockInfo{id: id, name: blockDisplayName(bb.id, domainID)}
+		return &blockInfo{id: id, name: displayName, domain: domainID}
 	}
+	// Padding slot (no domain, no leaves) — leave both name and domain empty.
 	return &blockInfo{id: id}
 }
+
+// paddingIDCounter tracks IDs already consumed by physical blocks so padding
+// slots pick a fresh unused number. Padding uses "block-pad-<n>" to avoid
+// colliding with regex-derived "block<digits>" IDs.
+type paddingIDCounter struct {
+	next int
+}
+
+// blockIDFor returns the ID string for a base block: "block<digits>" for a
+// physical stable-ID block, "block-pad-<n>" for a stable-ID padding slot, and
+// positional "block%03d" in legacy mode.
+func blockIDFor(bb *baseBlockNode, seq int, stableIDs bool, padCtr *paddingIDCounter) string {
+	if !stableIDs {
+		return fmt.Sprintf("block%03d", seq)
+	}
+	if bb.domain != "" {
+		return "block" + bb.domain
+	}
+	if padCtr == nil {
+		return fmt.Sprintf("%s%d", blockPadIDPrefix, seq)
+	}
+	padCtr.next++
+	return fmt.Sprintf("%s%d", blockPadIDPrefix, padCtr.next)
+}
+
+const blockPadIDPrefix = "block-pad-"
 
 func blockDisplayName(blockID, primarydomain string) string {
 	if primarydomain != "" {
@@ -219,13 +263,16 @@ func newEmptyBaseBlock(baseBlockSize int) *baseBlockNode {
 // padding) and returns both the fully padded domain nodes and the live bb count.
 // buildBlockTree uses the capacity recorded on each domain node to decide whether
 // higher-tier aggregation is needed, then delegates to packAggregateNodes.
-func buildBlockTree(domains topology.DomainMap, blockSizes []int) *aggregateBlockNode {
+//
+// emitEmpty is forwarded to splitIntoBaseBlocks so stable-ID callers keep
+// zero-host physical domains declared in the resulting tree.
+func buildBlockTree(domains topology.DomainMap, blockSizes []int, emitEmpty bool) *aggregateBlockNode {
 	baseBlockSize := blockSizes[0]
 	groupSize := groupSizeFromDomains(domains, baseBlockSize, blockSizes[len(blockSizes)-1])
 
 	//Pad each domain to a multiple of groupSize base blocks,
 	//then pack those blocks into aggregate nodes of size groupSize until we reach the top tier or satisfy blockSizes[last].
-	domainNodes := packDomainNodes(domains, baseBlockSize, groupSize)
+	domainNodes := packDomainNodes(domains, baseBlockSize, groupSize, emitEmpty)
 	if len(domainNodes) == 0 {
 		return nil
 	}
@@ -255,7 +302,7 @@ func buildBlockTree(domains topology.DomainMap, blockSizes []int) *aggregateBloc
 	return &aggregateBlockNode{children: aggregateNodes, nodeCount: aggCount}
 }
 
-func packDomainNodes(domains topology.DomainMap, baseBlockSize, groupSize int) []blockTreeNode {
+func packDomainNodes(domains topology.DomainMap, baseBlockSize, groupSize int, emitEmpty bool) []blockTreeNode {
 	if baseBlockSize <= 0 {
 		return nil
 	}
@@ -268,7 +315,7 @@ func packDomainNodes(domains topology.DomainMap, baseBlockSize, groupSize int) [
 
 	for _, domainID := range domainIDs {
 		hosts := hostsSorted(domains[domainID])
-		blocks := splitIntoBaseBlocks(domainID, hosts, baseBlockSize)
+		blocks := splitIntoBaseBlocks(domainID, hosts, baseBlockSize, emitEmpty)
 		for i := len(blocks); i < groupSize; i++ {
 			blocks = append(blocks, newEmptyBaseBlock(baseBlockSize))
 		}

--- a/pkg/translate/block_tree_test.go
+++ b/pkg/translate/block_tree_test.go
@@ -51,7 +51,7 @@ func TestSplitIntoBaseBlocksChunksExcessHosts(t *testing.T) {
 		}
 	}
 	sortHostsByName(hosts)
-	blocks := splitIntoBaseBlocks("B1", hosts, 4)
+	blocks := splitIntoBaseBlocks("B1", hosts, 4, false)
 	require.Len(t, blocks, 3)
 	require.Len(t, blocks[0].leaves, 4)
 	require.Len(t, hostNamesFromLeaves(blocks[0].leaves), 4)

--- a/pkg/translate/topology.go
+++ b/pkg/translate/topology.go
@@ -19,33 +19,52 @@ import (
 )
 
 type Config struct {
-	Plugin     string // topology plugin (cluster-wide)
-	BlockSizes []int
-	Topologies map[string]*TopologySpec // per-partiton topology settings
+	Plugin             string                   // topology plugin (cluster-wide)
+	BlockSizes         []int                    // sizes of blocks in the block topology (cluster-wide)
+	Topologies         map[string]*TopologySpec // per-partiton topology settings
+	BlockHostnameRegex string                   // stable block IDs from a decimal hostname capture; see Validate
 }
 
 // TopologySpec define topology for a partition
 type TopologySpec struct {
-	Plugin         string
-	BlockSizes     []int
-	ClusterDefault bool
-	Nodes          []string
+	Plugin             string
+	BlockSizes         []int
+	ClusterDefault     bool
+	Nodes              []string
+	BlockHostnameRegex string // per-partition override for Config.BlockHostnameRegex
 }
 
 type NetworkTopology struct {
-	config   *Config
-	tree     map[string][]string         // adjacency list
-	domains  topology.DomainMap          // accelerator domains from provider graph
-	blocks   []*blockInfo                // blocks
-	vertices map[string]*topology.Vertex // object ID to Vertex map
-	nodeInfo map[string]*nodeInfo        // node name to nodeInfo map
+	config    *Config
+	tree      map[string][]string         // adjacency list
+	domains   topology.DomainMap          // accelerator domains from provider graph
+	blocks    []*blockInfo                // blocks
+	vertices  map[string]*topology.Vertex // object ID to Vertex map
+	nodeInfo  map[string]*nodeInfo        // node name to nodeInfo map
+	blockRe   *BlockHostnameMatcher       // effective cluster-wide blockHostnameRegex (may be nil)
+	stableIDs bool                        // true when blockRe drove blockInfo.id assignments
 }
 
 type blockInfo struct {
-	id    string
-	name  string
-	indx  int
-	nodes []string
+	id     string
+	name   string // informative label for the "# blockID=name" comment (may be empty)
+	domain string // key into graph.Domains for HostInfo lookup; may equal id
+	indx   int
+	nodes  []string
+}
+
+// domainName returns the DomainMap key this block was built from. For
+// blockInfo values produced from an in-memory domain map it equals the
+// original domain name; padding blocks synthesized by complementBlocks return
+// an empty string because they carry no live hosts.
+func (b *blockInfo) domainName() string {
+	if b == nil {
+		return ""
+	}
+	if b.domain != "" {
+		return b.domain
+	}
+	return b.name
 }
 
 type nodeInfo struct {
@@ -78,6 +97,13 @@ func (cfg *Config) Validate(graph *topology.Graph) error {
 			if len(spec.Nodes) == 0 && spec.Plugin != topology.TopologyFlat {
 				return fmt.Errorf("topology %q specifies no nodes", topo)
 			}
+			if spec.BlockHostnameRegex != "" && spec.Plugin != topology.TopologyBlock {
+				return fmt.Errorf("topology %q: blockHostnameRegex requires plugin %q, got %q",
+					topo, topology.TopologyBlock, spec.Plugin)
+			}
+			if _, err := compileBlockHostnameRegex(spec.BlockHostnameRegex); err != nil {
+				return fmt.Errorf("topology %q: %v", topo, err)
+			}
 		}
 	} else { // cluster-wide topology
 		switch cfg.Plugin {
@@ -92,6 +118,19 @@ func (cfg *Config) Validate(graph *topology.Graph) error {
 		default:
 			return fmt.Errorf("unsupported topology plugin %q", cfg.Plugin)
 		}
+		if cfg.BlockHostnameRegex != "" && cfg.Plugin != topology.TopologyBlock {
+			return fmt.Errorf("blockHostnameRegex requires plugin %q, got %q",
+				topology.TopologyBlock, cfg.Plugin)
+		}
+		if _, err := compileBlockHostnameRegex(cfg.BlockHostnameRegex); err != nil {
+			return err
+		}
+	}
+
+	// All non-empty blockHostnameRegex values (cluster-wide + per-partition)
+	// must agree; otherwise domain keys would be ambiguous.
+	if _, err := cfg.effectiveBlockHostnameRegex(); err != nil {
+		return err
 	}
 	return nil
 }
@@ -101,15 +140,29 @@ func NewNetworkTopology(graph *topology.Graph, cfg *Config) (*NetworkTopology, e
 		return nil, err
 	}
 
+	// Derive the effective regex so initBlocks assigns stable IDs regardless
+	// of whether it was set cluster-wide or per-partition.
+	effectiveRegex, err := cfg.effectiveBlockHostnameRegex()
+	if err != nil {
+		return nil, err
+	}
+	blockRe, err := compileBlockHostnameRegex(effectiveRegex)
+	if err != nil {
+		return nil, err
+	}
+
 	nt := &NetworkTopology{
 		config:   cfg,
 		tree:     make(map[string][]string),
 		vertices: make(map[string]*topology.Vertex),
 		nodeInfo: make(map[string]*nodeInfo),
+		blockRe:  blockRe,
 	}
 
 	nt.initTree(graph)
-	nt.initBlocks(graph)
+	if err := nt.initBlocks(graph); err != nil {
+		return nil, err
+	}
 
 	return nt, nil
 }
@@ -148,7 +201,12 @@ func (nt *NetworkTopology) initTree(graph *topology.Graph) {
 	}
 }
 
-func toBlockInfos(domains topology.DomainMap) []*blockInfo {
+// toBlockInfos converts a DomainMap into an ordered slice of blockInfo entries.
+// When re is non-nil, block IDs are derived from the DomainMap keys (which
+// must be decimal digits). Otherwise, IDs fall back to positional "block%03d"
+// numbering and the domain key becomes blockInfo.name for the "# blockNNN=..."
+// comment.
+func toBlockInfos(domains topology.DomainMap, re *BlockHostnameMatcher) ([]*blockInfo, error) {
 	domainNames := make([]string, 0, len(domains))
 	for domainName := range domains {
 		domainNames = append(domainNames, domainName)
@@ -164,29 +222,52 @@ func toBlockInfos(domains topology.DomainMap) []*blockInfo {
 		}
 		sort.Strings(nodes)
 
+		var (
+			id   string
+			name string
+		)
+		if re != nil {
+			if !blockRegexDigitsOnly.MatchString(domainName) {
+				return nil, fmt.Errorf("blockHostnameRegex requires DomainMap keys to be decimal digits, got %q", domainName)
+			}
+			id = blockIDForDigits(domainName)
+			// name stays empty so toBlockTopology omits the "# blockNNN=..." comment.
+			name = ""
+		} else {
+			id = fmt.Sprintf("block%03d", i+1)
+			name = domainName
+		}
+
 		blocks = append(blocks, &blockInfo{
-			id:    fmt.Sprintf("block%03d", i+1),
-			name:  domainName,
-			nodes: nodes,
+			id:     id,
+			name:   name,
+			domain: domainName,
+			nodes:  nodes,
 		})
 	}
 
-	return blocks
+	return blocks, nil
 }
 
-func (nt *NetworkTopology) initBlocks(graph *topology.Graph) {
+func (nt *NetworkTopology) initBlocks(graph *topology.Graph) error {
+	// Set before the early returns so callers see stableIDs even for empty clusters.
+	nt.stableIDs = nt.blockRe != nil
+
 	if graph == nil || graph.Domains == nil {
 		klog.Warning("block topology data not found")
-		return
+		return nil
 	}
 
 	if len(graph.Domains) == 0 {
 		klog.Warning("no blocks found in block topology")
-		return
+		return nil
 	}
 
 	nt.domains = graph.Domains
-	domainBlocks := toBlockInfos(graph.Domains)
+	domainBlocks, err := toBlockInfos(graph.Domains, nt.blockRe)
+	if err != nil {
+		return err
+	}
 	nt.blocks = make([]*blockInfo, 0, len(domainBlocks))
 	indx := 0
 
@@ -194,9 +275,9 @@ func (nt *NetworkTopology) initBlocks(graph *topology.Graph) {
 		for _, bInfo := range domainBlocks {
 			bInfo.indx = indx
 			for _, node := range bInfo.nodes {
-				hostInfo := graph.Domains[bInfo.name][node]
+				hostInfo := graph.Domains[bInfo.domainName()][node]
 				if hostInfo == nil {
-					klog.Warningf("initBlocks: missing host info for node %q in domain %q", node, bInfo.name)
+					klog.Warningf("initBlocks: missing host info for node %q in domain %q", node, bInfo.domainName())
 					continue
 				}
 				nt.nodeInfo[node] = &nodeInfo{
@@ -248,17 +329,34 @@ func (nt *NetworkTopology) initBlocks(graph *topology.Graph) {
 				}
 			}
 		}
+		// Append any known physical blocks that never appeared as tree leaves
+		// (e.g. empty domains from EnsureDomain). Deterministic order matches
+		// toBlockInfos so pod-scale transitions keep the same relative order.
+		seen := make(map[string]bool, len(nt.blocks))
+		for _, b := range nt.blocks {
+			seen[b.id] = true
+		}
+		for _, bInfo := range domainBlocks {
+			if seen[bInfo.id] {
+				continue
+			}
+			bInfo.indx = indx
+			nt.blocks = append(nt.blocks, bInfo)
+			indx++
+		}
 	}
+	return nil
 }
 
 // markBlockNodes assigns provided block index to the block nodes
 func (nt *NetworkTopology) markBlockNodes(block *blockInfo, indx int) *blockInfo {
 	pIndx := ptr.Int(indx)
 	bInfo := &blockInfo{
-		id:    block.id,
-		name:  block.name,
-		indx:  indx,
-		nodes: append([]string(nil), block.nodes...),
+		id:     block.id,
+		name:   block.name,
+		domain: block.domain,
+		indx:   indx,
+		nodes:  append([]string(nil), block.nodes...),
 	}
 	for _, node := range bInfo.nodes {
 		if info, ok := nt.nodeInfo[node]; ok {

--- a/pkg/translate/topology_test.go
+++ b/pkg/translate/topology_test.go
@@ -757,3 +757,343 @@ func TestGetNodeTopologySpecAfterComplementPerPartition(t *testing.T) {
 		require.Equal(t, tc.spec, spec, "node %s", tc.node)
 	}
 }
+
+// TestBlockHostnameRegexValidation covers the regex contract enforced at
+// NewNetworkTopology time: bad plugin combinations, malformed regexes,
+// cluster-vs-partition mismatches, and non-decimal DomainMap keys.
+func TestBlockHostnameRegexValidation(t *testing.T) {
+	blockGraph := &topology.Graph{
+		Domains: topology.DomainMap{
+			"001": map[string]*topology.HostInfo{
+				"h": {Domain: "001", HostName: "h", InstanceID: "i"},
+			},
+		},
+	}
+	treeGraph := &topology.Graph{Tiers: &topology.Vertex{}}
+	nonDigitGraph := &topology.Graph{
+		Domains: topology.DomainMap{
+			"clique-a": map[string]*topology.HostInfo{
+				"h": {Domain: "clique-a", HostName: "h", InstanceID: "i"},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name string
+		root *topology.Graph
+		cfg  *Config
+		err  string
+	}{
+		{
+			name: "Case 1: regex with tree plugin rejected",
+			root: treeGraph,
+			cfg: &Config{
+				Plugin:             topology.TopologyTree,
+				BlockHostnameRegex: `d(\d+)`,
+			},
+			err: `blockHostnameRegex requires plugin "topology/block", got "topology/tree"`,
+		},
+		{
+			name: "Case 2: regex with multiple capture groups rejected",
+			root: blockGraph,
+			cfg: &Config{
+				Plugin:             topology.TopologyBlock,
+				BlockHostnameRegex: `d(\d+)(-T)\d+`,
+			},
+			err: `blockHostnameRegex "d(\\d+)(-T)\\d+" must contain exactly one capture group, found 2`,
+		},
+		{
+			name: "Case 3: per-partition regex on tree plugin rejected",
+			root: treeGraph,
+			cfg: &Config{
+				Topologies: map[string]*TopologySpec{
+					"bad": {
+						Plugin:             topology.TopologyTree,
+						Nodes:              []string{"n1"},
+						BlockHostnameRegex: `d(\d+)`,
+					},
+				},
+			},
+			err: `topology "bad": blockHostnameRegex requires plugin "topology/block", got "topology/tree"`,
+		},
+		{
+			name: "Case 4: cluster-wide vs partition regex mismatch rejected",
+			root: blockGraph,
+			cfg: &Config{
+				BlockHostnameRegex: `d(\d+)-T\d+`,
+				Topologies: map[string]*TopologySpec{
+					"a": {
+						Plugin:             topology.TopologyBlock,
+						Nodes:              []string{"h"},
+						BlockHostnameRegex: `nvl(\d+)`,
+					},
+				},
+			},
+			err: `blockHostnameRegex mismatch: partition "a" has "nvl(\\d+)" but cluster-wide has "d(\\d+)-T\\d+"`,
+		},
+		{
+			name: "Case 5: non-decimal DomainMap key rejected",
+			root: nonDigitGraph,
+			cfg: &Config{
+				Plugin:             topology.TopologyBlock,
+				BlockSizes:         []int{1},
+				BlockHostnameRegex: `d(\d+)`,
+			},
+			err: `blockHostnameRegex requires DomainMap keys to be decimal digits, got "clique-a"`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewNetworkTopology(tc.root, tc.cfg)
+			if len(tc.err) != 0 {
+				require.EqualError(t, err, tc.err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+
+	// Two cases below have implementation-defined or map-iteration-order
+	// dependent error text, so match a stable substring instead.
+	t.Run("Case 6: regex compile error rejected", func(t *testing.T) {
+		_, err := NewNetworkTopology(blockGraph, &Config{
+			Plugin:             topology.TopologyBlock,
+			BlockHostnameRegex: `d(\d+`,
+		})
+		require.ErrorContains(t, err, "invalid blockHostnameRegex")
+	})
+
+	t.Run("Case 7: two partitions disagreeing rejected", func(t *testing.T) {
+		_, err := NewNetworkTopology(blockGraph, &Config{
+			Topologies: map[string]*TopologySpec{
+				"a": {
+					Plugin:             topology.TopologyBlock,
+					Nodes:              []string{"h"},
+					BlockHostnameRegex: `d(\d+)-T\d+`,
+				},
+				"b": {
+					Plugin:             topology.TopologyBlock,
+					Nodes:              []string{"h"},
+					BlockHostnameRegex: `nvl(\d+)`,
+				},
+			},
+		})
+		require.ErrorContains(t, err, "blockHostnameRegex mismatch")
+	})
+}
+
+// TestBlockHostnameRegexRejectsSplit verifies the "one captured index
+// identifies one emitted physical base block" rule: if blockSizes[0] is less
+// than a physical block's host count, complementBlocks fails at Generate time.
+func TestBlockHostnameRegexRejectsSplit(t *testing.T) {
+	domains := topology.NewDomainMap()
+	domains.AddHostInfo(&topology.HostInfo{Domain: "001", HostName: "nvl72d001-T01", InstanceID: "i-1"})
+	domains.AddHostInfo(&topology.HostInfo{Domain: "001", HostName: "nvl72d001-T02", InstanceID: "i-2"})
+
+	cfg := &Config{
+		Plugin:             topology.TopologyBlock,
+		BlockSizes:         []int{1, 2},
+		BlockHostnameRegex: `d(\d+)-T\d+`,
+	}
+	nt, err := NewNetworkTopology(&topology.Graph{Domains: domains}, cfg)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	httpErr := nt.Generate(&buf)
+	require.NotNil(t, httpErr)
+	require.Contains(t, httpErr.Error(), "would be split")
+}
+
+// TestBlockHostnameRegexOutput covers the rendered topology for the main
+// blockHostnameRegex code paths: cluster-wide vs per-partition, cluster-wide
+// vs partition-only regex, empty BlockSizes, empty cluster fallback, and
+// multi-partition over-inclusion of empty physical blocks.
+func TestBlockHostnameRegexOutput(t *testing.T) {
+	domainsWithGap := func() topology.DomainMap {
+		m := topology.NewDomainMap()
+		m.AddHostInfo(&topology.HostInfo{Domain: "001", HostName: "nvl72d001-T01", InstanceID: "i-1"})
+		m.EnsureDomain("002")
+		m.AddHostInfo(&topology.HostInfo{Domain: "003", HostName: "nvl72d003-T01", InstanceID: "i-3"})
+		return m
+	}
+	twoLiveDomains := func() topology.DomainMap {
+		m := topology.NewDomainMap()
+		m.AddHostInfo(&topology.HostInfo{Domain: "001", HostName: "nvl72d001-T01", InstanceID: "i-1"})
+		m.AddHostInfo(&topology.HostInfo{Domain: "003", HostName: "nvl72d003-T01", InstanceID: "i-3"})
+		return m
+	}
+	twoAdjacentDomains := func() topology.DomainMap {
+		m := topology.NewDomainMap()
+		m.AddHostInfo(&topology.HostInfo{Domain: "001", HostName: "nvl72d001-T01", InstanceID: "i-1"})
+		m.AddHostInfo(&topology.HostInfo{Domain: "002", HostName: "nvl72d002-T01", InstanceID: "i-2"})
+		return m
+	}
+
+	testCases := []struct {
+		name     string
+		graph    *topology.Graph
+		cfg      *Config
+		expected string
+	}{
+		{
+			name:  "Case 1: cluster-wide stable IDs, empty domain declared",
+			graph: &topology.Graph{Domains: domainsWithGap()},
+			cfg: &Config{
+				Plugin:             topology.TopologyBlock,
+				BlockSizes:         []int{1},
+				BlockHostnameRegex: `d(\d+)-T\d+`,
+			},
+			expected: `BlockName=block001 Nodes=nvl72d001-T01
+BlockName=block002
+BlockName=block003 Nodes=nvl72d003-T01
+BlockSizes=1
+`,
+		},
+		{
+			name:  "Case 2: per-partition stable IDs, empty domain declared",
+			graph: &topology.Graph{Domains: domainsWithGap()},
+			cfg: &Config{
+				BlockHostnameRegex: `d(\d+)-T\d+`,
+				Topologies: map[string]*TopologySpec{
+					"gpu-block": {
+						Plugin:             topology.TopologyBlock,
+						Nodes:              []string{"nvl72d001-T01", "nvl72d003-T01"},
+						BlockSizes:         []int{1},
+						BlockHostnameRegex: `d(\d+)-T\d+`,
+					},
+				},
+			},
+			expected: `- topology: gpu-block
+  cluster_default: false
+  block:
+    block_sizes:
+        - 1
+    blocks:
+        - block: block001
+          nodes: nvl72d001-T01
+        - block: block002
+        - block: block003
+          nodes: nvl72d003-T01
+`,
+		},
+		{
+			name:  "Case 3: partition-only regex still yields stable IDs",
+			graph: &topology.Graph{Domains: twoLiveDomains()},
+			cfg: &Config{
+				Topologies: map[string]*TopologySpec{
+					"gpu-block": {
+						Plugin:             topology.TopologyBlock,
+						Nodes:              []string{"nvl72d001-T01", "nvl72d003-T01"},
+						BlockSizes:         []int{1},
+						BlockHostnameRegex: `d(\d+)-T\d+`,
+					},
+				},
+			},
+			expected: `- topology: gpu-block
+  cluster_default: false
+  block:
+    block_sizes:
+        - 1
+    blocks:
+        - block: block001
+          nodes: nvl72d001-T01
+        - block: block003
+          nodes: nvl72d003-T01
+`,
+		},
+		{
+			name:  "Case 4: empty BlockSizes preserves stable IDs and non-zero base",
+			graph: &topology.Graph{Domains: domainsWithGap()},
+			cfg: &Config{
+				BlockHostnameRegex: `d(\d+)-T\d+`,
+				Topologies: map[string]*TopologySpec{
+					"gpu-block": {
+						Plugin: topology.TopologyBlock,
+						Nodes:  []string{"nvl72d001-T01", "nvl72d003-T01"},
+					},
+				},
+			},
+			expected: `- topology: gpu-block
+  cluster_default: false
+  block:
+    block_sizes:
+        - 1
+        - 2
+    blocks:
+        - block: block001
+          nodes: nvl72d001-T01
+        - block: block002
+        - block: block003
+          nodes: nvl72d003-T01
+`,
+		},
+		{
+			name:  "Case 5: empty cluster falls back to flat",
+			graph: &topology.Graph{Domains: topology.NewDomainMap()},
+			cfg: &Config{
+				BlockHostnameRegex: `d(\d+)-T\d+`,
+				Topologies: map[string]*TopologySpec{
+					"gpu-block": {
+						Plugin:             topology.TopologyBlock,
+						Nodes:              []string{"nvl72d001-T01"},
+						BlockSizes:         []int{1},
+						BlockHostnameRegex: `d(\d+)-T\d+`,
+					},
+				},
+			},
+			expected: `- topology: gpu-block
+  cluster_default: false
+  flat: true
+`,
+		},
+		{
+			name:  "Case 6: multi-partition over-includes each other's blocks as empty",
+			graph: &topology.Graph{Domains: twoAdjacentDomains()},
+			cfg: &Config{
+				BlockHostnameRegex: `d(\d+)-T\d+`,
+				Topologies: map[string]*TopologySpec{
+					"partA": {
+						Plugin:     topology.TopologyBlock,
+						Nodes:      []string{"nvl72d001-T01"},
+						BlockSizes: []int{1},
+					},
+					"partB": {
+						Plugin:     topology.TopologyBlock,
+						Nodes:      []string{"nvl72d002-T01"},
+						BlockSizes: []int{1},
+					},
+				},
+			},
+			expected: `- topology: partA
+  cluster_default: false
+  block:
+    block_sizes:
+        - 1
+    blocks:
+        - block: block001
+          nodes: nvl72d001-T01
+        - block: block002
+- topology: partB
+  cluster_default: false
+  block:
+    block_sizes:
+        - 1
+    blocks:
+        - block: block001
+        - block: block002
+          nodes: nvl72d002-T01
+`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			nt, err := NewNetworkTopology(tc.graph, tc.cfg)
+			require.NoError(t, err)
+			buf := &bytes.Buffer{}
+			require.Nil(t, nt.Generate(buf))
+			require.Equal(t, tc.expected, buf.String())
+		})
+	}
+}

--- a/pkg/translate/yaml.go
+++ b/pkg/translate/yaml.go
@@ -95,7 +95,10 @@ func (nt *NetworkTopology) GetTopologies() ([]*TopologyUnit, *httperr.Error) {
 			tu := nt.getTreeTopologyUnit(topoName, topoSpec)
 			topologies = append(topologies, tu)
 		case topology.TopologyBlock:
-			tu := nt.getBlockTopologyUnit(topoName, topoSpec)
+			tu, err := nt.getBlockTopologyUnit(topoName, topoSpec)
+			if err != nil {
+				return topologies, err
+			}
 			topologies = append(topologies, tu)
 		case topology.TopologyFlat:
 			topologies = append(topologies, &TopologyUnit{
@@ -132,7 +135,17 @@ func (nt *NetworkTopology) toYamlTopology(wr io.Writer, topologies []*TopologyUn
 	return nil
 }
 
-func (nt *NetworkTopology) getBlockTopologyUnit(topoName string, topoSpec *TopologySpec) *TopologyUnit {
+func (nt *NetworkTopology) getBlockTopologyUnit(topoName string, topoSpec *TopologySpec) (*TopologyUnit, *httperr.Error) {
+	// Per-partition regex overrides the cluster-wide value; fall back when unset.
+	partitionRe, err := compileBlockHostnameRegex(topoSpec.BlockHostnameRegex)
+	if err != nil {
+		return nil, httperr.NewError(http.StatusBadRequest, fmt.Sprintf("topology %q: %v", topoName, err))
+	}
+	if partitionRe == nil {
+		partitionRe = nt.blockRe
+	}
+	partitionStableIDs := partitionRe != nil
+
 	// populate map [block indx : blockInfo]
 	nodeNames := cluset.Expand(topoSpec.Nodes)
 	blockMap := make(map[int]*blockInfo)
@@ -149,14 +162,22 @@ func (nt *NetworkTopology) getBlockTopologyUnit(topoName string, topoSpec *Topol
 		indx := *info.blockIndx
 		bInfo, ok := blockMap[indx]
 		if !ok {
+			// Carry stable id/name/domain from nt.blocks so blockNameForPartition
+			// still works when complementBlocks is a no-op (empty BlockSizes).
+			id := ""
 			name := ""
+			domain := ""
 			if indx < len(nt.blocks) {
+				id = nt.blocks[indx].id
 				name = nt.blocks[indx].name
+				domain = nt.blocks[indx].domain
 			}
 			blockMap[indx] = &blockInfo{
-				indx:  indx,
-				name:  name,
-				nodes: []string{nodeName},
+				indx:   indx,
+				id:     id,
+				name:   name,
+				domain: domain,
+				nodes:  []string{nodeName},
 			}
 		} else {
 			bInfo.nodes = append(bInfo.nodes, nodeName)
@@ -168,43 +189,78 @@ func (nt *NetworkTopology) getBlockTopologyUnit(topoName string, topoSpec *Topol
 		Default: topoSpec.ClusterDefault,
 	}
 
-	if nBlocks := len(blockMap); nBlocks == 0 {
+	// Fall back to flat when there is no live membership and no physical
+	// inventory to preserve.
+	if len(blockMap) == 0 && (!partitionStableIDs || len(nt.blocks) == 0) {
 		tu.Flat = true
-	} else {
-		// sort blockInfo by block index
-		bInfos := make([]*blockInfo, 0, len(blockMap))
-		for _, bInfo := range blockMap {
-			bInfos = append(bInfos, bInfo)
-		}
-		sort.Slice(bInfos, func(i, j int) bool {
-			return bInfos[i].indx < bInfos[j].indx
-		})
+		return tu, nil
+	}
 
-		bInfos = nt.complementBlocks(bInfos, topoSpec.BlockSizes)
-
-		// populate block topology units ordered by block indices
-		blocks := make([]*Block, 0, len(bInfos))
-		parents := make(map[string]string)
-		for indx, bInfo := range bInfos {
-			blockName := fmt.Sprintf("block%d", indx+1)
-			block := &Block{Name: blockName}
-			if len(bInfo.nodes) != 0 {
-				block.Nodes = strings.Join(cluset.Compact(bInfo.nodes), ",")
+	// In stable-ID mode, declare every known physical block, even those with
+	// no live pods, so retained annotations keep referencing valid IDs.
+	if partitionStableIDs {
+		for _, physical := range nt.blocks {
+			if physical == nil {
+				continue
 			}
-			blocks = append(blocks, block)
-
-			for _, nodeName := range bInfo.nodes {
-				parents[nodeName] = blockName
+			if _, ok := blockMap[physical.indx]; ok {
+				continue
 			}
-		}
-
-		tu.Block = &BlockTopo{
-			BlockSizes: getBlockSizes(bInfos, topoSpec.BlockSizes),
-			Blocks:     blocks,
-			parents:    parents,
+			blockMap[physical.indx] = &blockInfo{
+				indx:   physical.indx,
+				id:     physical.id,
+				name:   physical.name,
+				domain: physical.domain,
+			}
 		}
 	}
-	return tu
+
+	// sort blockInfo by block index
+	bInfos := make([]*blockInfo, 0, len(blockMap))
+	for _, bInfo := range blockMap {
+		bInfos = append(bInfos, bInfo)
+	}
+	sort.Slice(bInfos, func(i, j int) bool {
+		return bInfos[i].indx < bInfos[j].indx
+	})
+
+	completed, complErr := nt.complementBlocks(bInfos, topoSpec.BlockSizes)
+	if complErr != nil {
+		return nil, httperr.NewError(http.StatusBadRequest, fmt.Sprintf("topology %q: %v", topoName, complErr))
+	}
+	bInfos = completed
+
+	// populate block topology units ordered by block indices
+	blocks := make([]*Block, 0, len(bInfos))
+	parents := make(map[string]string)
+	for indx, bInfo := range bInfos {
+		blockName := blockNameForPartition(bInfo, indx, partitionStableIDs)
+		block := &Block{Name: blockName}
+		if len(bInfo.nodes) != 0 {
+			block.Nodes = strings.Join(cluset.Compact(bInfo.nodes), ",")
+		}
+		blocks = append(blocks, block)
+
+		for _, nodeName := range bInfo.nodes {
+			parents[nodeName] = blockName
+		}
+	}
+
+	tu.Block = &BlockTopo{
+		BlockSizes: getBlockSizes(bInfos, topoSpec.BlockSizes),
+		Blocks:     blocks,
+		parents:    parents,
+	}
+	return tu, nil
+}
+
+// blockNameForPartition returns the per-partition block name: bInfo.id in
+// stable-ID mode, otherwise the legacy positional "block<N>" numbering.
+func blockNameForPartition(bInfo *blockInfo, indx int, stableIDs bool) string {
+	if stableIDs && bInfo != nil && bInfo.id != "" {
+		return bInfo.id
+	}
+	return fmt.Sprintf("block%d", indx+1)
 }
 
 func (nt *NetworkTopology) getTreeTopologyUnit(topoName string, topoSpec *TopologySpec) *TopologyUnit {


### PR DESCRIPTION
## Description

Fixes the Slinky engine's block-topology instability. Today, block IDs are assigned positionally over the set of nodes with a Ready slurmd pod, so any pod-scale event can renumber blocks (e.g. `block2` gets reused for what was `block3`, or `block2` disappears entirely when its pod leaves). That breaks NVRx and every other consumer that stores or references `block<number>` names.

This PR adds a stable-ID mode driven by hostnames, plus the surrounding correctness fixes and a node-observer trigger filter. No changes are required in `slurm-operator`.

### 1. Stable block IDs via `blockHostnameRegex` (new)

Add a `blockHostnameRegex` engine parameter (also settable per-partition) that derives block IDs from a decimal capture in each node's hostname:

```yaml
global:
  engineParams:
    plugin: topology/block
    blockSizes: [1]
    blockHostnameRegex: 'd(\d+)-T\d+'   # captures "002" from "nvl72d002-T01" -> "block002"
```

Once configured:

- Physical block IDs come from the captured digits (`block<digits>`, leading zeros preserved). No positional numbering.
- **Every selected physical Kubernetes node contributes to the block inventory**, regardless of whether it has a Ready slurmd pod. Blocks with no live members are emitted as **empty declarations** so retained `topology.slinky.slurm.net/spec` annotations on drained nodes keep resolving to a defined block.
- Live nodes are grouped by the regex applied to the SLURM node name (the string that ends up in `topology.conf`); nodes without a Ready pod fall back to the K8s node name so their physical block can still be declared before any pod runs.

The full contract, validation rules, hostname-source semantics, and non-goals are in [`docs/engines/slinky.md`](docs/engines/slinky.md#stable-block-names-with-blockhostnameregex-nvrx-compatibility).

### 2. Fixes uncovered while wiring up stable IDs

- **`blockHostnameRegex` set only per-partition** used to silently fall back to positional IDs. `translate.NewNetworkTopology` now derives an *effective* cluster-wide regex from either the top-level value or a consistent per-partition value, and rejects configs where multiple non-empty values disagree (`blockHostnameRegex mismatch: ...`).
- **`block_sizes: [0]`** could be emitted when `blockHostnameRegex` was configured with an empty `blockSizes` and an empty physical block was declared. `findMinDomainSize` now skips empty blocks and defaults to `1` when all blocks are empty.
- **Empty cluster + regex + per-partition** previously produced an empty `blocks: []` topology unit. It now falls back to `flat: true` cleanly.
- **`blockHostnameRegex` + `configUpdateMode: none`** is rejected at load time. Topograph cannot guarantee the externally managed `topology.conf` references the same block names the annotations do.
- **Split physical block** (one captured index would need multiple base blocks because `blockSizes[0]` is too small) is rejected at generate time with an actionable error instead of emitting non-unique/suffixed IDs.

### 3. Node observer: trigger on block-relevant metadata only

`node_observer` now fires topology regeneration on Node updates only when block-relevant fields change: `topograph.nvidia.com/instance`, `topograph.nvidia.com/region`, `topograph.nvidia.com/cluster-id`, `nvidia.com/gpu.clique`, or the node name. Frequent status-only updates (heartbeats, condition transitions, capacity churn) no longer feed the trailing-delay queue.

### Scope of changes

`+1770 / -129` across 21 files.

Highlights:

- `pkg/engines/slinky/engine.go` (+151), `engine_test.go` (+620): parameter plumbing, physical-inventory grouping via regex, `configUpdateMode` validation, and end-to-end pod-scale-stability tests.
- `pkg/translate/block_hostname_regex.go` (new, +87): compiled matcher, decimal-capture semantics, effective cluster-wide resolution across partitions.
- `pkg/translate/{topology,block,block_complement,block_tree,yaml}.go`: stable-ID mode threaded through `initBlocks`, `complementBlocks`, and per-partition YAML generation; padding preserves captured IDs; split-block rejection.
- `pkg/translate/topology_test.go` (+340), `block_complement_test.go`, `block_tree_test.go`: table-driven regex validation and output coverage.
- `pkg/engines/slurm/slurm.go`, `slurm_test.go`: new `BaseParams.BlockHostnameRegex` and per-partition `Topology.BlockHostnameRegex`, threaded into `GetTranslateConfig`.
- `pkg/node_observer/status_informer{,_test}.go`: `nodeTopologyMetadataChanged` filter and coverage per triggering key.
- `pkg/topology/domain{,_test}.go`: `DomainMap.EnsureDomain` helper for declaring empty physical blocks.
- `charts/topograph/values.schema.json`, `values.slinky.block-example.yaml`, `docs/engines/slinky.md`, `CHANGELOG.md`: config schema, example values, docs, and changelog.

### Testing

- New `TestBlockHostnameRegexValidation` (table-driven, 7 cases) and `TestBlockHostnameRegexOutput` (table-driven, 6 cases, full `topology.conf`/YAML equality) in `pkg/translate`.
- End-to-end pod-scale-stability tests in `pkg/engines/slinky`: cluster-wide (`TestGenerateOutputPodScaleStability`) and per-partition (`TestGenerateOutputPodScaleStabilityPerPartition`), exercising the full `GenerateOutput` path against a fake `kubernetes.Clientset`. Both assert that removing the pod behind `block002` leaves `block002` declared empty and preserves `block001`/`block003` byte-for-byte, and that returning the pod restores the exact initial ConfigMap contents.
- `TestGenerateOutputSkeletonOnlyWithRegex` for `configUpdateMode: skeleton-only`, `TestGenerateOutputRejectsSplitInStableIDMode` for the split-block rejection, and `TestWithHostnameRegexDomainsPrefersSlurmNameForLiveNodes` pinning the SLURM-name-vs-K8s-name grouping contract.
- Node observer: `TestNodeTopologyMetadataChanged` covers each triggering annotation/label plus the negative status-only case.
- `go build ./...`, `go vet ./...`, `go test ./...`, and `golangci-lint run` all pass locally.

### Documentation

- New `## Stable block names with blockHostnameRegex (NVRx compatibility)` section in `docs/engines/slinky.md` covering usage, guarantees, non-goals, hostname source, and regex-authoring tips.
- Helm example (`charts/topograph/values.slinky.block-example.yaml`) and schema (`charts/topograph/values.schema.json`) describe the new field.
- `CHANGELOG.md` under `[Unreleased]` documents both the addition and each of the related fixes.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](./CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] All commits are signed off per DCO (`git commit -s`).