### PR TITLE
refactor(node-observer): reconcile topology with workqueue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- The node-observer now processes its existing topology-generation triggers through a client-go rate-limiting work queue, coalescing event bursts into a single cluster-wide reconciliation while preserving existing trigger and retry behavior.
 - **BREAKING:** Simulation models now define accelerator topology through inherited `switches[].annotations` and `blocks[].annotations` using `accelerator.topology.test/domain` and optional `accelerator.topology.test/sub-domain`, instead of the `network.topology.nvidia.com/accelerator` model label.
 - The Slurm topology-update trigger script now accepts AWS, GCP, OCI, Nebius, NetQ, Nscale, Lambda, and bare-metal InfiniBand providers.
 - **BREAKING:** Fabric topology now uses variable, closest-first tiers labeled `network.topology.nvidia.com/tier-N`; `InstanceTopology.FabricTiers` and graph conversion support arbitrary fabric depth. Accelerator topology remains a single `AcceleratorID`/`Graph.Domains` dimension labeled `network.topology.nvidia.com/accelerator`. The fixed `leaf`, `spine`, and `core` keys and process-wide Helm/CLI label overrides are replaced by optional `fabricLabels` and `acceleratorLabel` parameters on the `k8s` engine.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,7 @@ The API Server receives topology generation requests and returns results asynchr
 
 ### 2. Node Observer
 
-The Node Observer is used in Kubernetes deployments. It monitors configured node and pod changes, and it also watches the Topograph API pod. When the node-data-broker is enabled, it waits for the broker DaemonSet's ready replica count to match its desired count. If a selected node or pod changes, or if the API server becomes ready after startup or a container restart, the Node Observer sends a request to the API Server to generate a new topology configuration.
+The Node Observer is used in Kubernetes deployments. It is a controller that monitors configured node and pod changes, and it also watches the Topograph API pod. Relevant events enqueue one cluster-wide topology key in a rate-limited work queue, coalescing bursts into idempotent reconciliation. When the node-data-broker is enabled, reconciliation waits for the broker DaemonSet's ready replica count to match its desired count. The controller then asks the API Server to generate a new topology configuration and requeues failed requests.
 
 ### 3. Node Data Broker
 

--- a/pkg/node_observer/controller.go
+++ b/pkg/node_observer/controller.go
@@ -25,10 +25,9 @@ const (
 )
 
 type Controller struct {
-	ctx            context.Context
-	client         kubernetes.Interface
-	statusInformer *StatusInformer
-	healthURL      string
+	ctx        context.Context
+	reconciler *StatusInformer
+	healthURL  string
 }
 
 func NewController(ctx context.Context, client kubernetes.Interface, cfg *Config) (*Controller, error) {
@@ -59,10 +58,9 @@ func NewController(ctx context.Context, client kubernetes.Interface, cfg *Config
 		return nil, err
 	}
 	return &Controller{
-		ctx:            ctx,
-		client:         client,
-		statusInformer: statusInformer,
-		healthURL:      healthURL,
+		ctx:        ctx,
+		reconciler: statusInformer,
+		healthURL:  healthURL,
 	}, nil
 }
 
@@ -72,11 +70,11 @@ func (c *Controller) Start() error {
 		return err
 	}
 
-	klog.Infof("Starting state observer")
-	return c.statusInformer.Start()
+	klog.Infof("Starting topology controller")
+	return c.reconciler.Start()
 }
 
 func (c *Controller) Stop(err error) {
-	klog.Infof("Stopping state observer")
-	c.statusInformer.Stop(err)
+	klog.Infof("Stopping topology controller")
+	c.reconciler.Stop(err)
 }

--- a/pkg/node_observer/status_informer.go
+++ b/pkg/node_observer/status_informer.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-2025 NVIDIA CORPORATION
+ * Copyright 2024-2026 NVIDIA CORPORATION
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -9,6 +9,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -19,6 +21,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
 	"github.com/NVIDIA/topograph/internal/httperr"
@@ -26,32 +29,45 @@ import (
 	"github.com/NVIDIA/topograph/internal/k8s"
 )
 
+const topologyQueueKey = "cluster-topology"
+
+// StatusInformer watches the configured Kubernetes resources and reconciles
+// their cluster-wide topology through a single rate-limited work queue key.
+// The exported name is retained for compatibility with existing callers.
 type StatusInformer struct {
-	ctx           context.Context
-	cancel        context.CancelFunc
-	nodeFactory   informers.SharedInformerFactory
-	podFactory    informers.SharedInformerFactory
-	apiFactory    informers.SharedInformerFactory
-	brokerFactory informers.SharedInformerFactory
-	reqFunc       httpreq.RequestFunc
-	reqExecFunc   func(httpreq.RequestFunc, bool) ([]byte, *httperr.Error)
-	retryDelay    time.Duration
-	timer         *time.Timer
-	queue         chan struct{}
-	stopCh        chan struct{}
+	ctx                 context.Context
+	cancel              context.CancelFunc
+	nodeFactory         informers.SharedInformerFactory
+	podFactory          informers.SharedInformerFactory
+	apiFactory          informers.SharedInformerFactory
+	brokerFactory       informers.SharedInformerFactory
+	reqFunc             httpreq.RequestFunc
+	reqExecFunc         func(httpreq.RequestFunc, bool) ([]byte, *httperr.Error)
+	queue               workqueue.TypedRateLimitingInterface[string]
+	retryDelay          time.Duration
+	stopOnce            sync.Once
+	requestedGeneration atomic.Uint64
+	completedGeneration atomic.Uint64
+	attemptedGeneration uint64
+	retryNotBefore      time.Time
 
 	apiServerContainerName string
 }
 
 func NewStatusInformer(ctx context.Context, client kubernetes.Interface, trigger *Trigger, apiServer *APIServer, brokerName, brokerNamespace string, retryDelay time.Duration, reqFunc httpreq.RequestFunc) (*StatusInformer, error) {
 	klog.InfoS("Configuring status informer", "trigger", trigger, "apiServer", apiServer, "brokerName", brokerName, "brokerNamespace", brokerNamespace)
+	if retryDelay <= 0 {
+		retryDelay = defaultRetryDelay
+	}
 
 	statusInformer := &StatusInformer{
-		retryDelay:  retryDelay,
 		reqFunc:     reqFunc,
 		reqExecFunc: httpreq.DoRequestWithRetries,
-		queue:       make(chan struct{}, 1),
-		stopCh:      make(chan struct{}),
+		retryDelay:  retryDelay,
+		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.NewTypedItemExponentialFailureRateLimiter[string](retryDelay, retryDelay),
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: "node-observer"},
+		),
 	}
 
 	if trigger != nil && len(trigger.NodeSelector) != 0 {
@@ -153,21 +169,23 @@ func (s *StatusInformer) Start() error {
 }
 
 func (s *StatusInformer) Stop(_ error) {
-	klog.Info("Stopping status informer")
-	s.cancel()
-	close(s.stopCh)
-	if s.nodeFactory != nil {
-		s.nodeFactory.Shutdown()
-	}
-	if s.podFactory != nil {
-		s.podFactory.Shutdown()
-	}
-	if s.apiFactory != nil {
-		s.apiFactory.Shutdown()
-	}
-	if s.brokerFactory != nil {
-		s.brokerFactory.Shutdown()
-	}
+	s.stopOnce.Do(func() {
+		klog.Info("Stopping status informer")
+		s.cancel()
+		s.queue.ShutDown()
+		if s.nodeFactory != nil {
+			s.nodeFactory.Shutdown()
+		}
+		if s.podFactory != nil {
+			s.podFactory.Shutdown()
+		}
+		if s.apiFactory != nil {
+			s.apiFactory.Shutdown()
+		}
+		if s.brokerFactory != nil {
+			s.brokerFactory.Shutdown()
+		}
+	})
 }
 
 func (s *StatusInformer) startNodeInformer() error {
@@ -180,7 +198,6 @@ func (s *StatusInformer) startNodeInformer() error {
 					s.sendRequest()
 				}
 			},
-			//UpdateFunc: func(_, obj any) {} // TODO: clarify the change in node that would require topology update
 			DeleteFunc: func(obj any) {
 				switch v := obj.(type) {
 				case *corev1.Node:
@@ -198,7 +215,9 @@ func (s *StatusInformer) startNodeInformer() error {
 			return err
 		}
 		s.nodeFactory.Start(s.ctx.Done())
-		s.nodeFactory.WaitForCacheSync(s.ctx.Done())
+		if err := waitForInformerCache(s.ctx, "nodes", informer.HasSynced); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -237,7 +256,9 @@ func (s *StatusInformer) startAPIServerInformer() error {
 			return err
 		}
 		s.apiFactory.Start(s.ctx.Done())
-		s.apiFactory.WaitForCacheSync(s.ctx.Done())
+		if err := waitForInformerCache(s.ctx, "API server pods", informer.HasSynced); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -299,7 +320,9 @@ func (s *StatusInformer) startBrokerInformer() error {
 			return err
 		}
 		s.brokerFactory.Start(s.ctx.Done())
-		s.brokerFactory.WaitForCacheSync(s.ctx.Done())
+		if err := waitForInformerCache(s.ctx, "node-data-broker DaemonSet", informer.HasSynced); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -347,42 +370,84 @@ func (s *StatusInformer) startPodInformer() error {
 			return err
 		}
 		s.podFactory.Start(s.ctx.Done())
-		s.podFactory.WaitForCacheSync(s.ctx.Done())
+		if err := waitForInformerCache(s.ctx, "trigger pods", informer.HasSynced); err != nil {
+			return err
+		}
 	}
 	return nil
 }
 
-func (s *StatusInformer) sendRequest() {
-	select {
-	case s.queue <- struct{}{}:
-	default:
-		// Drop if already queued (prevents flooding)
+func waitForInformerCache(ctx context.Context, name string, synced cache.InformerSynced) error {
+	if cache.WaitForCacheSync(ctx.Done(), synced) {
+		return nil
 	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("failed to sync %s informer cache: %w", name, err)
+	}
+	return fmt.Errorf("failed to sync %s informer cache", name)
+}
+
+func (s *StatusInformer) sendRequest() {
+	s.requestedGeneration.Add(1)
+	s.queue.Add(topologyQueueKey)
 }
 
 func (s *StatusInformer) run() {
-	for {
-		select {
-		case <-s.stopCh:
-			return
-
-		case <-s.queue:
-			// Cancel any pending retry
-			if s.timer != nil {
-				s.timer.Stop()
-				s.timer = nil
-			}
-			s.process()
-
-		case <-func() <-chan time.Time {
-			if s.timer != nil {
-				return s.timer.C
-			}
-			return nil
-		}():
-			s.process()
-		}
+	for s.processNextWorkItem() {
 	}
+}
+
+func (s *StatusInformer) processNextWorkItem() bool {
+	key, shutdown := s.queue.Get()
+	if shutdown {
+		return false
+	}
+	defer s.queue.Done(key)
+
+	// Queue entries carry only the cluster key; generations determine their meaning:
+	//   - completed generation: obsolete delayed entry, discard
+	//   - newer than attempted: new informer event, reconcile immediately
+	//   - already attempted before retryNotBefore: early delayed entry, postpone
+	//   - otherwise: retry deadline reached, reconcile
+	generation := s.requestedGeneration.Load()
+	if generation <= s.completedGeneration.Load() {
+		// AddAfter entries cannot be cancelled. If a newer informer event has
+		// already reconciled successfully, discard the obsolete delayed item.
+		s.queue.Forget(key)
+		return true
+	}
+	if generation == s.attemptedGeneration && time.Now().Before(s.retryNotBefore) {
+		// A newer informer event resets main's retry timer. A delayed workqueue
+		// entry cannot be cancelled, so postpone an obsolete entry until the
+		// latest attempt's retry deadline instead of reconciling too early.
+		s.queue.AddAfter(key, time.Until(s.retryNotBefore))
+		return true
+	}
+
+	requeueAfter, err := s.reconcile()
+	if s.ctx.Err() != nil {
+		s.queue.Forget(key)
+		return false
+	}
+	if err != nil {
+		klog.Errorf("Topology reconciliation failed: %v", err)
+		s.attemptedGeneration = generation
+		s.retryNotBefore = time.Now().Add(s.retryDelay)
+		s.queue.AddRateLimited(key)
+		return true
+	}
+
+	s.queue.Forget(key)
+	if requeueAfter > 0 {
+		s.attemptedGeneration = generation
+		s.retryNotBefore = time.Now().Add(requeueAfter)
+		s.queue.AddAfter(key, requeueAfter)
+		return true
+	}
+	s.attemptedGeneration = generation
+	s.retryNotBefore = time.Time{}
+	s.completedGeneration.Store(generation)
+	return true
 }
 
 func shouldRequestOnAPIServerUpdate(oldPod, newPod *corev1.Pod, containerName string) bool {
@@ -481,37 +546,27 @@ func brokerDaemonSetReady(daemonSet *appsv1.DaemonSet) (bool, error) {
 	return daemonSet.Status.DesiredNumberScheduled == daemonSet.Status.NumberReady, nil
 }
 
-func (s *StatusInformer) process() {
+func (s *StatusInformer) reconcile() (time.Duration, error) {
 	brokerReady, err := s.brokerReady()
 	if err != nil {
+		// Broker errors describe the current unready state. Log the diagnostic and
+		// continue polling on the broker cadence rather than treating it as a
+		// topology-generation failure.
 		klog.Error(err)
 	}
 	if !brokerReady {
 		klog.V(2).Info("Waiting for the node-data-broker DaemonSet to become ready before topology generation")
-		if s.timer != nil {
-			s.timer.Stop()
-		}
-		s.timer = time.NewTimer(defaultBrokerRetryDelay)
-		return
+		return defaultBrokerRetryDelay, nil
 	}
 
+	if s.reqFunc == nil {
+		return 0, nil
+	}
 	if _, err := s.reqExecFunc(s.reqFunc, false); err != nil {
-		if s.ctx != nil && s.ctx.Err() != nil {
-			return
+		if s.ctx.Err() != nil {
+			return 0, nil
 		}
-		klog.Errorf("failed to send HTTP request; retrying in %s: %v", s.retryDelay, err)
-
-		// Reset retry timer
-		if s.timer != nil {
-			s.timer.Stop()
-		}
-		s.timer = time.NewTimer(s.retryDelay)
-		return
+		return 0, fmt.Errorf("failed to send topology generation request: %w", err)
 	}
-
-	// clear retry timer
-	if s.timer != nil {
-		s.timer.Stop()
-		s.timer = nil
-	}
+	return 0, nil
 }

--- a/pkg/node_observer/status_informer_test.go
+++ b/pkg/node_observer/status_informer_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 NVIDIA CORPORATION
+ * Copyright 2025-2026 NVIDIA CORPORATION
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -39,6 +39,7 @@ func TestNewStatusInformer(t *testing.T) {
 	}
 	informer, err := NewStatusInformer(ctx, nil, trigger, apiServer, "topograph-node-data-broker", "topograph", 0, nil)
 	require.NoError(t, err)
+	t.Cleanup(func() { informer.Stop(nil) })
 	require.NotNil(t, informer.nodeFactory)
 	require.NotNil(t, informer.podFactory)
 	require.NotNil(t, informer.apiFactory)
@@ -61,9 +62,61 @@ func TestNewStatusInformerBrokerGateRequiresNameAndNamespace(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			informer, err := NewStatusInformer(context.TODO(), nil, nil, nil, tc.brokerName, tc.brokerNamespace, 0, nil)
 			require.NoError(t, err)
+			t.Cleanup(func() { informer.Stop(nil) })
 			require.Nil(t, informer.brokerFactory)
 		})
 	}
+}
+
+func TestNodeInformerPreservesMainBranchTriggers(t *testing.T) {
+	client := k8sfake.NewSimpleClientset()
+	s, err := NewStatusInformer(
+		context.Background(),
+		client,
+		&Trigger{NodeSelector: map[string]string{"role": "compute"}},
+		nil,
+		"",
+		"",
+		time.Second,
+		nil,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { s.Stop(nil) })
+	require.NoError(t, s.startNodeInformer())
+
+	node, err := client.CoreV1().Nodes().Create(context.Background(), &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node-1",
+			Labels: map[string]string{"role": "compute"},
+		},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+	require.Eventually(t, func() bool { return s.queue.Len() == 1 }, time.Second, 10*time.Millisecond)
+
+	key, shutdown := s.queue.Get()
+	require.False(t, shutdown)
+	s.queue.Done(key)
+	s.queue.Forget(key)
+	require.Zero(t, s.queue.Len())
+
+	updated := node.DeepCopy()
+	updated.Annotations = map[string]string{"example.com/input": "changed"}
+	_, err = client.CoreV1().Nodes().Update(context.Background(), updated, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	informer := s.nodeFactory.Core().V1().Nodes().Informer()
+	require.Eventually(t, func() bool {
+		obj, exists, getErr := informer.GetStore().GetByKey(node.Name)
+		if getErr != nil || !exists {
+			return false
+		}
+		cachedNode, ok := obj.(*corev1.Node)
+		return ok && cachedNode.Annotations["example.com/input"] == "changed"
+	}, time.Second, 10*time.Millisecond)
+	require.Never(t, func() bool { return s.queue.Len() != 0 }, 100*time.Millisecond, 10*time.Millisecond)
+
+	require.NoError(t, client.CoreV1().Nodes().Delete(context.Background(), node.Name, metav1.DeleteOptions{}))
+	require.Eventually(t, func() bool { return s.queue.Len() == 1 }, time.Second, 10*time.Millisecond)
 }
 
 func TestBrokerDaemonSetReady(t *testing.T) {
@@ -199,14 +252,14 @@ func TestAPIServerPodDeleteQueuesRequest(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			s := &StatusInformer{queue: make(chan struct{}, 1)}
+			s := newTestStatusInformer(t, time.Second, nil)
 
 			s.requestOnAPIServerDelete(tc.obj)
 
 			if tc.queued {
-				require.Len(t, s.queue, 1)
+				require.Equal(t, 1, s.queue.Len())
 			} else {
-				require.Empty(t, s.queue)
+				require.Zero(t, s.queue.Len())
 			}
 		})
 	}
@@ -235,18 +288,14 @@ func TestAPIServerInformerRegistersDeleteHandler(t *testing.T) {
 	})
 
 	require.NoError(t, s.startAPIServerInformer())
-	require.Empty(t, s.queue)
+	require.Zero(t, s.queue.Len())
 	require.NoError(t, client.CoreV1().Pods(pod.Namespace).Delete(
 		context.Background(),
 		pod.Name,
 		metav1.DeleteOptions{},
 	))
 
-	select {
-	case <-s.queue:
-	case <-time.After(time.Second):
-		t.Fatal("API-server Pod deletion did not queue a topology request")
-	}
+	require.Eventually(t, func() bool { return s.queue.Len() == 1 }, time.Second, 10*time.Millisecond)
 }
 
 func reqExecFunc(f httpreq.RequestFunc, _ bool) ([]byte, *httperr.Error) {
@@ -254,6 +303,15 @@ func reqExecFunc(f httpreq.RequestFunc, _ bool) ([]byte, *httperr.Error) {
 		return nil, err
 	}
 	return nil, nil
+}
+
+func newTestStatusInformer(t *testing.T, retryDelay time.Duration, reqFunc httpreq.RequestFunc) *StatusInformer {
+	t.Helper()
+	s, err := NewStatusInformer(context.Background(), nil, nil, nil, "", "", retryDelay, reqFunc)
+	require.NoError(t, err)
+	s.reqExecFunc = reqExecFunc
+	t.Cleanup(func() { s.Stop(nil) })
+	return s
 }
 
 func TestSendRequestAndRetry(t *testing.T) {
@@ -269,25 +327,45 @@ func TestSendRequestAndRetry(t *testing.T) {
 		}
 	}
 
-	s := &StatusInformer{
-		queue:       make(chan struct{}, 1),
-		stopCh:      make(chan struct{}),
-		retryDelay:  50 * time.Millisecond,
-		reqFunc:     reqFunc,
-		reqExecFunc: reqExecFunc,
-	}
+	s := newTestStatusInformer(t, 50*time.Millisecond, reqFunc)
 
 	// start worker
 	go s.run()
-	defer close(s.stopCh)
 
 	// trigger request
 	s.sendRequest()
 
 	// wait enough time for: fail + delay + fail + delay + success
-	time.Sleep(200 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&calls) == 3
+	}, time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool {
+		return s.queue.NumRequeues(topologyQueueKey) == 0
+	}, time.Second, 10*time.Millisecond)
+}
 
-	require.Equal(t, int32(3), atomic.LoadInt32(&calls))
+func TestReconcileRequeuesWhileBrokerCacheIsNotReady(t *testing.T) {
+	var calls int32
+	s, err := NewStatusInformer(
+		context.Background(),
+		k8sfake.NewSimpleClientset(),
+		nil,
+		nil,
+		"topograph-node-data-broker",
+		"topograph",
+		time.Second,
+		func() (*http.Request, *httperr.Error) {
+			atomic.AddInt32(&calls, 1)
+			return nil, nil
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { s.Stop(nil) })
+
+	requeueAfter, reconcileErr := s.reconcile()
+	require.NoError(t, reconcileErr)
+	require.Equal(t, defaultBrokerRetryDelay, requeueAfter)
+	require.Zero(t, atomic.LoadInt32(&calls))
 }
 
 func TestDeduplicatesRequests(t *testing.T) {
@@ -298,26 +376,18 @@ func TestDeduplicatesRequests(t *testing.T) {
 		return nil, nil
 	}
 
-	s := &StatusInformer{
-		queue:       make(chan struct{}, 1),
-		stopCh:      make(chan struct{}),
-		retryDelay:  50 * time.Millisecond,
-		reqFunc:     reqFunc,
-		reqExecFunc: reqExecFunc,
-	}
-
-	go s.run()
-	defer close(s.stopCh)
+	s := newTestStatusInformer(t, 50*time.Millisecond, reqFunc)
 
 	// flood with requests
 	for range 5 {
 		s.sendRequest()
 	}
+	require.Equal(t, 1, s.queue.Len())
+	go s.run()
 
-	time.Sleep(50 * time.Millisecond)
-
-	require.Equal(t, int32(1), atomic.LoadInt32(&calls))
-
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&calls) == 1
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestStartBlocksUntilStopped(t *testing.T) {
@@ -351,6 +421,41 @@ func TestStartBlocksUntilStopped(t *testing.T) {
 	case <-time.After(time.Second):
 		require.Fail(t, "Start did not return after Stop")
 	}
+}
+
+func TestStartDoesNotRequestWithoutInformerEvent(t *testing.T) {
+	requestAttempted := make(chan struct{}, 1)
+	s := newTestStatusInformer(t, time.Second, func() (*http.Request, *httperr.Error) {
+		requestAttempted <- struct{}{}
+		return nil, nil
+	})
+	done := make(chan error, 1)
+	go func() {
+		done <- s.Start()
+	}()
+
+	select {
+	case <-requestAttempted:
+		t.Fatal("Start issued a topology request without an informer event")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	s.Stop(nil)
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Start did not return after Stop")
+	}
+}
+
+func TestWaitForInformerCacheReportsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := waitForInformerCache(ctx, "nodes", func() bool { return false })
+	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorContains(t, err, "failed to sync nodes informer cache")
 }
 
 func TestStopCancelsRequestContext(t *testing.T) {
@@ -415,7 +520,7 @@ func TestStopCancelsRequestRetry(t *testing.T) {
 	}
 }
 
-func TestRetryCancelledByNewRequest(t *testing.T) {
+func TestNewRequestRunsBeforeRateLimitedRetry(t *testing.T) {
 	var calls int32
 
 	// always fail
@@ -424,29 +529,92 @@ func TestRetryCancelledByNewRequest(t *testing.T) {
 		return nil, httperr.NewError(http.StatusInternalServerError, "")
 	}
 
-	s := &StatusInformer{
-		queue:       make(chan struct{}, 1),
-		stopCh:      make(chan struct{}),
-		retryDelay:  200 * time.Millisecond,
-		reqFunc:     reqFunc,
-		reqExecFunc: reqExecFunc,
-	}
+	s := newTestStatusInformer(t, time.Second, reqFunc)
 
 	go s.run()
-	defer close(s.stopCh)
 
 	s.sendRequest()
 
-	time.Sleep(50 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&calls) == 1
+	}, time.Second, 10*time.Millisecond)
 
 	// send another request before retry fires
 	s.sendRequest()
 
-	time.Sleep(100 * time.Millisecond)
-
 	// expected 2 calls:
 	// - initial
 	// - immediate second (not waiting full retryDelay)
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&calls) == 2
+	}, 500*time.Millisecond, 10*time.Millisecond)
+}
+
+func TestSuccessfulEventSupersedesPendingRetry(t *testing.T) {
+	const retryDelay = 100 * time.Millisecond
+	var calls int32
+	thirdCall := make(chan struct{}, 1)
+
+	reqFunc := func() (*http.Request, *httperr.Error) {
+		call := atomic.AddInt32(&calls, 1)
+		if call == 1 {
+			return nil, httperr.NewError(http.StatusInternalServerError, "retry")
+		}
+		if call > 2 {
+			select {
+			case thirdCall <- struct{}{}:
+			default:
+			}
+		}
+		return nil, nil
+	}
+
+	s := newTestStatusInformer(t, retryDelay, reqFunc)
+	go s.run()
+
+	// The first request fails and schedules a delayed retry.
+	s.sendRequest()
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&calls) == 1
+	}, time.Second, 10*time.Millisecond)
+
+	// A new event reconciles successfully before the delayed retry fires.
+	s.sendRequest()
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&calls) == 2
+	}, time.Second, 10*time.Millisecond)
+
+	// The obsolete delayed item may still enter the queue, but it must not
+	// issue another topology-generation request.
+	select {
+	case <-thirdCall:
+		t.Fatal("obsolete delayed retry issued a third request")
+	case <-time.After(3 * retryDelay):
+	}
+	require.Equal(t, int32(2), atomic.LoadInt32(&calls))
+}
+
+func TestNewFailedEventResetsPendingRetry(t *testing.T) {
+	var calls int32
+	s := newTestStatusInformer(t, time.Second, func() (*http.Request, *httperr.Error) {
+		atomic.AddInt32(&calls, 1)
+		return nil, httperr.NewError(http.StatusInternalServerError, "retry")
+	})
+
+	// The initial event fails and schedules a retry.
+	s.sendRequest()
+	require.True(t, s.processNextWorkItem())
+	require.Equal(t, int32(1), atomic.LoadInt32(&calls))
+
+	// A newer event runs immediately, fails, and resets the retry deadline.
+	s.sendRequest()
+	require.True(t, s.processNextWorkItem())
+	require.Equal(t, int32(2), atomic.LoadInt32(&calls))
+
+	// Simulate the older delayed entry reaching the queue before the reset
+	// deadline. It must be postponed without issuing another request.
+	s.queue.Add(topologyQueueKey)
+	require.True(t, s.processNextWorkItem())
 	require.Equal(t, int32(2), atomic.LoadInt32(&calls))
 }
 


### PR DESCRIPTION
Replace the ad hoc channel and timer loop with a client-go
rate-limiting workqueue using one cluster-wide topology key.

Coalesce event bursts, wait for informer caches to synchronize,
retry failed generation requests, and requeue while the node-data
broker is not ready.

Add coverage for queue deduplication, retries, cache cancellation,
broker readiness, and Node update predicates.

closes #445 